### PR TITLE
Make CLI agent-first: add show command, --json everywhere, rewrite skill

### DIFF
--- a/skills/mem/SKILL.md
+++ b/skills/mem/SKILL.md
@@ -8,124 +8,277 @@ allowed-tools: Bash
 
 You are an expert at managing a structured knowledge base using the `mem` CLI — a local-first markdown memory system built on Zettelkasten principles.
 
-## Core Principles
+## Core Workflow
 
-1. **One idea per note.** Never cram multiple concepts into a single note.
-2. **Be brutally concise.** Every word must earn its place.
-3. **Link aggressively.** Use `[[wikilinks]]` to connect ideas. Isolated notes are dead notes.
-4. **Capture now, refine later.** Fleeting notes are raw — don't overthink them.
+Every interaction follows this loop:
 
-## Word Limits (STRICT)
+```
+1. Search  →  check if a related note exists
+2. Create or Append  →  never duplicate
+3. Link  →  connect with [[wikilinks]]
+4. Verify  →  check line limits, run suggest-links
+```
 
-| Type | Max words | Purpose |
-|------|-----------|---------|
-| `fleeting` | **30 words** | Raw thought, single sentence. Inbox item. |
-| `permanent` | **150 words** | One refined idea. Summary + details + links. |
-| `reference` | **200 words** | External source notes. Key points in your own words. |
-| `person` | **100 words** | Contact card. Role, context, interaction log. |
-| `meeting` | **200 words** | Attendees, decisions, action items. No fluff. |
-| `project` | **150 words** | Goal, status, people, key decisions. |
-| `decision` | **150 words** | Context, options, outcome, rationale. |
+## Note Type Decision Tree
 
-If a note exceeds its limit, split it into multiple linked notes.
+| Situation | Type |
+|-----------|------|
+| Quick capture, raw thought | `fleeting` |
+| Refined idea, one concept | `permanent` |
+| External source (article, book, talk) | `reference` |
+| A person you interact with | `person` |
+| Meeting that happened or is planned | `meeting` |
+| Ongoing initiative with goals | `project` |
+| Choice made with rationale | `decision` |
+
+## Line Limits (STRICT)
+
+| Type | Max lines | Enforced | Purpose |
+|------|-----------|----------|---------|
+| `fleeting` | 50 | warn | Raw thought. One sentence or short paragraph. |
+| `permanent` | 200 | hard | One atomic idea. Summary + details + links. |
+| `reference` | 300 | warn | External source. Key points in your own words. |
+| `person` | 150 | warn | Contact card. Role, context, interaction log. |
+| `meeting` | 300 | warn | Attendees, decisions, action items. No fluff. |
+| `project` | 300 | warn | Goal, status, people, key decisions. |
+| `decision` | 200 | hard | Context, options, outcome, rationale. |
+
+If a note exceeds its limit, **split it** into multiple linked notes.
 
 ## CLI Reference
 
-### Create notes
+### Create
 
 ```bash
-# Fleeting note (default type) — title becomes the body
-mem new "Raw thought or observation"
-
-# Typed note — gets the type's template
-mem new "Note title" -t permanent
-mem new "John Doe" -t person
-mem new "Sprint planning 2026-03-30" -t meeting
-
-# Quick capture (also accepts stdin)
-mem add "Quick thought"
-echo "Piped content" | mem add
+mem new "Note title" -t permanent       # Create typed note
+mem new "Quick thought"                  # Fleeting note (default)
+mem new "Sprint review 2026-03-30" -t meeting --json  # JSON output
+mem add "Quick thought"                  # Quick-capture fleeting note
+echo "Piped content" | mem add --json    # Stdin + JSON output
 ```
 
-### Edit notes
+### Read
 
 ```bash
-# Open in $EDITOR (human)
-mem edit <slug>
-
-# Programmatic edits (agent-friendly)
-mem edit <slug> --body $'## Section\n\nContent here.'
-mem edit <slug> --append $'- 2026-03-30: New interaction'
-mem edit <slug> --title "New Title"
-mem edit <slug> --tag "tag1,tag2"
+mem show <slug>              # Display note with header
+mem show <slug> --json       # Full note as JSON (agent-friendly)
+mem show <slug> --body       # Raw body only (for piping)
+mem list                     # All notes, sorted by modified
+mem list -t person           # Filter by type
+mem list --json              # JSON output
+mem search "query"           # Full-text search
+mem search "query" --json    # JSON output
 ```
 
-### Browse and search
+### Update
 
 ```bash
-# List notes
-mem list                    # all notes, sorted by modified
-mem list -t person          # filter by type
-mem list --json             # JSON output (agent-friendly)
-mem ls                      # alias
-
-# Search
-mem search "query"          # full-text search
-
-# Relationships
-mem backlinks <slug>        # who links to this note?
-mem suggest-links <slug>    # find unlinked mentions
+mem edit <slug> --body $'## Section\n\nContent here.'   # Replace body
+mem edit <slug> --append $'- 2026-03-30: Met at conf'   # Append text
+mem edit <slug> --title "New Title"                      # Update title
+mem edit <slug> --tag "tag1,tag2"                        # Add tags
+mem edit <slug> --alias "short-name,abbreviation"        # Add aliases
+mem edit <slug>                                          # Open in $EDITOR
 ```
 
-### Vault management
+### Graph
 
 ```bash
-mem init                    # initialize a new vault
-mem types                   # list available note types
-mem doctor                  # validate vault health
-mem serve                   # start web UI at localhost:4321
+mem backlinks <slug>              # Who links to this note?
+mem backlinks <slug> --json       # JSON output
+mem suggest-links <slug>          # Find unlinked mentions
+mem suggest-links <slug> --json   # JSON output
 ```
 
-## Writing Guidelines
+### Manage
 
-When creating or editing notes:
+```bash
+mem init          # Initialize a new vault
+mem types         # List available note types
+mem doctor        # Validate vault health
+mem serve         # Start web UI at localhost:4321
+```
 
-- **Fleeting notes**: One sentence. No formatting. Just the raw thought.
-  - Good: `mem new "Granite could auto-suggest note type based on content"`
-  - Bad: `mem new "I was thinking today about how it would be really cool if Granite could maybe look at what you're writing and suggest what type of note it should be"`
+All `--json` commands return `{"success": true, "data": ...}` or `{"success": false, "error": "..."}`.
 
-- **Permanent notes**: Start with a one-line summary. Use `## Summary`, `## Details`, `## Links` sections. Link to related notes with `[[wikilinks]]`.
+## Writing by Type
 
-- **Person notes**: Lead with role and context. Add timestamped interaction notes with `--append`. Always link to projects and meetings.
-  ```bash
-  mem new "Jane Smith" -t person
-  mem edit jane-smith --body $'## Role\n\nCTO at Acme Corp\n\n## Context\n\nMet at ReactConf 2026. Working on similar infra problems.\n\n## Notes\n\n## Links\n'
-  mem edit jane-smith --append $'- 2026-03-30: Discussed [[project-x]] migration timeline'
-  ```
+### Fleeting
+One sentence. No formatting. Just the raw thought.
 
-- **Meeting notes**: List attendees as `[[person]]` links. Capture decisions and action items as bullet points. Skip everything that isn't actionable.
+```bash
+mem new "Granite could auto-detect note type from content"
+```
 
-- **Decisions**: State the context in one sentence. List options briefly. State what was decided and why. Link to the project.
+Bad: `mem new "I was thinking about how it would be really cool if Granite could maybe analyze what you write and automatically suggest the type"`
 
-## Agent Workflow
+### Permanent
+Start with a one-line summary. Use `## Summary`, `## Details`, `## Links` sections.
 
-When an agent needs to capture information:
+```
+## Summary
 
-1. **Check if a related note exists**: `mem search "topic"` or `mem list --json | jq`
-2. **Create or append**: Don't duplicate — append to existing notes when possible
-3. **Link**: Always reference related notes with `[[slug]]`
-4. **Stay under word limits**: Count words. Split if needed.
+Atomic notes outperform long documents for knowledge retention.
 
-When an agent needs to retrieve information:
+## Details
 
-1. `mem search "query"` for full-text search
-2. `mem list --json -t <type>` for structured listing
-3. `mem backlinks <slug>` to understand relationships
+When each note captures one idea, linking creates emergent structure.
+The key is [[wikilinks]] between concepts, not folder hierarchies.
+
+## Links
+
+Related: [[Zettelkasten Method]], [[Knowledge Graphs]]
+```
+
+### Reference
+Capture source, date, key points in your own words, and your reaction.
+
+```
+## Source
+
+https://example.com/local-first-article
+
+## Date
+
+2026-03-30
+
+## Key Points
+
+- Data lives on device, not in the cloud
+- Sync is a feature, not a requirement
+
+## My Take
+
+This aligns with how [[Granite]] works. See also [[Local-First Software]].
+```
+
+### Person
+Lead with role and context. Add timestamped interaction notes with `--append`.
+
+```bash
+mem new "Jane Smith" -t person --json
+mem edit jane-smith --body $'## Role\n\nCTO at Acme Corp\n\n## Context\n\nMet at ReactConf 2026. Working on similar infra.\n\n## Contact\n\nSlack: @jsmith\n\n## Notes\n\n## Links\n'
+mem edit jane-smith --append $'- 2026-03-30: Discussed [[project-x]] migration timeline'
+```
+
+### Meeting
+List attendees as `[[person]]` links. Capture only decisions and actions.
+
+```
+## Attendees
+
+- [[jane-smith]]
+- [[bob-chen]]
+
+## Agenda
+
+- Q2 roadmap review
+
+## Notes
+
+Agreed to focus on API v2 first.
+
+## Decisions
+
+- Prioritize API v2 over dashboard redesign
+
+## Actions
+
+- [ ] [[jane-smith]]: Draft API v2 spec by April 5
+- [ ] [[bob-chen]]: Set up staging environment
+```
+
+### Decision
+State context in one sentence. List options. State what was decided and why.
+
+```
+## Context
+
+Need to choose a database for the new analytics service.
+
+## Options Considered
+
+1. PostgreSQL — proven, team knows it well
+2. ClickHouse — optimized for analytics queries
+
+## Decision
+
+ClickHouse for analytics, PostgreSQL for metadata.
+
+## Rationale
+
+Analytics queries are 10x faster on ClickHouse. Keep PostgreSQL for CRUD.
+Linked to [[analytics-service]] project.
+
+## Status
+
+Active
+```
+
+## Tags and Aliases
+
+**Tags**: lowercase, hyphenated. Use sparingly — prefer `[[wikilinks]]` for relationships.
+- Good: `status/active`, `area/infrastructure`, `priority/high`
+- Bad: using tags to replicate what links already do
+
+**Aliases**: set when a note has common abbreviations or alternate names.
+```bash
+mem edit amazon-web-services --alias "AWS,aws"
+mem edit jane-smith --alias "Jane,jsmith"
+```
+This makes wikilinks resolve correctly: `[[AWS]]` will find the `amazon-web-services` note.
+
+## Key Patterns
+
+### Capturing a meeting
+
+```bash
+mem search "sprint review" --json           # Check if note exists
+mem new "Sprint review 2026-03-30" -t meeting --json
+# For each attendee:
+mem search "Jane Smith" --json              # Check if person note exists
+mem new "Jane Smith" -t person --json       # Create if missing
+# Fill meeting body:
+mem edit sprint-review-2026-03-30 --body $'## Attendees\n\n- [[jane-smith]]\n...'
+# Update person notes:
+mem edit jane-smith --append $'- 2026-03-30: [[sprint-review-2026-03-30]]'
+```
+
+### Recording a decision
+
+```bash
+mem search "database choice" --json
+mem new "Analytics database choice" -t decision --json
+mem edit analytics-database-choice --body $'## Context\n\n...\n\n## Decision\n\n...\n\n## Status\n\nActive'
+mem edit analytics-database-choice --tag "area/infrastructure"
+mem edit analytics-service --append $'Key decision: [[analytics-database-choice]]'
+```
+
+### Retrieving knowledge
+
+When the user asks "what do I know about X?":
+
+```bash
+mem search "X" --json                    # Find relevant notes
+mem show <slug> --json                   # Read each note's content
+mem backlinks <slug> --json              # Find what links to it
+# Synthesize across results and present to user
+```
+
+### Maintaining the knowledge graph
+
+```bash
+mem suggest-links <slug> --json          # Find unlinked mentions → add links
+mem doctor                               # Check vault health
+# Build hub notes for major topics (permanent notes that are mostly links)
+```
 
 ## Anti-patterns
 
-- Writing essays in fleeting notes → split into permanent notes
-- Notes without links → add `[[wikilinks]]` to at least one other note
-- Vague titles → be specific: "Auth migration decision" not "Decision"
-- Duplicating information → use `--append` on existing notes
-- Ignoring `suggest-links` output → if it detects a mention, link it
+- **Essays in fleeting notes** — split into permanent notes
+- **Notes without links** — add `[[wikilinks]]` to at least one other note
+- **Vague titles** — be specific: "Auth migration decision" not "Decision"
+- **Duplicating information** — search first, use `--append` on existing notes
+- **Ignoring suggest-links** — if it detects a mention, link it
+- **Tags instead of links** — if it's a relationship, use a `[[wikilink]]`
+- **Creating without searching** — always check if a related note exists first

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -2,8 +2,9 @@ import fs from 'node:fs';
 import { loadConfig } from '../core/config.js';
 import { requireVaultRoot } from '../core/vault.js';
 import { createNote } from '../core/note.js';
+import { jsonSuccess } from '../core/json-output.js';
 
-export function addNote(text?: string): void {
+export function addNote(text?: string, options: { json?: boolean } = {}): void {
   const vaultRoot = requireVaultRoot();
   const config = loadConfig(vaultRoot);
   const typeName = config.defaults.note_type;
@@ -30,5 +31,16 @@ export function addNote(text?: string): void {
   const title = firstLine.length > 60 ? firstLine.slice(0, 60).trim() + '...' : firstLine;
 
   const note = createNote(vaultRoot, config, typeName, title, content + '\n');
+
+  if (options.json) {
+    console.log(jsonSuccess({
+      slug: note.slug,
+      title: note.frontmatter.title,
+      type: typeName,
+      filepath: note.filepath,
+    }));
+    return;
+  }
+
   console.log(note.filepath);
 }

--- a/src/commands/backlinks.ts
+++ b/src/commands/backlinks.ts
@@ -2,14 +2,20 @@ import { loadConfig } from '../core/config.js';
 import { requireVaultRoot } from '../core/vault.js';
 import { ensureIndex } from '../core/index-db.js';
 import { getBacklinks } from '../core/backlinks.js';
+import { jsonSuccess } from '../core/json-output.js';
 
-export function backlinksCommand(slug: string): void {
+export function backlinksCommand(slug: string, options: { json?: boolean }): void {
   const vaultRoot = requireVaultRoot();
   const config = loadConfig(vaultRoot);
   const db = ensureIndex(vaultRoot, config);
 
   const backlinks = getBacklinks(db, slug);
   db.close();
+
+  if (options.json) {
+    console.log(jsonSuccess(backlinks));
+    return;
+  }
 
   if (backlinks.length === 0) {
     console.log(`No backlinks found for "${slug}".`);

--- a/src/commands/edit.ts
+++ b/src/commands/edit.ts
@@ -10,6 +10,7 @@ interface EditOptions {
   append?: string;
   title?: string;
   tag?: string;
+  alias?: string;
 }
 
 export function editCommand(slug: string, options: EditOptions): void {
@@ -22,7 +23,7 @@ export function editCommand(slug: string, options: EditOptions): void {
     process.exit(1);
   }
 
-  const hasFlags = options.body !== undefined || options.append !== undefined || options.title !== undefined || options.tag !== undefined;
+  const hasFlags = options.body !== undefined || options.append !== undefined || options.title !== undefined || options.tag !== undefined || options.alias !== undefined;
 
   if (hasFlags) {
     // Programmatic edit (agent mode)
@@ -37,6 +38,13 @@ export function editCommand(slug: string, options: EditOptions): void {
       const existing = new Set(frontmatter.tags);
       for (const t of newTags) existing.add(t);
       frontmatter.tags = [...existing];
+    }
+
+    if (options.alias) {
+      const newAliases = options.alias.split(',').map(a => a.trim()).filter(Boolean);
+      const existing = new Set(frontmatter.aliases);
+      for (const a of newAliases) existing.add(a);
+      frontmatter.aliases = [...existing];
     }
 
     if (options.body !== undefined) {

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -1,6 +1,7 @@
 import { loadConfig } from '../core/config.js';
 import { requireVaultRoot } from '../core/vault.js';
 import { listNotes } from '../core/note.js';
+import { jsonSuccess } from '../core/json-output.js';
 
 export function listCommand(options: { type?: string; json?: boolean }): void {
   const vaultRoot = requireVaultRoot();
@@ -24,7 +25,7 @@ export function listCommand(options: { type?: string; json?: boolean }): void {
       tags: n.frontmatter.tags,
       filepath: n.filepath,
     }));
-    console.log(JSON.stringify(out, null, 2));
+    console.log(jsonSuccess(out));
     return;
   }
 

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -1,11 +1,12 @@
 import { loadConfig } from '../core/config.js';
 import { requireVaultRoot } from '../core/vault.js';
 import { createNote, listNotes } from '../core/note.js';
+import { jsonSuccess } from '../core/json-output.js';
 
-export function newNote(title: string, typeName?: string): void {
+export function newNote(title: string, options: { type?: string; json?: boolean }): void {
   const vaultRoot = requireVaultRoot();
   const config = loadConfig(vaultRoot);
-  const resolvedType = typeName || config.defaults.note_type;
+  const resolvedType = options.type || config.defaults.note_type;
   const typeConfig = config.note_types[resolvedType];
 
   // For date-slug types (like fleeting), the title IS the content
@@ -13,18 +14,7 @@ export function newNote(title: string, typeName?: string): void {
   const note = createNote(vaultRoot, config, resolvedType, title, bodyOverride);
 
   const lines = note.body.split('\n').length;
-  if (typeConfig && typeConfig.line_limit && lines > typeConfig.line_limit) {
-    const action = typeConfig.warn_only ? 'Warning' : 'Error';
-    console.warn(`${action}: Note exceeds ${typeConfig.line_limit} line limit for type "${resolvedType}"`);
-  }
-
-  console.log(note.filepath);
-
-  // Show instructions if available
-  if (typeConfig?.instructions) {
-    console.log('');
-    console.log(`  💡 ${typeConfig.instructions}`);
-  }
+  const overLimit = typeConfig && typeConfig.line_limit && lines > typeConfig.line_limit;
 
   // Suggest links: check if any existing note titles/aliases appear in the note content
   const textToScan = (note.body + ' ' + title).toLowerCase();
@@ -46,6 +36,30 @@ export function newNote(title: string, typeName?: string): void {
         break;
       }
     }
+  }
+
+  if (options.json) {
+    console.log(jsonSuccess({
+      slug: note.slug,
+      title: note.frontmatter.title,
+      type: resolvedType,
+      filepath: note.filepath,
+      suggestions,
+    }));
+    return;
+  }
+
+  if (overLimit) {
+    const action = typeConfig.warn_only ? 'Warning' : 'Error';
+    console.warn(`${action}: Note exceeds ${typeConfig.line_limit} line limit for type "${resolvedType}"`);
+  }
+
+  console.log(note.filepath);
+
+  // Show instructions if available
+  if (typeConfig?.instructions) {
+    console.log('');
+    console.log(`  💡 ${typeConfig.instructions}`);
   }
 
   if (suggestions.length > 0) {

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -2,14 +2,20 @@ import { loadConfig } from '../core/config.js';
 import { requireVaultRoot } from '../core/vault.js';
 import { ensureIndex } from '../core/index-db.js';
 import { searchNotes } from '../core/search.js';
+import { jsonSuccess } from '../core/json-output.js';
 
-export function searchCommand(query: string): void {
+export function searchCommand(query: string, options: { json?: boolean }): void {
   const vaultRoot = requireVaultRoot();
   const config = loadConfig(vaultRoot);
   const db = ensureIndex(vaultRoot, config);
 
   const results = searchNotes(db, query);
   db.close();
+
+  if (options.json) {
+    console.log(jsonSuccess(results));
+    return;
+  }
 
   if (results.length === 0) {
     console.log('No results found.');

--- a/src/commands/show.ts
+++ b/src/commands/show.ts
@@ -1,0 +1,47 @@
+import fs from 'node:fs';
+import { loadConfig } from '../core/config.js';
+import { requireVaultRoot } from '../core/vault.js';
+import { findNoteBySlug } from '../core/note.js';
+import { jsonSuccess, jsonError } from '../core/json-output.js';
+
+export function showCommand(slug: string, options: { json?: boolean; body?: boolean }): void {
+  const vaultRoot = requireVaultRoot();
+  const config = loadConfig(vaultRoot);
+  const note = findNoteBySlug(vaultRoot, config, slug);
+
+  if (!note) {
+    if (options.json) {
+      console.log(jsonError(`Note not found: ${slug}`));
+    } else {
+      console.error(`Note not found: ${slug}`);
+    }
+    process.exit(1);
+  }
+
+  if (options.json) {
+    console.log(jsonSuccess({
+      slug: note.slug,
+      title: note.frontmatter.title,
+      type: note.frontmatter.type,
+      created: note.frontmatter.created,
+      modified: note.frontmatter.modified,
+      tags: note.frontmatter.tags,
+      aliases: note.frontmatter.aliases,
+      body: note.body,
+      filepath: note.filepath,
+    }));
+    return;
+  }
+
+  if (options.body) {
+    process.stdout.write(note.body);
+    return;
+  }
+
+  // Default: print full file content
+  console.log(`# ${note.frontmatter.title}  (${note.slug})`);
+  console.log(`# type: ${note.frontmatter.type}  |  modified: ${note.frontmatter.modified.slice(0, 10)}`);
+  console.log('');
+  const content = fs.readFileSync(note.filepath, 'utf-8');
+  console.log(content);
+}

--- a/src/commands/suggest-links.ts
+++ b/src/commands/suggest-links.ts
@@ -3,20 +3,30 @@ import { requireVaultRoot } from '../core/vault.js';
 import { ensureIndex } from '../core/index-db.js';
 import { findNoteBySlug } from '../core/note.js';
 import { suggestLinks } from '../core/suggest.js';
+import { jsonSuccess, jsonError } from '../core/json-output.js';
 
-export function suggestLinksCommand(slug: string): void {
+export function suggestLinksCommand(slug: string, options: { json?: boolean }): void {
   const vaultRoot = requireVaultRoot();
   const config = loadConfig(vaultRoot);
   const note = findNoteBySlug(vaultRoot, config, slug);
 
   if (!note) {
-    console.error(`Note not found: "${slug}"`);
+    if (options.json) {
+      console.log(jsonError(`Note not found: ${slug}`));
+    } else {
+      console.error(`Note not found: "${slug}"`);
+    }
     process.exit(1);
   }
 
   const db = ensureIndex(vaultRoot, config);
   const suggestions = suggestLinks(db, note);
   db.close();
+
+  if (options.json) {
+    console.log(jsonSuccess(suggestions));
+    return;
+  }
 
   if (suggestions.length === 0) {
     console.log('No link suggestions found.');

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -29,7 +29,7 @@ const DEFAULT_CONFIG: GraniteConfig = {
     reference: {
       folder: 'notes/reference',
       description: 'Notes on external sources (articles, books, talks)',
-      template: '## Source\n\nURL or citation here.\n\n## Key Points\n\n- \n\n## My Take\n\n',
+      template: '## Source\n\nURL or citation here.\n\n## Date\n\n## Key Points\n\n- \n\n## My Take\n\n',
       line_limit: 300,
       warn_only: true,
       instructions: 'Capture the source, the key points in your own words, and your reaction. Link to permanent notes that relate.',
@@ -37,7 +37,7 @@ const DEFAULT_CONFIG: GraniteConfig = {
     person: {
       folder: 'notes/people',
       description: 'Card for a person — contact, context, history',
-      template: '## Role\n\n## Context\n\nHow I know them, what we work on.\n\n## Notes\n\n- \n\n## Links\n\n',
+      template: '## Role\n\n## Context\n\nHow I know them, what we work on.\n\n## Contact\n\n## Notes\n\n- \n\n## Links\n\n',
       line_limit: 150,
       warn_only: true,
       instructions: 'Fill in their role and context. Add timestamped notes as you interact (meetings, emails, calls). Link to projects, companies, or topics they relate to.',
@@ -61,7 +61,7 @@ const DEFAULT_CONFIG: GraniteConfig = {
     decision: {
       folder: 'notes/decisions',
       description: 'Record of a decision — context, options, outcome',
-      template: '## Context\n\nWhat prompted this decision.\n\n## Options Considered\n\n1. \n2. \n\n## Decision\n\n\n\n## Rationale\n\n',
+      template: '## Context\n\nWhat prompted this decision.\n\n## Options Considered\n\n1. \n2. \n\n## Decision\n\n\n\n## Rationale\n\n## Status\n\nActive\n',
       line_limit: 200,
       warn_only: false,
       instructions: 'Document the context, what options were considered, what was decided, and why. This is a permanent record — future-you will thank you. Link to the project or topic.',

--- a/src/core/json-output.ts
+++ b/src/core/json-output.ts
@@ -1,0 +1,7 @@
+export function jsonSuccess(data: unknown): string {
+  return JSON.stringify({ success: true, data }, null, 2);
+}
+
+export function jsonError(error: string): string {
+  return JSON.stringify({ success: false, error }, null, 2);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { initVault } from './commands/init.js';
 import { newNote } from './commands/new.js';
 import { addNote } from './commands/add.js';
 import { openNote } from './commands/open.js';
+import { showCommand } from './commands/show.js';
 import { searchCommand } from './commands/search.js';
 import { backlinksCommand } from './commands/backlinks.js';
 import { suggestLinksCommand } from './commands/suggest-links.js';
@@ -31,16 +32,18 @@ program
   .description('Create a new note')
   .argument('<title>', 'Note title')
   .option('-t, --type <type>', 'Note type (e.g. fleeting, permanent, reference)')
-  .action((title: string, options: { type?: string }) => {
-    newNote(title, options.type);
+  .option('--json', 'Output as JSON (agent-friendly)')
+  .action((title: string, options: { type?: string; json?: boolean }) => {
+    newNote(title, options);
   });
 
 program
   .command('add')
   .description('Quick-capture a fleeting note (reads stdin if no text given)')
   .argument('[text]', 'Note text (or pipe via stdin)')
-  .action((text?: string) => {
-    addNote(text);
+  .option('--json', 'Output as JSON (agent-friendly)')
+  .action((text: string | undefined, options: { json?: boolean }) => {
+    addNote(text, options);
   });
 
 program
@@ -61,7 +64,8 @@ program
   .option('--append <text>', 'Append text to the note body')
   .option('--title <title>', 'Update the note title')
   .option('--tag <tags>', 'Add tags (comma-separated)')
-  .action((slug: string, options: { body?: string; append?: string; title?: string; tag?: string }) => {
+  .option('--alias <aliases>', 'Add aliases (comma-separated)')
+  .action((slug: string, options: { body?: string; append?: string; title?: string; tag?: string; alias?: string }) => {
     editCommand(slug, options);
   });
 
@@ -74,27 +78,41 @@ program
   });
 
 program
+  .command('show')
+  .alias('cat')
+  .description('Display a note by slug')
+  .argument('<slug>', 'Note slug')
+  .option('--json', 'Output as JSON (agent-friendly)')
+  .option('--body', 'Output body only (no frontmatter)')
+  .action((slug: string, options: { json?: boolean; body?: boolean }) => {
+    showCommand(slug, options);
+  });
+
+program
   .command('search')
   .description('Full-text search across notes')
   .argument('<query>', 'Search query')
-  .action((query: string) => {
-    searchCommand(query);
+  .option('--json', 'Output as JSON (agent-friendly)')
+  .action((query: string, options: { json?: boolean }) => {
+    searchCommand(query, options);
   });
 
 program
   .command('backlinks')
   .description('Show notes that link to a given note')
   .argument('<slug>', 'Note slug')
-  .action((slug: string) => {
-    backlinksCommand(slug);
+  .option('--json', 'Output as JSON (agent-friendly)')
+  .action((slug: string, options: { json?: boolean }) => {
+    backlinksCommand(slug, options);
   });
 
 program
   .command('suggest-links')
   .description('Suggest wikilinks based on unlinked mentions')
   .argument('<slug>', 'Note slug')
-  .action((slug: string) => {
-    suggestLinksCommand(slug);
+  .option('--json', 'Output as JSON (agent-friendly)')
+  .action((slug: string, options: { json?: boolean }) => {
+    suggestLinksCommand(slug, options);
   });
 
 program


### PR DESCRIPTION
- Add `mem show <slug>` command (alias `cat`) for reading notes by slug
  with --json and --body flags
- Add consistent JSON envelope ({"success", "data"}) via json-output.ts
- Add --json flag to search, backlinks, suggest-links, new, add commands
- Update list --json to use the same envelope format
- Add --alias flag to edit command for managing note aliases
- Improve note templates: add Date to reference, Contact to person,
  Status to decision
- Rewrite SKILL.md with agent-first patterns: core workflow loop,
  type decision tree, concrete writing examples per type, key patterns
  (meeting capture, decision recording, knowledge retrieval), tags
  and aliases guidance

https://claude.ai/code/session_01Bvt8uVZXaFeFWjahSBwAjG

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk due to CLI interface changes and new `--json` output paths that could affect downstream scripts; functionality is straightforward but touches multiple commands’ output/error behavior.
> 
> **Overview**
> Makes the `mem` CLI more agent-friendly by adding `mem show`/`cat` to read notes by slug (with `--json` and `--body`) and by standardizing JSON output across commands via a shared `{ success, data|error }` envelope.
> 
> Extends existing commands to accept `--json` (`new`, `add`, `search`, `backlinks`, `suggest-links`) and updates `list --json` to match the new envelope; `new --json` now returns link suggestions as structured data.
> 
> Adds `mem edit --alias` to manage frontmatter aliases, updates default note templates (reference date, person contact, decision status), and rewrites `skills/mem/SKILL.md` with an agent-first workflow, examples, and tagging/alias guidance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2d60ddb2add434432524c74049849024f63792a1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the CLI agent-first by adding `mem show`, unifying JSON outputs, and improving note authoring. Easier programmatic use, consistent responses, and clearer SKILL guidance.

- **New Features**
  - Add `mem show <slug>` (alias `cat`) with `--json` and `--body` for reading notes.
  - Add `--json` to `new`, `add`, `search`, `backlinks`, and `suggest-links`; all JSON now uses `{"success": true, "data": ...}` via `json-output.ts`.
  - Add `--alias` to `edit` to manage note aliases.
  - Improve templates: `reference` adds Date, `person` adds Contact, `decision` adds Status.
  - Rewrite `skills/mem/SKILL.md` with an agent-first workflow, type decision tree, concrete examples, and tags/aliases guidance.

- **Migration**
  - `list --json` now returns `{ success, data }` instead of a raw array; update scripts to read from `data` and check `success`.
  - Commands with new `--json` output follow the same envelope; errors return `{ success: false, error }`.

<sup>Written for commit 2d60ddb2add434432524c74049849024f63792a1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

