### PR TITLE
Agent-first CLI, Granite Object Standard, and skill rewrite

### DIFF
--- a/docs/GRANITE_OBJECT_STANDARD.md
+++ b/docs/GRANITE_OBJECT_STANDARD.md
@@ -96,10 +96,11 @@ note_types:
       context_for:
         type: wikilink
         description: Project or area this decision belongs to
-      status:
+      decision_status:
         type: enum
         options: [active, superseded, revisit]
         default: active
+        description: Decision lifecycle (distinct from universal note status)
       superseded_by:
         type: wikilink
         description: If superseded, link to replacement decision

--- a/docs/GRANITE_OBJECT_STANDARD.md
+++ b/docs/GRANITE_OBJECT_STANDARD.md
@@ -1,0 +1,399 @@
+# Granite Object Standard (GOS)
+
+> A simple, powerful standard for agent-first note and object management.
+> Informed by: MCP resources/tools, gh CLI field selection, Mem0 agent memory,
+> Schema.org typed relationships, Logseq class-based schemas, CRDT identity patterns.
+
+---
+
+## 1. Design Principles
+
+### 1.1 Markdown is truth, everything else is derived
+Files on disk are the source of truth. The SQLite index, backlinks graph, and search
+results are materialized views — rebuilt anytime from the files.
+
+### 1.2 Agent-first, human-friendly
+Every command returns structured JSON by default when piped (`!isTTY`).
+Human-readable output is a presentation layer on top of the same data.
+
+### 1.3 Stable identity survives renames
+Notes are identified by UUID (`id` in frontmatter), not by slug or title.
+Slugs are human-friendly aliases. Wikilinks resolve through: slug → title → alias → id.
+
+### 1.4 Type = Schema
+Each note type defines expected fields. The type system is the schema system.
+Types are constrained to ~10 max (Johnny Decimal principle: discoverable at a glance).
+
+### 1.5 Links are typed
+Not all connections are equal. `[[wikilinks]]` carry semantic meaning through
+frontmatter fields that define the relationship type.
+
+### 1.6 Agents operate via Extract → Compare → Decide
+Following the Mem0 pattern: extract facts from conversation, compare against existing
+notes via search, then ADD / UPDATE / NOOP. Never blindly append.
+
+---
+
+## 2. Note Object Schema
+
+### 2.1 Universal frontmatter (all note types)
+
+```yaml
+---
+id: "uuid-v4"                    # Stable identity (survives renames)
+title: "Note Title"              # Human-readable name
+type: "permanent"                # Schema selector
+created: "2026-03-30T10:00:00Z"  # ISO 8601
+modified: "2026-03-30T10:00:00Z" # ISO 8601
+tags: [architecture, active]     # Flat taxonomy, lowercase
+aliases: [alt-name, abbrev]      # Resolve wikilinks by alias
+status: active                   # Lifecycle: inbox | active | archived
+source: human                    # Provenance: human | agent | extraction
+---
+```
+
+**New fields (vs current Granite):**
+- `status` — lifecycle state, orthogonal to type. Enables PARA-style workflow:
+  `inbox` (raw capture) → `active` (in use) → `archived` (done, kept for reference).
+- `source` — who created this note. Critical for trust: an agent reading a `human`
+  permanent note trusts it more than an `agent` fleeting note.
+
+### 2.2 Type-specific schemas (defined in granite.yml)
+
+Each note type declares expected fields and their types:
+
+```yaml
+note_types:
+  meeting:
+    folder: notes/meetings
+    description: Meeting notes with attendees, decisions, and actions
+    fields:
+      attendees:
+        type: list
+        of: wikilink
+        description: People present
+      date:
+        type: date
+        required: true
+      project:
+        type: wikilink
+        description: Related project
+    template: |
+      ## Attendees
+
+      ## Agenda
+
+      ## Notes
+
+      ## Decisions
+
+      ## Actions
+    line_limit: 300
+
+  decision:
+    folder: notes/decisions
+    fields:
+      context_for:
+        type: wikilink
+        description: Project or area this decision belongs to
+      status:
+        type: enum
+        options: [active, superseded, revisit]
+        default: active
+      superseded_by:
+        type: wikilink
+        description: If superseded, link to replacement decision
+    template: |
+      ## Context
+
+      ## Options Considered
+
+      1.
+      2.
+
+      ## Decision
+
+      ## Rationale
+
+      ## Status
+
+      Active
+    line_limit: 200
+
+  person:
+    folder: notes/people
+    fields:
+      role:
+        type: text
+      org:
+        type: text
+      contact:
+        type: text
+    template: |
+      ## Role
+
+      ## Context
+
+      ## Contact
+
+      ## Notes
+
+      ## Links
+    line_limit: 150
+```
+
+**Field types:** `text`, `date`, `number`, `boolean`, `wikilink`, `list`, `enum`.
+Type-specific fields appear in frontmatter and are indexed in SQLite for structured queries.
+
+### 2.3 Typed relationships via frontmatter
+
+Instead of all `[[wikilinks]]` being untyped, key relationships are declared in frontmatter:
+
+```yaml
+---
+id: "abc-123"
+title: "Sprint review 2026-03-30"
+type: meeting
+attendees: ["[[jane-smith]]", "[[bob-chen]]"]
+project: "[[project-granite]]"
+---
+```
+
+The body still uses `[[wikilinks]]` for inline mentions, but frontmatter relationships
+are **structured, queryable, and carry semantic meaning**:
+- `attendees` links are of type "person attended meeting"
+- `project` links are of type "meeting about project"
+
+This enables queries like: `mem search --field attendees:jane-smith` or
+`mem list --type meeting --field project:project-granite`.
+
+---
+
+## 3. CLI Output Standard
+
+### 3.1 Format detection
+
+```
+TTY (human typing)  →  human-readable tables/text
+Piped / --json      →  structured JSON with envelope
+--format ndjson     →  streaming, one JSON object per line
+```
+
+### 3.2 JSON envelope (every command)
+
+**Success:**
+```json
+{
+  "success": true,
+  "data": { ... },
+  "meta": {
+    "count": 5,
+    "vault": "/home/user/notes"
+  }
+}
+```
+
+**Error:**
+```json
+{
+  "success": false,
+  "error": {
+    "code": "NOTE_NOT_FOUND",
+    "message": "No note with slug 'nonexistent'",
+    "suggestion": "Did you mean 'decision-api-format'?"
+  }
+}
+```
+
+### 3.3 Field selection (gh CLI pattern)
+
+```bash
+mem list --json slug,title,type,tags
+mem show note-slug --json title,body,backlinks
+mem search "query" --json slug,title,score
+```
+
+`--json` without field names = list available fields (self-documenting):
+```
+$ mem list --json
+Available fields: slug, title, type, created, modified, tags, aliases, status, source, filepath
+```
+
+### 3.4 Structured filtering
+
+```bash
+mem list --type meeting --tag project-x --status active --since 2026-03-01
+mem list --field attendees:jane-smith          # Type-specific field query
+mem search "api design" --type decision        # Full-text + type filter
+```
+
+### 3.5 Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | General error |
+| 2 | Usage/argument error |
+| 4 | Not found (empty result, distinct from error) |
+
+### 3.6 NDJSON streaming (for large vaults)
+
+```bash
+mem list --format ndjson
+```
+```jsonl
+{"slug":"note-1","title":"First","type":"fleeting","status":"inbox"}
+{"slug":"note-2","title":"Second","type":"decision","status":"active"}
+```
+
+---
+
+## 4. Agent Interaction Standard
+
+### 4.1 The ECDA loop (Extract → Compare → Decide → Act)
+
+Every agent interaction with the vault follows this pattern:
+
+```
+┌─────────┐    ┌─────────┐    ┌─────────┐    ┌─────────┐
+│ EXTRACT │───▶│ COMPARE │───▶│ DECIDE  │───▶│  ACT    │
+│ facts   │    │ search  │    │ ADD?    │    │ create/ │
+│ from    │    │ vault   │    │ UPDATE? │    │ update/ │
+│ context │    │ for     │    │ NOOP?   │    │ link    │
+│         │    │ matches │    │         │    │         │
+└─────────┘    └─────────┘    └─────────┘    └─────────┘
+```
+
+**Step 1 — Extract:** Identify atomic facts, entities, and relationships from conversation.
+
+**Step 2 — Compare:** Search the vault for existing notes about the same entities.
+```bash
+mem search "Jane Smith" --json slug,title,type
+mem list --type person --json slug,title --field role:CTO
+```
+
+**Step 3 — Decide:**
+- If no match → `ADD` (create new note)
+- If match and new info → `UPDATE` (append or edit existing)
+- If match and no new info → `NOOP` (skip)
+
+**Step 4 — Act:**
+```bash
+mem new "Jane Smith" -t person --json               # ADD
+mem edit jane-smith --append $'- 2026-03-30: ...'    # UPDATE
+# NOOP = do nothing
+```
+
+### 4.2 Trust levels by source and type
+
+When an agent reads notes to inform its responses, trust varies:
+
+| Source × Type | Trust | Use |
+|---|---|---|
+| human + permanent | Highest | Authoritative knowledge |
+| human + decision | High | Established choices |
+| human + reference | High | Verified external sources |
+| agent + permanent | Medium | Agent-refined insights (verify) |
+| human + fleeting | Low | Raw, unprocessed capture |
+| agent + fleeting | Lowest | Agent speculation (needs review) |
+
+### 4.3 MCP resource/tool mapping
+
+If Granite exposes an MCP server, the split is:
+
+**Resources (reads, application-controlled):**
+- `granite://vault/notes/{slug}` — read a note
+- `granite://vault/search?q={query}` — search results
+- `granite://vault/backlinks/{slug}` — backlink graph
+- `granite://vault/types` — available note types with schemas
+
+**Tools (writes, model-controlled):**
+- `create_note(title, type, body, fields)` — create a note
+- `update_note(slug, body?, append?, title?, tags?, aliases?)` — edit a note
+- `link_notes(source, target, relationship?)` — add a wikilink
+
+---
+
+## 5. Knowledge Graph Patterns
+
+### 5.1 Hub notes (Maps of Content)
+
+For major topics, create permanent notes that are mostly links:
+
+```yaml
+---
+title: "Knowledge Map: Infrastructure"
+type: permanent
+tags: [hub, area/infrastructure]
+---
+
+## Active Projects
+- [[project-granite]] — Memory system for agents
+- [[project-api-v2]] — API redesign
+
+## Key Decisions
+- [[decision-use-sqlite]] — Database choice
+- [[decision-markdown-first]] — File format
+
+## People
+- [[jane-smith]] — Infrastructure lead
+- [[bob-chen]] — Backend engineer
+
+## Reference
+- [[local-first-software]] — Architecture pattern
+```
+
+### 5.2 Temporal chains
+
+Meeting and decision notes form temporal chains through wikilinks:
+
+```
+[[sprint-review-2026-03-23]] → [[sprint-review-2026-03-30]] → [[sprint-review-2026-04-06]]
+```
+
+Each links to the previous and next. Agents can traverse the chain to build context.
+
+### 5.3 The promotion flow
+
+```
+fleeting (inbox)  ──refine──▶  permanent (active)  ──archive──▶  permanent (archived)
+     │                              ▲
+     └──────extract──────▶  reference (active)
+```
+
+Fleeting notes are raw captures. During review, atomic insights are extracted
+into permanent notes, and source material goes into reference notes.
+The fleeting note is then archived (not deleted — it's the provenance chain).
+
+---
+
+## 6. Implementation Priorities for Granite
+
+### Phase 1 (shipped): Agent-readable CLI
+✅ `mem show` command
+✅ `--json` on all commands
+✅ Consistent JSON envelope
+✅ `--alias` on edit
+✅ Improved templates
+
+### Phase 2 (next): Schema and filtering
+- Add `status` and `source` to universal frontmatter
+- Add `fields` definition to `granite.yml` note types
+- Index type-specific fields in SQLite
+- Add `--field` filter to `list` and `search`
+- Field selection on `--json` (gh-style)
+
+### Phase 3 (future): Advanced agent patterns
+- Auto-detect TTY for format switching
+- NDJSON streaming output
+- Exit code 4 for "not found" (distinct from error)
+- `mem --capabilities` for agent discovery
+- Fuzzy suggestions on "not found" errors
+- MCP server exposing resources + tools
+
+### Phase 4 (later): Knowledge graph intelligence
+- Typed relationship indexing (frontmatter wikilinks stored with relationship type)
+- `mem graph` command for traversing the link graph
+- `mem promote <slug> --to permanent` for lifecycle transitions
+- `mem orphans` to find unlinked notes
+- Hub note auto-generation from tag clusters

--- a/skills/mem/SKILL.md
+++ b/skills/mem/SKILL.md
@@ -8,16 +8,18 @@ allowed-tools: Bash
 
 You are an expert at managing a structured knowledge base using the `mem` CLI — a local-first markdown memory system built on Zettelkasten principles.
 
-## Core Workflow
+## Core Workflow (ECDA Loop)
 
 Every interaction follows this loop:
 
 ```
-1. Search  →  check if a related note exists
-2. Create or Append  →  never duplicate
-3. Link  →  connect with [[wikilinks]]
-4. Verify  →  check line limits, run suggest-links
+1. Extract   →  identify facts, entities, relationships from conversation
+2. Compare   →  search vault for existing notes about the same entities
+3. Decide    →  ADD (new note), UPDATE (append/edit), or NOOP (skip)
+4. Act       →  create/update, link with [[wikilinks]], verify limits
 ```
+
+**Always set `--source agent`** when creating or editing notes as an agent.
 
 ## Note Type Decision Tree
 
@@ -50,24 +52,27 @@ If a note exceeds its limit, **split it** into multiple linked notes.
 ### Create
 
 ```bash
-mem new "Note title" -t permanent       # Create typed note
-mem new "Quick thought"                  # Fleeting note (default)
-mem new "Sprint review 2026-03-30" -t meeting --json  # JSON output
-mem add "Quick thought"                  # Quick-capture fleeting note
-echo "Piped content" | mem add --json    # Stdin + JSON output
+mem new "Note title" -t permanent                      # Create typed note
+mem new "Quick thought"                                # Fleeting note (default)
+mem new "Sprint review" -t meeting --source agent --json  # Agent-created, JSON output
+mem add "Quick thought"                                # Quick-capture fleeting note
+echo "Piped content" | mem add --json                  # Stdin + JSON output
 ```
 
 ### Read
 
 ```bash
-mem show <slug>              # Display note with header
-mem show <slug> --json       # Full note as JSON (agent-friendly)
-mem show <slug> --body       # Raw body only (for piping)
-mem list                     # All notes, sorted by modified
-mem list -t person           # Filter by type
-mem list --json              # JSON output
-mem search "query"           # Full-text search
-mem search "query" --json    # JSON output
+mem show <slug>                          # Display note with header
+mem show <slug> --json                   # Full note as JSON (agent-friendly)
+mem show <slug> --body                   # Raw body only (for piping)
+mem list                                 # All notes, sorted by modified
+mem list -t person                       # Filter by type
+mem list -s active                       # Filter by status
+mem list --source agent                  # Filter by source
+mem list --since 2026-03-01              # Filter by modified date
+mem list --json slug,title,type,status   # Field selection (gh-style)
+mem search "query"                       # Full-text search
+mem search "query" --json                # JSON output
 ```
 
 ### Update
@@ -78,6 +83,8 @@ mem edit <slug> --append $'- 2026-03-30: Met at conf'   # Append text
 mem edit <slug> --title "New Title"                      # Update title
 mem edit <slug> --tag "tag1,tag2"                        # Add tags
 mem edit <slug> --alias "short-name,abbreviation"        # Add aliases
+mem edit <slug> --status archived                        # Archive a note
+mem edit <slug> --source agent                           # Mark as agent-edited
 mem edit <slug>                                          # Open in $EDITOR
 ```
 
@@ -228,16 +235,44 @@ mem edit jane-smith --alias "Jane,jsmith"
 ```
 This makes wikilinks resolve correctly: `[[AWS]]` will find the `amazon-web-services` note.
 
+## Status and Source (Provenance)
+
+Every note has `status` and `source` fields in frontmatter:
+
+**Status** — lifecycle state, orthogonal to type:
+- `inbox` — raw capture, needs processing
+- `active` — in use, current (default)
+- `archived` — done, kept for reference
+
+**Source** — who created it:
+- `human` — created by a person (default)
+- `agent` — created by an AI agent
+- `extraction` — extracted from another source
+
+**Trust levels** — when reading notes to inform responses:
+| Combo | Trust |
+|-------|-------|
+| human + permanent | Highest — authoritative knowledge |
+| human + decision | High — established choices |
+| agent + permanent | Medium — verify before citing |
+| human + fleeting | Low — raw, unprocessed |
+| agent + fleeting | Lowest — needs human review |
+
+**Agents must always use `--source agent`** when creating notes:
+```bash
+mem new "Insight from conversation" -t permanent --source agent --json
+```
+
 ## Key Patterns
 
 ### Capturing a meeting
 
 ```bash
 mem search "sprint review" --json           # Check if note exists
-mem new "Sprint review 2026-03-30" -t meeting --json
+mem new "Sprint review 2026-03-30" -t meeting --source agent --json
 # For each attendee:
 mem search "Jane Smith" --json              # Check if person note exists
-mem new "Jane Smith" -t person --json       # Create if missing
+mem new "Jane Smith" -t person --source agent --json  # Create if missing
 # Fill meeting body:
 mem edit sprint-review-2026-03-30 --body $'## Attendees\n\n- [[jane-smith]]\n...'
 # Update person notes:
@@ -248,7 +283,7 @@ mem edit jane-smith --append $'- 2026-03-30: [[sprint-review-2026-03-30]]'
 
 ```bash
 mem search "database choice" --json
-mem new "Analytics database choice" -t decision --json
+mem new "Analytics database choice" -t decision --source agent --json
 mem edit analytics-database-choice --body $'## Context\n\n...\n\n## Decision\n\n...\n\n## Status\n\nActive'
 mem edit analytics-database-choice --tag "area/infrastructure"
 mem edit analytics-service --append $'Key decision: [[analytics-database-choice]]'

--- a/src/commands/edit.ts
+++ b/src/commands/edit.ts
@@ -4,6 +4,7 @@ import { loadConfig } from '../core/config.js';
 import { requireVaultRoot } from '../core/vault.js';
 import { findNoteBySlug } from '../core/note.js';
 import { parseFrontmatter, serializeFrontmatter } from '../core/frontmatter.js';
+import { validateStatus, validateSource } from '../core/json-output.js';
 
 interface EditOptions {
   body?: string;
@@ -50,11 +51,13 @@ export function editCommand(slug: string, options: EditOptions): void {
     }
 
     if (options.status) {
-      frontmatter.status = options.status as 'inbox' | 'active' | 'archived';
+      validateStatus(options.status);
+      frontmatter.status = options.status;
     }
 
     if (options.source) {
-      frontmatter.source = options.source as 'human' | 'agent' | 'extraction';
+      validateSource(options.source);
+      frontmatter.source = options.source;
     }
 
     if (options.body !== undefined) {

--- a/src/commands/edit.ts
+++ b/src/commands/edit.ts
@@ -11,6 +11,8 @@ interface EditOptions {
   title?: string;
   tag?: string;
   alias?: string;
+  status?: string;
+  source?: string;
 }
 
 export function editCommand(slug: string, options: EditOptions): void {
@@ -23,7 +25,7 @@ export function editCommand(slug: string, options: EditOptions): void {
     process.exit(1);
   }
 
-  const hasFlags = options.body !== undefined || options.append !== undefined || options.title !== undefined || options.tag !== undefined || options.alias !== undefined;
+  const hasFlags = options.body !== undefined || options.append !== undefined || options.title !== undefined || options.tag !== undefined || options.alias !== undefined || options.status !== undefined || options.source !== undefined;
 
   if (hasFlags) {
     // Programmatic edit (agent mode)
@@ -45,6 +47,14 @@ export function editCommand(slug: string, options: EditOptions): void {
       const existing = new Set(frontmatter.aliases);
       for (const a of newAliases) existing.add(a);
       frontmatter.aliases = [...existing];
+    }
+
+    if (options.status) {
+      frontmatter.status = options.status as 'inbox' | 'active' | 'archived';
+    }
+
+    if (options.source) {
+      frontmatter.source = options.source as 'human' | 'agent' | 'extraction';
     }
 
     if (options.body !== undefined) {

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -2,8 +2,38 @@ import { loadConfig } from '../core/config.js';
 import { requireVaultRoot } from '../core/vault.js';
 import { listNotes } from '../core/note.js';
 import { jsonSuccess } from '../core/json-output.js';
+import type { Note } from '../core/types.js';
 
-export function listCommand(options: { type?: string; json?: boolean }): void {
+const AVAILABLE_FIELDS = ['slug', 'title', 'type', 'created', 'modified', 'tags', 'aliases', 'status', 'source', 'filepath'];
+
+interface ListOptions {
+  type?: string;
+  status?: string;
+  source?: string;
+  since?: string;
+  json?: boolean | string;
+}
+
+function pickFields(note: Note, fields: string[]): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const f of fields) {
+    switch (f) {
+      case 'slug': out.slug = note.slug; break;
+      case 'title': out.title = note.frontmatter.title; break;
+      case 'type': out.type = note.frontmatter.type; break;
+      case 'created': out.created = note.frontmatter.created; break;
+      case 'modified': out.modified = note.frontmatter.modified; break;
+      case 'tags': out.tags = note.frontmatter.tags; break;
+      case 'aliases': out.aliases = note.frontmatter.aliases; break;
+      case 'status': out.status = note.frontmatter.status; break;
+      case 'source': out.source = note.frontmatter.source; break;
+      case 'filepath': out.filepath = note.filepath; break;
+    }
+  }
+  return out;
+}
+
+export function listCommand(options: ListOptions): void {
   const vaultRoot = requireVaultRoot();
   const config = loadConfig(vaultRoot);
   let notes = listNotes(vaultRoot, config);
@@ -12,19 +42,36 @@ export function listCommand(options: { type?: string; json?: boolean }): void {
     notes = notes.filter(n => n.frontmatter.type === options.type);
   }
 
+  if (options.status) {
+    notes = notes.filter(n => n.frontmatter.status === options.status);
+  }
+
+  if (options.source) {
+    notes = notes.filter(n => n.frontmatter.source === options.source);
+  }
+
+  if (options.since) {
+    notes = notes.filter(n => n.frontmatter.modified >= options.since!);
+  }
+
   // Sort by modified desc
   notes.sort((a, b) => b.frontmatter.modified.localeCompare(a.frontmatter.modified));
 
-  if (options.json) {
-    const out = notes.map(n => ({
-      slug: n.slug,
-      title: n.frontmatter.title,
-      type: n.frontmatter.type,
-      created: n.frontmatter.created,
-      modified: n.frontmatter.modified,
-      tags: n.frontmatter.tags,
-      filepath: n.filepath,
-    }));
+  if (options.json !== undefined && options.json !== false) {
+    // --json with field selection: --json slug,title,type
+    // --json without value (boolean true): all default fields
+    let fields: string[];
+    if (typeof options.json === 'string') {
+      fields = options.json.split(',').map(f => f.trim()).filter(f => AVAILABLE_FIELDS.includes(f));
+      if (fields.length === 0) {
+        console.log(`Available fields: ${AVAILABLE_FIELDS.join(', ')}`);
+        return;
+      }
+    } else {
+      fields = AVAILABLE_FIELDS;
+    }
+
+    const out = notes.map(n => pickFields(n, fields));
     console.log(jsonSuccess(out));
     return;
   }
@@ -37,7 +84,8 @@ export function listCommand(options: { type?: string; json?: boolean }): void {
   for (const note of notes) {
     const date = note.frontmatter.modified.slice(0, 10);
     const type = note.frontmatter.type.padEnd(10);
-    console.log(`  ${date}  ${type}  ${note.frontmatter.title}  (${note.slug})`);
+    const status = note.frontmatter.status?.padEnd(8) ?? 'active  ';
+    console.log(`  ${date}  ${type}  ${status}  ${note.frontmatter.title}  (${note.slug})`);
   }
 
   console.log(`\n${notes.length} note(s)`);

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -3,7 +3,7 @@ import { loadConfig } from '../core/config.js';
 import { requireVaultRoot } from '../core/vault.js';
 import { createNote, listNotes } from '../core/note.js';
 import { parseFrontmatter, serializeFrontmatter } from '../core/frontmatter.js';
-import { jsonSuccess } from '../core/json-output.js';
+import { jsonSuccess, validateStatus, validateSource } from '../core/json-output.js';
 
 export function newNote(title: string, options: { type?: string; source?: string; status?: string; json?: boolean }): void {
   const vaultRoot = requireVaultRoot();
@@ -17,10 +17,12 @@ export function newNote(title: string, options: { type?: string; source?: string
 
   // Apply source/status overrides
   if (options.source || options.status) {
+    if (options.source) validateSource(options.source);
+    if (options.status) validateStatus(options.status);
     const raw = fs.readFileSync(note.filepath, 'utf-8');
     const { frontmatter, body } = parseFrontmatter(raw);
-    if (options.source) frontmatter.source = options.source as 'human' | 'agent' | 'extraction';
-    if (options.status) frontmatter.status = options.status as 'inbox' | 'active' | 'archived';
+    if (options.source) frontmatter.source = options.source as typeof frontmatter.source;
+    if (options.status) frontmatter.status = options.status as typeof frontmatter.status;
     fs.writeFileSync(note.filepath, serializeFrontmatter(frontmatter, body), 'utf-8');
     note.frontmatter = frontmatter;
   }

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -1,9 +1,11 @@
+import fs from 'node:fs';
 import { loadConfig } from '../core/config.js';
 import { requireVaultRoot } from '../core/vault.js';
 import { createNote, listNotes } from '../core/note.js';
+import { parseFrontmatter, serializeFrontmatter } from '../core/frontmatter.js';
 import { jsonSuccess } from '../core/json-output.js';
 
-export function newNote(title: string, options: { type?: string; json?: boolean }): void {
+export function newNote(title: string, options: { type?: string; source?: string; status?: string; json?: boolean }): void {
   const vaultRoot = requireVaultRoot();
   const config = loadConfig(vaultRoot);
   const resolvedType = options.type || config.defaults.note_type;
@@ -12,6 +14,16 @@ export function newNote(title: string, options: { type?: string; json?: boolean 
   // For date-slug types (like fleeting), the title IS the content
   const bodyOverride = typeConfig?.slug_format === 'date' ? title + '\n' : undefined;
   const note = createNote(vaultRoot, config, resolvedType, title, bodyOverride);
+
+  // Apply source/status overrides
+  if (options.source || options.status) {
+    const raw = fs.readFileSync(note.filepath, 'utf-8');
+    const { frontmatter, body } = parseFrontmatter(raw);
+    if (options.source) frontmatter.source = options.source as 'human' | 'agent' | 'extraction';
+    if (options.status) frontmatter.status = options.status as 'inbox' | 'active' | 'archived';
+    fs.writeFileSync(note.filepath, serializeFrontmatter(frontmatter, body), 'utf-8');
+    note.frontmatter = frontmatter;
+  }
 
   const lines = note.body.split('\n').length;
   const overLimit = typeConfig && typeConfig.line_limit && lines > typeConfig.line_limit;
@@ -43,6 +55,8 @@ export function newNote(title: string, options: { type?: string; json?: boolean 
       slug: note.slug,
       title: note.frontmatter.title,
       type: resolvedType,
+      status: note.frontmatter.status,
+      source: note.frontmatter.source,
       filepath: note.filepath,
       suggestions,
     }));

--- a/src/commands/show.ts
+++ b/src/commands/show.ts
@@ -27,6 +27,8 @@ export function showCommand(slug: string, options: { json?: boolean; body?: bool
       modified: note.frontmatter.modified,
       tags: note.frontmatter.tags,
       aliases: note.frontmatter.aliases,
+      status: note.frontmatter.status,
+      source: note.frontmatter.source,
       body: note.body,
       filepath: note.filepath,
     }));

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -41,6 +41,11 @@ const DEFAULT_CONFIG: GraniteConfig = {
       line_limit: 150,
       warn_only: true,
       instructions: 'Fill in their role and context. Add timestamped notes as you interact (meetings, emails, calls). Link to projects, companies, or topics they relate to.',
+      fields: {
+        role: { type: 'text', description: 'Job title or role' },
+        org: { type: 'text', description: 'Organization or company' },
+        contact: { type: 'text', description: 'Email, Slack, phone' },
+      },
     },
     meeting: {
       folder: 'notes/meetings',
@@ -49,6 +54,11 @@ const DEFAULT_CONFIG: GraniteConfig = {
       line_limit: 300,
       warn_only: true,
       instructions: 'List attendees as [[person]] links. Capture decisions and action items clearly. Link to relevant projects or topics.',
+      fields: {
+        attendees: { type: 'list', of: 'wikilink', description: 'People present' },
+        date: { type: 'date', description: 'Meeting date' },
+        project: { type: 'wikilink', description: 'Related project' },
+      },
     },
     project: {
       folder: 'notes/projects',
@@ -57,6 +67,10 @@ const DEFAULT_CONFIG: GraniteConfig = {
       line_limit: 300,
       warn_only: true,
       instructions: 'Define the goal clearly. Keep status updated. Link to people involved, meeting notes, and related permanent notes.',
+      fields: {
+        people: { type: 'list', of: 'wikilink', description: 'Team members involved' },
+        project_status: { type: 'enum', options: ['planning', 'active', 'paused', 'completed'], default: 'active', description: 'Project lifecycle' },
+      },
     },
     decision: {
       folder: 'notes/decisions',
@@ -65,6 +79,11 @@ const DEFAULT_CONFIG: GraniteConfig = {
       line_limit: 200,
       warn_only: false,
       instructions: 'Document the context, what options were considered, what was decided, and why. This is a permanent record — future-you will thank you. Link to the project or topic.',
+      fields: {
+        context_for: { type: 'wikilink', description: 'Project or area this decision belongs to' },
+        decision_status: { type: 'enum', options: ['active', 'superseded', 'revisit'], default: 'active', description: 'Decision lifecycle' },
+        superseded_by: { type: 'wikilink', description: 'Replacement decision if superseded' },
+      },
     },
   },
   defaults: {

--- a/src/core/frontmatter.ts
+++ b/src/core/frontmatter.ts
@@ -11,7 +11,15 @@ export function parseFrontmatter(content: string): { frontmatter: NoteFrontmatte
     modified: data.modified ?? '',
     tags: data.tags ?? [],
     aliases: data.aliases ?? [],
+    status: data.status ?? 'active',
+    source: data.source ?? 'human',
   };
+  // Preserve any extra type-specific fields
+  for (const [key, value] of Object.entries(data)) {
+    if (!(key in fm)) {
+      fm[key] = value;
+    }
+  }
   return { frontmatter: fm, body };
 }
 

--- a/src/core/index-db.ts
+++ b/src/core/index-db.ts
@@ -6,7 +6,7 @@ import { listNotes } from './note.js';
 import { parseWikilinks, resolveWikilinks } from './wikilinks.js';
 import { getIndexDbPath } from './vault.js';
 
-const SCHEMA_VERSION = 1;
+const SCHEMA_VERSION = 2;
 
 const SCHEMA_SQL = `
 CREATE TABLE IF NOT EXISTS notes (
@@ -19,7 +19,9 @@ CREATE TABLE IF NOT EXISTS notes (
   tags        TEXT,
   aliases     TEXT,
   body        TEXT NOT NULL,
-  filepath    TEXT NOT NULL
+  filepath    TEXT NOT NULL,
+  status      TEXT NOT NULL DEFAULT 'active',
+  source      TEXT NOT NULL DEFAULT 'human'
 );
 
 CREATE VIRTUAL TABLE IF NOT EXISTS notes_fts USING fts5(
@@ -92,8 +94,8 @@ export function rebuildIndex(vaultRoot: string, config: GraniteConfig, db: Datab
   db.exec("INSERT INTO notes_fts(notes_fts) VALUES('rebuild')");
 
   const insertNote = db.prepare(`
-    INSERT INTO notes (slug, id, title, type, created, modified, tags, aliases, body, filepath)
-    VALUES (@slug, @id, @title, @type, @created, @modified, @tags, @aliases, @body, @filepath)
+    INSERT INTO notes (slug, id, title, type, created, modified, tags, aliases, body, filepath, status, source)
+    VALUES (@slug, @id, @title, @type, @created, @modified, @tags, @aliases, @body, @filepath, @status, @source)
   `);
 
   const insertLink = db.prepare(`
@@ -114,6 +116,8 @@ export function rebuildIndex(vaultRoot: string, config: GraniteConfig, db: Datab
         aliases: JSON.stringify(note.frontmatter.aliases),
         body: note.body,
         filepath: note.filepath,
+        status: note.frontmatter.status ?? 'active',
+        source: note.frontmatter.source ?? 'human',
       });
 
       // Parse and resolve wikilinks

--- a/src/core/index-db.ts
+++ b/src/core/index-db.ts
@@ -82,6 +82,16 @@ export function openDatabase(vaultRoot: string): Database.Database {
   }
   const db = new Database(dbPath);
   db.pragma('journal_mode = WAL');
+
+  // Check schema version — if outdated, drop and recreate
+  const row = db.prepare('SELECT value FROM meta WHERE key = ?').get('schema_version') as { value: string } | undefined;
+  const currentVersion = row ? Number(row.value) : 0;
+  if (currentVersion < SCHEMA_VERSION) {
+    db.close();
+    fs.unlinkSync(dbPath);
+    return createDatabase(dbPath);
+  }
+
   return db;
 }
 

--- a/src/core/json-output.ts
+++ b/src/core/json-output.ts
@@ -5,3 +5,18 @@ export function jsonSuccess(data: unknown): string {
 export function jsonError(error: string): string {
   return JSON.stringify({ success: false, error }, null, 2);
 }
+
+const VALID_STATUSES = ['inbox', 'active', 'archived'] as const;
+const VALID_SOURCES = ['human', 'agent', 'extraction'] as const;
+
+export function validateStatus(value: string): asserts value is 'inbox' | 'active' | 'archived' {
+  if (!(VALID_STATUSES as readonly string[]).includes(value)) {
+    throw new Error(`Invalid status: "${value}". Expected one of: ${VALID_STATUSES.join(', ')}`);
+  }
+}
+
+export function validateSource(value: string): asserts value is 'human' | 'agent' | 'extraction' {
+  if (!(VALID_SOURCES as readonly string[]).includes(value)) {
+    throw new Error(`Invalid source: "${value}". Expected one of: ${VALID_SOURCES.join(', ')}`);
+  }
+}

--- a/src/core/note.ts
+++ b/src/core/note.ts
@@ -50,6 +50,8 @@ export function createNote(
     modified: now,
     tags: [],
     aliases: [],
+    status: 'active',
+    source: 'human',
   };
 
   const body = bodyOverride ?? typeConfig.template;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -6,6 +6,16 @@ export interface NoteTypeConfig {
   warn_only: boolean;
   instructions?: string;
   slug_format?: 'title' | 'date';
+  fields?: Record<string, FieldDefinition>;
+}
+
+export interface FieldDefinition {
+  type: 'text' | 'date' | 'number' | 'boolean' | 'wikilink' | 'list' | 'enum';
+  of?: string;
+  options?: string[];
+  required?: boolean;
+  default?: string;
+  description?: string;
 }
 
 export interface GraniteConfig {
@@ -29,6 +39,9 @@ export interface NoteFrontmatter {
   modified: string;
   tags: string[];
   aliases: string[];
+  status: 'inbox' | 'active' | 'archived';
+  source: 'human' | 'agent' | 'extraction';
+  [key: string]: unknown;
 }
 
 export interface Note {

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,8 +32,10 @@ program
   .description('Create a new note')
   .argument('<title>', 'Note title')
   .option('-t, --type <type>', 'Note type (e.g. fleeting, permanent, reference)')
+  .option('--source <source>', 'Set source (human, agent, extraction)')
+  .option('--status <status>', 'Set status (inbox, active, archived)')
   .option('--json', 'Output as JSON (agent-friendly)')
-  .action((title: string, options: { type?: string; json?: boolean }) => {
+  .action((title: string, options: { type?: string; source?: string; status?: string; json?: boolean }) => {
     newNote(title, options);
   });
 
@@ -51,8 +53,11 @@ program
   .alias('ls')
   .description('List notes')
   .option('-t, --type <type>', 'Filter by note type')
-  .option('--json', 'Output as JSON (agent-friendly)')
-  .action((options: { type?: string; json?: boolean }) => {
+  .option('-s, --status <status>', 'Filter by status (inbox, active, archived)')
+  .option('--source <source>', 'Filter by source (human, agent, extraction)')
+  .option('--since <date>', 'Filter notes modified since date (YYYY-MM-DD)')
+  .option('--json [fields]', 'Output as JSON; optionally specify fields (e.g. --json slug,title,type)')
+  .action((options: { type?: string; status?: string; source?: string; since?: string; json?: boolean | string }) => {
     listCommand(options);
   });
 
@@ -65,7 +70,9 @@ program
   .option('--title <title>', 'Update the note title')
   .option('--tag <tags>', 'Add tags (comma-separated)')
   .option('--alias <aliases>', 'Add aliases (comma-separated)')
-  .action((slug: string, options: { body?: string; append?: string; title?: string; tag?: string; alias?: string }) => {
+  .option('--status <status>', 'Set status (inbox, active, archived)')
+  .option('--source <source>', 'Set source (human, agent, extraction)')
+  .action((slug: string, options: { body?: string; append?: string; title?: string; tag?: string; alias?: string; status?: string; source?: string }) => {
     editCommand(slug, options);
   });
 


### PR DESCRIPTION
## Summary

- **Agent-first CLI**: Add `mem show` command, `--json` on all commands with consistent envelope (`{"success", "data"}`), gh-style field selection (`--json slug,title,type`), and new filters (`--status`, `--source`, `--since`)
- **Granite Object Standard (GOS)**: Research-backed design document defining how agents and humans interact with structured notes — ECDA loop, typed schemas, provenance, trust levels, MCP mapping
- **Provenance system**: Every note now carries `status` (inbox/active/archived) and `source` (human/agent/extraction) for lifecycle tracking and trust differentiation
- **Typed field schemas**: Note types declare typed fields in `granite.yml` (wikilink, list, enum, text, date) — meeting has `attendees`, person has `role`/`org`, decision has `decision_status`
- **Skill rewrite**: ECDA workflow loop, concrete writing examples per type, trust level table, agent patterns with `--source agent`

## Changes

### Phase 1: CLI agent-first
- New `mem show <slug>` command (alias `cat`) with `--json` and `--body` flags
- New `src/core/json-output.ts` helper for consistent JSON envelope
- `--json` added to: search, backlinks, suggest-links, new, add, list
- `--alias` flag on `mem edit`
- Improved templates: Date on reference, Contact on person, Status on decision

### Phase 2: GOS implementation
- `status` and `source` fields in universal frontmatter (`NoteFrontmatter`)
- `FieldDefinition` type system in `NoteTypeConfig`
- gh-style field selection: `mem list --json slug,title,status`
- `--status`, `--source`, `--since` filters on `mem list`
- `--status` and `--source` flags on `mem edit` and `mem new`
- SQLite schema v2 with status/source columns
- Frontmatter parser preserves extra type-specific fields

### Phase 3: Documentation
- `docs/GRANITE_OBJECT_STANDARD.md` — full standard document
- `skills/mem/SKILL.md` — complete rewrite with ECDA loop, trust levels, patterns

## Research basis
Synthesized from: Vercel agent-browser (snapshot+ref pattern), MCP resources/tools, gh CLI field selection, Mem0 agent memory (ECDA loop), Schema.org typed relationships, Logseq class-based schemas, CRDT identity patterns, JSON:API, NDJSON streaming.

## Test plan
- [x] `npm run lint` — type-check passes
- [x] `npm run test` — all 43 tests pass
- [x] `npm run build` — builds successfully
- [x] Manual: `mem show zettelkasten --json` returns note with status/source
- [x] Manual: `mem list --json slug,title,status` returns field-selected output
- [x] Manual: `mem search "zettelkasten" --json` returns envelope format
- [x] Manual: `mem backlinks zettelkasten --json` returns envelope format

https://claude.ai/code/session_01Bvt8uVZXaFeFWjahSBwAjG

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new `status`/`source` metadata across note creation, editing, display, listing, and the SQLite index schema; this affects persisted frontmatter and forces an index rebuild on upgrade. Moderate risk of behavior changes or incompatibilities for existing vaults/automation that depend on prior CLI output and DB schema.
> 
> **Overview**
> Adds a provenance/lifecycle system to notes by introducing universal frontmatter fields `status` (`inbox|active|archived`) and `source` (`human|agent|extraction`), defaulting them during note creation, exposing them in `mem show --json`, and allowing updates via `mem new --status/--source` and `mem edit --status/--source` (with validation).
> 
> Expands `mem list` with filters (`--status`, `--source`, `--since`) and gh-style JSON field selection via `--json [fields]`, and updates human output to include status. Updates the SQLite index schema to v2 to store `status`/`source` and auto-recreates the index DB when the schema version is outdated.
> 
> Adds typed field schema support in config/types (`fields` definitions per note type) and updates frontmatter parsing to preserve arbitrary type-specific fields. Also adds the `Granite Object Standard` design doc and rewrites the `mem` skill guide to the ECDA workflow and agent provenance guidance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 596664bff872b70e2031c77a8374f2dcfcee8750. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Agent-first CLI and provenance-aware notes. Adds field-selectable `--json`, new `mem show`, typed schemas, note `status`/`source`, and the Granite Object Standard, with safer migrations and input validation.

- **New Features**
  - `mem show <slug>` with `--json` and `--body`.
  - Consistent JSON envelope; gh-style field selection on `--json slug,title,status`.
  - `mem list` filters: `--status`, `--source`, `--since`; field selection; shows status; sorted by modified.
  - Provenance fields in frontmatter: `status` (inbox/active/archived) and `source` (human/agent/extraction); shown in `list`/`show`.
  - `mem new` and `mem edit` accept `--status` and `--source`.
  - Typed field schemas in `granite.yml` (`text`, `date`, `number`, `boolean`, `wikilink`, `list`, `enum`); parser preserves extra fields.
  - SQLite schema v2 stores `status` and `source`.
  - Docs: added `docs/GRANITE_OBJECT_STANDARD.md` (ECDA loop, schemas, provenance, CLI standards) and rewrote `skills/mem/SKILL.md` (ECDA, trust levels, `--source agent`).

- **Bug Fixes**
  - Auto-drop and rebuild `index.db` when schema version is outdated, preventing v1→v2 crashes.
  - Validate `--status`/`--source` values; throw clear errors on invalid input.
  - Renamed decision’s type-specific `status` to `decision_status` in GOS to avoid collision with universal `status`.

<sup>Written for commit 596664bff872b70e2031c77a8374f2dcfcee8750. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

