### PR TITLE
feat: add local note recommendations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,50 @@
+# AGENTS.md
+
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
+
+## What is Granite?
+
+Granite (`mem` CLI) is a local-first markdown memory system for humans and agents. Notes are plain markdown files with YAML frontmatter, organized by configurable note types (fleeting, permanent, reference, person, meeting, project, decision). Configuration lives in `granite.yml` at the vault root. A SQLite index (`.granite/index.db`) provides full-text search and wikilink resolution.
+
+## Commands
+
+```bash
+npm run build        # Build with tsup + copy web assets to dist/
+npm run dev          # Run CLI directly via tsx (no build needed)
+npm run test         # Run all tests (vitest)
+npm run test:watch   # Run tests in watch mode
+npm run lint         # Type-check with tsc --noEmit
+
+# Run a single test file
+npx vitest run test/core/note.test.ts
+
+# Run the CLI during development
+npx tsx src/index.ts <command>
+```
+
+## Architecture
+
+- **`src/index.ts`** — CLI entrypoint using Commander. Registers all subcommands (`init`, `new`, `add`, `list`, `edit`, `open`, `search`, `backlinks`, `suggest-links`, `types`, `doctor`, `serve`).
+- **`src/core/`** — Pure business logic, no CLI concerns:
+  - `types.ts` — All shared interfaces (`Note`, `GraniteConfig`, `WikiLink`, `SearchResult`, etc.)
+  - `config.ts` — Loads/writes `granite.yml`, holds default config
+  - `vault.ts` — Vault root discovery (walks up looking for `granite.yml`), path helpers
+  - `note.ts` — CRUD for notes (create, read, list, find by slug)
+  - `index-db.ts` — SQLite index with FTS5 for full-text search and a `links` table for wikilink graph
+  - `frontmatter.ts` — Parse/serialize YAML frontmatter via `gray-matter`
+  - `wikilinks.ts` — Parse `[[wikilinks]]` from note bodies and resolve them to slugs
+  - `slugify.ts` — Title-to-slug conversion
+  - `search.ts`, `backlinks.ts`, `suggest.ts`, `doctor.ts` — Query/validation logic
+- **`src/commands/`** — Thin CLI wrappers that call into `src/core/`
+- **`src/web/`** — Hono-based local web UI served by `mem serve`
+
+## Key Patterns
+
+- **Vault detection**: `findVaultRoot()` walks up from CWD looking for `granite.yml`. Most commands call `requireVaultRoot()` which throws if not found.
+- **Index rebuild**: `ensureIndex()` rebuilds the entire SQLite index on every command when `config.index.auto_rebuild` is true. The index is derived state — the markdown files are the source of truth.
+- **Slug formats**: Fleeting notes use date-based slugs (`2026-03-30-a1b2`), all other types use title-based slugs with collision counters.
+- **Note files**: Each note is `<folder>/<slug>.md` with YAML frontmatter (id, title, type, created, modified, tags, aliases).
+
+## Testing
+
+Tests live in `test/core/` mirroring `src/core/`. A fixture vault at `test-vault/` provides test data. Tests use vitest with globals enabled (no need to import `describe`/`it`/`expect`).

--- a/README.md
+++ b/README.md
@@ -1,0 +1,229 @@
+# Granite
+
+> A local-first markdown memory system for humans and agents.
+
+Granite is a simple PKM tool built around plain Markdown files, a small set of opinionated note types, and a fast loop for turning raw notes into useful memory.
+
+Most PKM tools give you a blank canvas. Granite gives you a working system:
+
+- capture quickly
+- structure ideas without over-designing your workflow
+- link people, meetings, projects, and decisions
+- surface what to connect or write next
+- stay fully local, scriptable, and agent-friendly
+
+If you want a flexible framework, there are already many options. Granite is for people who want plain files, strong defaults, and a memory system that starts helping immediately.
+
+![Granite note view](docs/screenshots/granite-note.png)
+
+## Why Granite
+
+Granite is built around a simple loop:
+
+`capture -> link -> recommend -> resurface`
+
+That means:
+
+- your notes live as plain Markdown files with YAML frontmatter
+- the index is derived state, not the source of truth
+- the default note types create just enough structure to stay useful
+- custom note types are easy to add in `granite.yml`
+- the CLI is predictable for both humans and agents
+- the local web UI makes the vault browseable without adding cloud lock-in
+
+Granite is opinionated where it matters and flexible where it should be.
+
+## What Makes It Different
+
+### 1. Simple by default
+
+Granite ships with a small working model instead of an empty workspace:
+
+- `fleeting` for quick capture
+- `permanent` for durable ideas
+- `reference` for external sources
+- `person` for people and relationships
+- `meeting` for notes with attendees, decisions, and actions
+- `project` for active work
+- `decision` for durable decision records
+
+This is enough structure to make your notes connect naturally, without forcing you into a heavyweight system.
+
+### 2. Custom types without losing the plot
+
+You can add your own note types in `granite.yml`, but Granite still works out of the box. The product stays simple because the core model is small and every type shares the same mechanics: folder, template, line limit, guidance, and slug strategy.
+
+### 3. Agent-native, not just agent-compatible
+
+Granite is designed to be easy for agents to read and act on:
+
+- notes are plain files
+- metadata is explicit
+- commands support `--json`
+- vault structure is predictable
+- search, backlinks, and recommendations are available from the CLI
+
+It works well as a personal system, and it also works as a memory layer for coding agents, assistants, or local automation.
+
+## Quickstart
+
+Clone the repo and install dependencies:
+
+```bash
+git clone https://github.com/The-Vibe-Company/Granite
+cd Granite
+npm install
+npm run build
+npm link
+```
+
+Create a vault and start capturing:
+
+```bash
+mem init
+mem add "Talked to Alice about local-first sync tradeoffs"
+mem new "Local-first sync tradeoffs" --type permanent
+mem list
+mem search "sync"
+mem serve
+```
+
+`mem new` does more than create a file. It can immediately suggest related links, tags, and the next note to create, which is the core of Granite's value loop.
+
+## Example Workflow
+
+Capture something quickly:
+
+```bash
+mem add "Users want fewer note types, but stronger defaults."
+```
+
+Turn it into a durable note:
+
+```bash
+mem new "Strong defaults beat infinite flexibility" --type permanent
+```
+
+Find connections:
+
+```bash
+mem suggest-links strong-defaults-beat-infinite-flexibility
+mem recommend strong-defaults-beat-infinite-flexibility
+mem backlinks strong-defaults-beat-infinite-flexibility
+```
+
+Open the local UI:
+
+```bash
+mem serve
+```
+
+Then browse notes, search the vault, inspect backlinks, and explore the graph locally.
+
+![Granite graph view](docs/screenshots/granite-graph.png)
+
+## Custom Note Types
+
+Granite is intentionally small, but not rigid. Add a type in `granite.yml` when your workflow genuinely needs it:
+
+```yaml
+note_types:
+  idea:
+    folder: notes/ideas
+    description: Early product ideas worth pressure-testing
+    template: |
+      ## Problem
+
+      ## Insight
+
+      ## Why now
+
+      ## Next step
+    line_limit: 120
+    warn_only: true
+    slug_format: title
+    instructions: Capture the idea clearly, then link it to a project, person, or permanent note.
+```
+
+The point is not to create 30 note types. The point is to add a type only when it makes your memory system sharper.
+
+## Local-First Architecture
+
+Granite keeps the source of truth boring and durable:
+
+- notes are Markdown files
+- metadata lives in YAML frontmatter
+- vault configuration lives in `granite.yml`
+- full-text search and link resolution are backed by a local SQLite index in `.granite/index.db`
+- the index can be rebuilt from the files at any time
+
+This keeps the system transparent, portable, and inspectable.
+
+## Agent-Friendly CLI
+
+Many commands support JSON output:
+
+```bash
+mem new "Sync constraints" --type permanent --json
+mem list --json
+mem show sync-constraints --json
+mem search "constraints" --json
+mem backlinks sync-constraints --json
+mem recommend sync-constraints --json
+```
+
+That makes Granite a useful substrate for local workflows, scripts, and agent memory.
+
+## Commands
+
+```bash
+mem init
+mem new <title> [--type <type>] [--json]
+mem add [text] [--json]
+mem list [--type <type>] [--json]
+mem edit <slug>
+mem open <slug>
+mem show <slug> [--json] [--body]
+mem search <query> [--json]
+mem backlinks <slug> [--json]
+mem suggest-links <slug> [--json]
+mem recommend <slug> [--json]
+mem types
+mem doctor
+mem serve [-p <port>]
+```
+
+## Development
+
+```bash
+npm run build
+npm run dev
+npm run test
+npm run test:watch
+npm run lint
+```
+
+Run a single test file:
+
+```bash
+npx vitest run test/core/note.test.ts
+```
+
+Run the CLI without building:
+
+```bash
+npx tsx src/index.ts <command>
+```
+
+## Philosophy
+
+Granite is built on a few beliefs:
+
+- local-first beats cloud dependence for personal memory
+- plain Markdown beats proprietary formats
+- strong defaults beat blank canvases
+- relationships between notes matter more than visual chrome
+- a good PKM should help you decide what to connect or write next
+- tools for humans should also be legible to agents
+
+If that sounds right, Granite is the tool.

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -3,6 +3,7 @@ import { loadConfig } from '../core/config.js';
 import { requireVaultRoot } from '../core/vault.js';
 import { createNote } from '../core/note.js';
 import { jsonSuccess } from '../core/json-output.js';
+import { recommendNote, formatRecommendations } from '../core/recommendations.js';
 
 export function addNote(text?: string, options: { json?: boolean } = {}): void {
   const vaultRoot = requireVaultRoot();
@@ -31,6 +32,7 @@ export function addNote(text?: string, options: { json?: boolean } = {}): void {
   const title = firstLine.length > 60 ? firstLine.slice(0, 60).trim() + '...' : firstLine;
 
   const note = createNote(vaultRoot, config, typeName, title, content + '\n');
+  const recommendations = recommendNote(vaultRoot, config, note, { strategy: 'incremental' });
 
   if (options.json) {
     console.log(jsonSuccess({
@@ -38,9 +40,19 @@ export function addNote(text?: string, options: { json?: boolean } = {}): void {
       title: note.frontmatter.title,
       type: typeName,
       filepath: note.filepath,
+      recommendations,
     }));
     return;
   }
 
   console.log(note.filepath);
+
+  const recommendationLines = formatRecommendations(recommendations);
+  if (recommendationLines.length > 0) {
+    console.log('');
+    console.log('Recommendations:');
+    for (const line of recommendationLines) {
+      console.log(line);
+    }
+  }
 }

--- a/src/commands/edit.ts
+++ b/src/commands/edit.ts
@@ -2,9 +2,10 @@ import fs from 'node:fs';
 import { execSync } from 'node:child_process';
 import { loadConfig } from '../core/config.js';
 import { requireVaultRoot } from '../core/vault.js';
-import { findNoteBySlug } from '../core/note.js';
+import { findNoteBySlug, readNote } from '../core/note.js';
 import { parseFrontmatter, serializeFrontmatter } from '../core/frontmatter.js';
 import { validateStatus, validateSource } from '../core/json-output.js';
+import { recommendNote, formatRecommendations } from '../core/recommendations.js';
 
 interface EditOptions {
   body?: string;
@@ -72,6 +73,7 @@ export function editCommand(slug: string, options: EditOptions): void {
     fs.writeFileSync(note.filepath, serializeFrontmatter(frontmatter, body), 'utf-8');
 
     console.log(note.filepath);
+    printRecommendations(vaultRoot, config, note.filepath);
   } else {
     // Interactive edit (human mode) — open in $EDITOR
     const editor = process.env.EDITOR || 'vi';
@@ -91,6 +93,21 @@ export function editCommand(slug: string, options: EditOptions): void {
       frontmatter.modified = new Date().toISOString();
       fs.writeFileSync(note.filepath, serializeFrontmatter(frontmatter, body), 'utf-8');
       console.log(`Updated: ${note.filepath}`);
+      printRecommendations(vaultRoot, config, note.filepath);
     }
+  }
+}
+
+function printRecommendations(vaultRoot: string, config: ReturnType<typeof loadConfig>, filepath: string): void {
+  const updatedNote = readNote(filepath);
+  const recommendations = recommendNote(vaultRoot, config, updatedNote, { strategy: 'incremental' });
+  const lines = formatRecommendations(recommendations);
+
+  if (lines.length === 0) return;
+
+  console.log('');
+  console.log('Recommendations:');
+  for (const line of lines) {
+    console.log(line);
   }
 }

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -1,9 +1,10 @@
 import fs from 'node:fs';
 import { loadConfig } from '../core/config.js';
 import { requireVaultRoot } from '../core/vault.js';
-import { createNote, listNotes } from '../core/note.js';
+import { createNote } from '../core/note.js';
 import { parseFrontmatter, serializeFrontmatter } from '../core/frontmatter.js';
 import { jsonSuccess, validateStatus, validateSource } from '../core/json-output.js';
+import { recommendNote, formatRecommendations } from '../core/recommendations.js';
 
 export function newNote(title: string, options: { type?: string; source?: string; status?: string; json?: boolean }): void {
   const vaultRoot = requireVaultRoot();
@@ -27,30 +28,10 @@ export function newNote(title: string, options: { type?: string; source?: string
     note.frontmatter = frontmatter;
   }
 
+  const recommendations = recommendNote(vaultRoot, config, note, { strategy: 'incremental' });
+
   const lines = note.body.split('\n').length;
   const overLimit = typeConfig && typeConfig.line_limit && lines > typeConfig.line_limit;
-
-  // Suggest links: check if any existing note titles/aliases appear in the note content
-  const textToScan = (note.body + ' ' + title).toLowerCase();
-  const allNotes = listNotes(vaultRoot, config).filter(n => n.slug !== note.slug);
-  const suggestions: Array<{ slug: string; title: string; type: string }> = [];
-
-  for (const other of allNotes) {
-    const otherTitle = other.frontmatter.title.toLowerCase();
-    if (otherTitle.length < 3) continue; // skip very short titles
-    if (textToScan.includes(otherTitle)) {
-      suggestions.push({ slug: other.slug, title: other.frontmatter.title, type: other.frontmatter.type });
-      continue;
-    }
-    // Check aliases
-    for (const alias of other.frontmatter.aliases) {
-      if (alias.length < 3) continue;
-      if (textToScan.includes(alias.toLowerCase())) {
-        suggestions.push({ slug: other.slug, title: other.frontmatter.title, type: other.frontmatter.type });
-        break;
-      }
-    }
-  }
 
   if (options.json) {
     console.log(jsonSuccess({
@@ -60,7 +41,12 @@ export function newNote(title: string, options: { type?: string; source?: string
       status: note.frontmatter.status,
       source: note.frontmatter.source,
       filepath: note.filepath,
-      suggestions,
+      suggestions: recommendations.links.map(link => ({
+        slug: link.slug,
+        title: link.title,
+        type: link.type,
+      })),
+      recommendations,
     }));
     return;
   }
@@ -78,11 +64,12 @@ export function newNote(title: string, options: { type?: string; source?: string
     console.log(`  💡 ${typeConfig.instructions}`);
   }
 
-  if (suggestions.length > 0) {
+  const recommendationLines = formatRecommendations(recommendations);
+  if (recommendationLines.length > 0) {
     console.log('');
-    console.log('  🔗 Linked notes detected:');
-    for (const s of suggestions) {
-      console.log(`     [[${s.slug}]] — ${s.title} (${s.type})`);
+    console.log('Recommendations:');
+    for (const line of recommendationLines) {
+      console.log(line);
     }
   }
 }

--- a/src/commands/recommend.ts
+++ b/src/commands/recommend.ts
@@ -1,0 +1,44 @@
+import { loadConfig } from '../core/config.js';
+import { jsonError, jsonSuccess } from '../core/json-output.js';
+import { findNoteBySlug } from '../core/note.js';
+import { recommendNote, formatRecommendations } from '../core/recommendations.js';
+import { requireVaultRoot } from '../core/vault.js';
+
+export function recommendCommand(slug: string, options: { json?: boolean }): void {
+  const vaultRoot = requireVaultRoot();
+  const config = loadConfig(vaultRoot);
+  const note = findNoteBySlug(vaultRoot, config, slug);
+
+  if (!note) {
+    if (options.json) {
+      console.log(jsonError(`Note not found: ${slug}`));
+    } else {
+      console.error(`Note not found: "${slug}"`);
+    }
+    process.exit(1);
+  }
+
+  const recommendations = recommendNote(vaultRoot, config, note);
+
+  if (options.json) {
+    console.log(jsonSuccess({
+      slug: note.slug,
+      title: note.frontmatter.title,
+      type: note.frontmatter.type,
+      recommendations,
+    }));
+    return;
+  }
+
+  const lines = formatRecommendations(recommendations);
+  if (lines.length === 0) {
+    console.log(`No recommendations found for "${note.frontmatter.title}".`);
+    return;
+  }
+
+  console.log(`Recommendations for "${note.frontmatter.title}":`);
+  console.log('');
+  for (const line of lines) {
+    console.log(line);
+  }
+}

--- a/src/core/frontmatter.ts
+++ b/src/core/frontmatter.ts
@@ -4,11 +4,11 @@ import type { NoteFrontmatter } from './types.js';
 export function parseFrontmatter(content: string): { frontmatter: NoteFrontmatter; body: string } {
   const { data, content: body } = matter(content);
   const fm: NoteFrontmatter = {
-    id: data.id ?? '',
-    title: data.title ?? '',
-    type: data.type ?? '',
-    created: data.created ?? '',
-    modified: data.modified ?? '',
+    id: toFrontmatterString(data.id),
+    title: toFrontmatterString(data.title),
+    type: toFrontmatterString(data.type),
+    created: toFrontmatterString(data.created),
+    modified: toFrontmatterString(data.modified),
     tags: data.tags ?? [],
     aliases: data.aliases ?? [],
     status: data.status ?? 'active',
@@ -25,4 +25,10 @@ export function parseFrontmatter(content: string): { frontmatter: NoteFrontmatte
 
 export function serializeFrontmatter(fm: NoteFrontmatter, body: string): string {
   return matter.stringify(body, fm);
+}
+
+function toFrontmatterString(value: unknown): string {
+  if (value === null || value === undefined) return '';
+  if (value instanceof Date) return value.toISOString();
+  return String(value);
 }

--- a/src/core/index-db.ts
+++ b/src/core/index-db.ts
@@ -3,7 +3,8 @@ import fs from 'node:fs';
 import path from 'node:path';
 import type { GraniteConfig, Note } from './types.js';
 import { listNotes } from './note.js';
-import { parseWikilinks, resolveWikilinks } from './wikilinks.js';
+import { parseWikilinks } from './wikilinks.js';
+import { slugify } from './slugify.js';
 import { getIndexDbPath } from './vault.js';
 
 const SCHEMA_VERSION = 2;
@@ -132,7 +133,7 @@ export function rebuildIndex(vaultRoot: string, config: GraniteConfig, db: Datab
 
       // Parse and resolve wikilinks
       const links = parseWikilinks(note.body);
-      const resolved = resolveWikilinks(links, notes);
+      const resolved = resolveLinksAgainstNotes(links, notes);
 
       for (const link of resolved) {
         // Find context line
@@ -154,6 +155,25 @@ export function rebuildIndex(vaultRoot: string, config: GraniteConfig, db: Datab
   transaction();
 }
 
+export function syncNoteInIndex(
+  vaultRoot: string,
+  config: GraniteConfig,
+  db: Database.Database,
+  note: Note,
+): void {
+  const noteCountInDb = db.prepare('SELECT COUNT(*) as c FROM notes').get() as { c: number };
+  const noteCountOnDisk = countNoteFiles(vaultRoot, config);
+  const noteExists = db.prepare('SELECT 1 FROM notes WHERE slug = ?').get(note.slug) as { 1: number } | undefined;
+  const allowedCount = noteExists ? noteCountOnDisk : noteCountOnDisk - 1;
+
+  if (noteCountInDb.c !== allowedCount) {
+    rebuildIndex(vaultRoot, config, db);
+    return;
+  }
+
+  upsertNoteAndLinks(db, note);
+}
+
 export function ensureIndex(vaultRoot: string, config: GraniteConfig): Database.Database {
   const db = openDatabase(vaultRoot);
 
@@ -162,4 +182,121 @@ export function ensureIndex(vaultRoot: string, config: GraniteConfig): Database.
   }
 
   return db;
+}
+
+function countNoteFiles(vaultRoot: string, config: GraniteConfig): number {
+  let count = 0;
+
+  for (const typeConfig of Object.values(config.note_types)) {
+    const folder = path.join(vaultRoot, typeConfig.folder);
+    if (!fs.existsSync(folder)) continue;
+    count += fs.readdirSync(folder).filter(file => file.endsWith('.md')).length;
+  }
+
+  return count;
+}
+
+function upsertNoteAndLinks(db: Database.Database, note: Note): void {
+  const upsertNote = db.prepare(`
+    INSERT INTO notes (slug, id, title, type, created, modified, tags, aliases, body, filepath)
+    VALUES (@slug, @id, @title, @type, @created, @modified, @tags, @aliases, @body, @filepath)
+    ON CONFLICT(slug) DO UPDATE SET
+      id = excluded.id,
+      title = excluded.title,
+      type = excluded.type,
+      created = excluded.created,
+      modified = excluded.modified,
+      tags = excluded.tags,
+      aliases = excluded.aliases,
+      body = excluded.body,
+      filepath = excluded.filepath
+  `);
+
+  const deleteLinks = db.prepare('DELETE FROM links WHERE source_slug = ?');
+  const insertLink = db.prepare(`
+    INSERT INTO links (source_slug, target_slug, target_raw, context)
+    VALUES (@source_slug, @target_slug, @target_raw, @context)
+  `);
+
+  const transaction = db.transaction(() => {
+    upsertNote.run({
+      slug: note.slug,
+      id: note.frontmatter.id,
+      title: note.frontmatter.title,
+      type: note.frontmatter.type,
+      created: note.frontmatter.created,
+      modified: note.frontmatter.modified,
+      tags: JSON.stringify(note.frontmatter.tags),
+      aliases: JSON.stringify(note.frontmatter.aliases),
+      body: note.body,
+      filepath: note.filepath,
+    });
+
+    deleteLinks.run(note.slug);
+
+    const links = parseWikilinks(note.body);
+    for (const link of links) {
+      const resolvedSlug = resolveLinkTarget(db, link.target);
+      const contextLine = note.body.split('\n').find(line => line.includes(link.raw)) ?? '';
+
+      insertLink.run({
+        source_slug: note.slug,
+        target_slug: resolvedSlug,
+        target_raw: link.target,
+        context: contextLine.trim(),
+      });
+    }
+
+    db.prepare('INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)').run('last_rebuild', new Date().toISOString());
+  });
+
+  transaction();
+}
+
+function resolveLinksAgainstNotes(links: ReturnType<typeof parseWikilinks>, allNotes: Note[]) {
+  return links.map(link => {
+    const targetSlug = slugify(link.target);
+
+    let found = allNotes.find(note => note.slug === targetSlug);
+    if (!found) {
+      found = allNotes.find(note => note.frontmatter.title.toLowerCase() === link.target.toLowerCase());
+    }
+    if (!found) {
+      found = allNotes.find(note =>
+        note.frontmatter.aliases.some(alias => alias.toLowerCase() === link.target.toLowerCase()),
+      );
+    }
+
+    return {
+      ...link,
+      resolved: !!found,
+      resolved_slug: found?.slug,
+    };
+  });
+}
+
+function resolveLinkTarget(db: Database.Database, target: string): string | null {
+  const targetSlug = slugify(target);
+  const exact = db.prepare(`
+    SELECT slug
+    FROM notes
+    WHERE slug = ? OR lower(title) = ?
+    LIMIT 1
+  `).get(targetSlug, target.toLowerCase()) as { slug: string } | undefined;
+
+  if (exact) return exact.slug;
+
+  const rows = db.prepare('SELECT slug, aliases FROM notes').all() as Array<{ slug: string; aliases: string }>;
+  for (const row of rows) {
+    try {
+      const aliases = JSON.parse(row.aliases || '[]') as unknown[];
+      if (aliases.some(alias => typeof alias === 'string' && alias.toLowerCase() === target.toLowerCase())) {
+        return row.slug;
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return null;
 }

--- a/src/core/recommendations.ts
+++ b/src/core/recommendations.ts
@@ -1,0 +1,614 @@
+import type Database from 'better-sqlite3';
+import type { GraniteConfig, Note } from './types.js';
+import { ensureIndex, openDatabase, syncNoteInIndex } from './index-db.js';
+import { suggestLinks } from './suggest.js';
+import { parseWikilinks } from './wikilinks.js';
+
+const MAX_LINK_RECOMMENDATIONS = 3;
+const MAX_TAG_RECOMMENDATIONS = 3;
+const MAX_ADDITION_RECOMMENDATIONS = 3;
+
+const STOP_WORDS = new Set([
+  'the', 'and', 'for', 'with', 'from', 'that', 'this', 'into', 'about', 'your', 'have', 'will', 'them',
+  'they', 'what', 'when', 'where', 'which', 'their', 'there', 'here', 'then', 'than', 'also', 'just',
+  'should', 'could', 'would', 'into', 'over', 'under', 'after', 'before', 'using', 'used', 'make',
+  'made', 'more', 'most', 'some', 'such', 'each', 'many', 'only', 'through', 'between', 'within',
+  'write', 'notes', 'note', 'links', 'link', 'summary', 'details', 'source', 'date', 'role', 'context',
+  'contact', 'attendees', 'agenda', 'decisions', 'actions', 'goal', 'status', 'people', 'rationale',
+  'decision', 'options', 'considered', 'active', 'points', 'take', 'idea', 'ideas', 'project', 'meeting',
+  'person', 'reference', 'permanent', 'fleeting', 'how', 'know', 'work', 'works', 'what', 'prompted',
+  'them', 'what', 'plus', 'latest', 'recent', 'capture', 'record', 'refine', 'later', 'local', 'first',
+  'short', 'clear', 'split', 'related', 'relevant', 'title', 'titles',
+]);
+
+interface NoteMetadata {
+  slug: string;
+  title: string;
+  type: string;
+  tags: string[];
+}
+
+export interface LinkRecommendation {
+  slug: string;
+  title: string;
+  type: string;
+  reason: string;
+  source: 'mention' | 'search';
+}
+
+export interface TagRecommendation {
+  tag: string;
+  weight: number;
+  source_slugs: string[];
+}
+
+export interface NextNoteRecommendation {
+  type: string;
+  title_hint?: string;
+  reason: string;
+}
+
+export interface AdditionRecommendation {
+  text: string;
+}
+
+export interface NoteRecommendations {
+  additions: AdditionRecommendation[];
+  links: LinkRecommendation[];
+  tags: TagRecommendation[];
+  next_steps: NextNoteRecommendation[];
+}
+
+interface RankedLinkRecommendation extends LinkRecommendation {
+  tags: string[];
+  rank: number;
+}
+
+interface SimilarRow {
+  slug: string;
+  title: string;
+  type: string;
+  tags: string;
+  score: number;
+}
+
+interface RecommendNoteOptions {
+  strategy?: 'rebuild' | 'incremental';
+}
+
+interface NearbyNote {
+  slug: string;
+  title: string;
+  type: string;
+  tags: string[];
+  source: 'outgoing' | 'backlink' | 'mention' | 'search';
+}
+
+export function recommendNote(
+  vaultRoot: string,
+  config: GraniteConfig,
+  note: Note,
+  options: RecommendNoteOptions = {},
+): NoteRecommendations {
+  const strategy = options.strategy ?? 'rebuild';
+  const db = strategy === 'incremental' ? openDatabase(vaultRoot) : ensureIndex(vaultRoot, config);
+
+  try {
+    if (strategy === 'incremental') {
+      syncNoteInIndex(vaultRoot, config, db, note);
+    }
+    return getRecommendations(db, note, config);
+  } finally {
+    db.close();
+  }
+}
+
+export function getRecommendations(db: Database.Database, note: Note, config?: GraniteConfig): NoteRecommendations {
+  const nearbyNotes = getNearbyNotes(db, note);
+  const existingTargets = getExistingTargets(db, note);
+  const mentionLinks = getMentionRecommendations(db, note);
+  const excludedSlugs = new Set(mentionLinks.map(link => link.slug));
+  const similarLinks = getSearchRecommendations(db, note, existingTargets, excludedSlugs);
+  const links = [...mentionLinks, ...similarLinks]
+    .sort((a, b) => b.rank - a.rank || a.title.localeCompare(b.title))
+    .slice(0, MAX_LINK_RECOMMENDATIONS);
+  const allNearbyNotes = mergeNearbyNotes(nearbyNotes, links);
+
+  return {
+    additions: getAdditionRecommendations(note, config),
+    links: links.map(({ tags: _tags, rank: _rank, ...link }) => link),
+    tags: getTagRecommendations(note, allNearbyNotes),
+    next_steps: getNextSteps(note, allNearbyNotes),
+  };
+}
+
+export function formatRecommendations(recommendations: NoteRecommendations): string[] {
+  const lines: string[] = [];
+
+  if (
+    recommendations.additions.length === 0 &&
+    recommendations.links.length === 0 &&
+    recommendations.tags.length === 0 &&
+    recommendations.next_steps.length === 0
+  ) {
+    return lines;
+  }
+
+  if (recommendations.additions.length > 0) {
+    lines.push('  Add now:');
+    for (const item of recommendations.additions) {
+      lines.push(`    ${item.text}`);
+    }
+  }
+
+  if (recommendations.links.length > 0) {
+    lines.push('  Link now:');
+    for (const link of recommendations.links) {
+      lines.push(`    [[${link.slug}]] — ${link.reason}`);
+    }
+  }
+
+  if (recommendations.tags.length > 0) {
+    lines.push('  Tag now:');
+    for (const tag of recommendations.tags) {
+      const notes = tag.source_slugs.length === 1 ? '1 nearby note' : `${tag.source_slugs.length} nearby notes`;
+      lines.push(`    ${tag.tag} — seen on ${notes}`);
+    }
+  }
+
+  if (recommendations.next_steps.length > 0) {
+    lines.push('  Next note:');
+    for (const step of recommendations.next_steps) {
+      const hint = step.title_hint ? ` Title hint: ${step.title_hint}.` : '';
+      lines.push(`    ${step.type} — ${step.reason}${hint}`);
+    }
+  }
+
+  return lines;
+}
+
+function getExistingTargets(db: Database.Database, note: Note): Set<string> {
+  const existing = new Set<string>();
+
+  const rows = db.prepare(`
+    SELECT target_slug, target_raw
+    FROM links
+    WHERE source_slug = ?
+  `).all(note.slug) as Array<{ target_slug: string | null; target_raw: string }>;
+
+  for (const row of rows) {
+    existing.add(row.target_raw.toLowerCase());
+    if (row.target_slug) {
+      existing.add(row.target_slug.toLowerCase());
+    }
+  }
+
+  return existing;
+}
+
+function getMentionRecommendations(db: Database.Database, note: Note): RankedLinkRecommendation[] {
+  const raw = suggestLinks(db, note);
+  const recommendations: RankedLinkRecommendation[] = [];
+
+  for (const suggestion of raw) {
+    const metadata = getNoteMetadata(db, suggestion.target_slug);
+    if (!metadata) continue;
+
+    recommendations.push({
+      slug: metadata.slug,
+      title: metadata.title,
+      type: metadata.type,
+      reason: `mentioned ${suggestion.mentions} time${suggestion.mentions === 1 ? '' : 's'}`,
+      source: 'mention',
+      tags: metadata.tags,
+      rank: 100 + suggestion.mentions,
+    });
+  }
+
+  return recommendations;
+}
+
+function getSearchRecommendations(
+  db: Database.Database,
+  note: Note,
+  existingTargets: Set<string>,
+  excludedSlugs: Set<string>,
+): RankedLinkRecommendation[] {
+  const query = buildSearchQuery(note);
+  if (!query) return [];
+
+  const rows = db.prepare(`
+    SELECT
+      n.slug,
+      n.title,
+      n.type,
+      n.tags,
+      bm25(notes_fts, 8.0, 1.5, 0.5) AS score
+    FROM notes_fts
+    JOIN notes n ON n.rowid = notes_fts.rowid
+    WHERE notes_fts MATCH ? AND n.slug != ?
+    ORDER BY score
+    LIMIT 12
+  `).all(query, note.slug) as SimilarRow[];
+
+  const out: RankedLinkRecommendation[] = [];
+
+  for (const row of rows) {
+    if (existingTargets.has(row.slug.toLowerCase()) || excludedSlugs.has(row.slug)) continue;
+
+    out.push({
+      slug: row.slug,
+      title: row.title,
+      type: row.type,
+      reason: 'shared keywords',
+      source: 'search',
+      tags: parseJsonArray(row.tags),
+      rank: Math.max(1, 40 - Math.round(row.score * 10)),
+    });
+  }
+
+  return out;
+}
+
+function getTagRecommendations(note: Note, nearbyNotes: NearbyNote[]): TagRecommendation[] {
+  const existingTags = new Set(note.frontmatter.tags.map(tag => tag.toLowerCase()));
+  const noteTokens = new Set(tokenize(`${note.frontmatter.title} ${note.body}`));
+  const counts = new Map<string, { weight: number; sourceSlugs: Set<string> }>();
+
+  for (const nearby of nearbyNotes) {
+    const weight = getNearbyWeight(nearby.source);
+
+    for (const tag of nearby.tags) {
+      const normalized = tag.trim().toLowerCase();
+      if (!normalized || existingTags.has(normalized)) continue;
+
+      const entry = counts.get(normalized) ?? { weight: 0, sourceSlugs: new Set<string>() };
+      entry.weight += weight;
+      if (tagMatchesNoteTokens(normalized, noteTokens)) {
+        entry.weight += 2;
+      }
+      entry.sourceSlugs.add(nearby.slug);
+      counts.set(normalized, entry);
+    }
+  }
+
+  return [...counts.entries()]
+    .map(([tag, info]) => ({
+      tag,
+      weight: info.weight,
+      source_slugs: [...info.sourceSlugs],
+    }))
+    .sort((a, b) => b.weight - a.weight || a.tag.localeCompare(b.tag))
+    .slice(0, MAX_TAG_RECOMMENDATIONS);
+}
+
+function getNextSteps(note: Note, nearbyNotes: NearbyNote[]): NextNoteRecommendation[] {
+  const projectLink = nearbyNotes.find(link => link.type === 'project');
+  const personLink = nearbyNotes.find(link => link.type === 'person');
+
+  switch (note.frontmatter.type) {
+    case 'fleeting':
+      return [{
+        type: 'permanent',
+        title_hint: note.frontmatter.title,
+        reason: 'Promote this into a durable note if it keeps mattering.',
+      }];
+    case 'reference':
+      return [{
+        type: 'permanent',
+        title_hint: `Idea from ${note.frontmatter.title}`,
+        reason: 'Distill one durable idea from this source.',
+      }];
+    case 'person':
+      return [{
+        type: projectLink ? 'meeting' : 'project',
+        title_hint: projectLink ? `${note.frontmatter.title} + ${projectLink.title}` : `${note.frontmatter.title} collaboration`,
+        reason: projectLink
+          ? 'Capture the latest interaction connected to this person.'
+          : 'Anchor this person to a company, project, or collaboration note.',
+      }];
+    case 'meeting':
+      return [{
+        type: 'decision',
+        title_hint: `Decision from ${note.frontmatter.title}`,
+        reason: 'Extract the main decision so it can be linked independently.',
+      }];
+    case 'project':
+      return [{
+        type: personLink ? 'meeting' : 'decision',
+        title_hint: personLink ? `${note.frontmatter.title} sync` : `${note.frontmatter.title} decision`,
+        reason: personLink
+          ? 'Capture the next concrete conversation for this project.'
+          : 'Record the decision that drives this project forward.',
+      }];
+    case 'decision':
+      return [{
+        type: 'project',
+        title_hint: `${note.frontmatter.title} rollout`,
+        reason: 'Attach this decision to the project where it applies.',
+      }];
+    case 'permanent':
+      return [{
+        type: projectLink ? 'decision' : 'project',
+        title_hint: projectLink ? `Decision from ${note.frontmatter.title}` : `${note.frontmatter.title} in practice`,
+        reason: projectLink
+          ? 'Capture the concrete decision this idea supports.'
+          : 'Anchor this idea in a project, company, or active thread.',
+      }];
+    default:
+      return [];
+  }
+}
+
+function getAdditionRecommendations(note: Note, config?: GraniteConfig): AdditionRecommendation[] {
+  const recommendations: AdditionRecommendation[] = [];
+  const body = note.body;
+  const existingLinks = parseWikilinks(body);
+  const templateBody = config?.note_types[note.frontmatter.type]?.template ?? '';
+
+  switch (note.frontmatter.type) {
+    case 'person':
+      if (isSectionSparse(body, 'Role', templateBody)) {
+        recommendations.push({ text: 'Add a one-line role, company, or why this person matters.' });
+      }
+      if (isSectionSparse(body, 'Context', templateBody)) {
+        recommendations.push({ text: 'Add how you know them or what you work on together.' });
+      }
+      if (existingLinks.length === 0) {
+        recommendations.push({ text: 'Link one project, company, or topic in the Links section.' });
+      }
+      break;
+    case 'reference':
+      if (!hasUrl(body) || body.includes('URL or citation here.')) {
+        recommendations.push({ text: 'Add the source URL or citation.' });
+      }
+      if (!hasMeaningfulBullets(body, 'Key Points')) {
+        recommendations.push({ text: 'Write 2-3 key points in your own words.' });
+      }
+      if (existingLinks.length === 0) {
+        recommendations.push({ text: 'Link one permanent note, project, or topic this source relates to.' });
+      }
+      break;
+    case 'project':
+      if (isSectionSparse(body, 'Goal', templateBody)) {
+        recommendations.push({ text: 'Add a one-line goal so the project has a clear anchor.' });
+      }
+      if (isSectionSparse(body, 'People', templateBody)) {
+        recommendations.push({ text: 'Link the people involved in the project.' });
+      }
+      if (!hasMeaningfulBullets(body, 'Key Decisions')) {
+        recommendations.push({ text: 'Record one key decision or current status update.' });
+      }
+      break;
+    case 'meeting':
+      if (!hasAnyWikilinks(body)) {
+        recommendations.push({ text: 'Link the attendees directly in the note.' });
+      }
+      if (!hasMeaningfulBullets(body, 'Actions')) {
+        recommendations.push({ text: 'Capture at least one next action.' });
+      }
+      if (!hasMeaningfulBullets(body, 'Decisions')) {
+        recommendations.push({ text: 'Capture one decision or open question.' });
+      }
+      break;
+    case 'permanent':
+      if (isSectionSparse(body, 'Summary', templateBody)) {
+        recommendations.push({ text: 'Write a one-line summary before expanding the idea.' });
+      }
+      if (existingLinks.length === 0) {
+        recommendations.push({ text: 'Link one project, company, person, or adjacent idea.' });
+      }
+      break;
+    case 'decision':
+      if (isSectionSparse(body, 'Context', templateBody)) {
+        recommendations.push({ text: 'Add the context that forced this decision.' });
+      }
+      if (isSectionSparse(body, 'Decision', templateBody)) {
+        recommendations.push({ text: 'State the decision in one sentence.' });
+      }
+      if (existingLinks.length === 0) {
+        recommendations.push({ text: 'Link the project, meeting, or note affected by this decision.' });
+      }
+      break;
+    case 'fleeting':
+      if (tokenize(body).length < 8) {
+        recommendations.push({ text: 'Add one more sentence if this capture is worth keeping.' });
+      }
+      break;
+    default:
+      break;
+  }
+
+  if (config) {
+    const typeTemplate = config.note_types[note.frontmatter.type]?.template ?? '';
+    if (body.trim() === typeTemplate.trim() && recommendations.length === 0) {
+      recommendations.push({ text: 'Fill the main sections before asking for related notes.' });
+    }
+  }
+
+  return recommendations.slice(0, MAX_ADDITION_RECOMMENDATIONS);
+}
+
+function buildSearchQuery(note: Note): string {
+  const counts = new Map<string, number>();
+  const titleTokens = tokenize(note.frontmatter.title);
+  const bodyTokens = tokenize(note.body);
+
+  for (const token of titleTokens) {
+    counts.set(token, (counts.get(token) ?? 0) + 3);
+  }
+
+  for (const token of bodyTokens) {
+    counts.set(token, (counts.get(token) ?? 0) + 1);
+  }
+
+  const terms = [...counts.entries()]
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .map(([token]) => token)
+    .slice(0, 8);
+
+  return terms.map(token => `"${token}"`).join(' OR ');
+}
+
+function tokenize(text: string): string[] {
+  const matches = text.toLowerCase().match(/[\p{L}\p{N}]{3,}/gu) ?? [];
+  return matches.filter(token => !STOP_WORDS.has(token));
+}
+
+function tagMatchesNoteTokens(tag: string, noteTokens: Set<string>): boolean {
+  const tagTokens = tokenize(tag.replace(/[-_]/g, ' '));
+  return tagTokens.some(token => noteTokens.has(token));
+}
+
+function getNearbyNotes(db: Database.Database, note: Note): NearbyNote[] {
+  const bySlug = new Map<string, NearbyNote>();
+
+  const outgoingRows = db.prepare(`
+    SELECT DISTINCT n.slug, n.title, n.type, n.tags
+    FROM links l
+    JOIN notes n ON n.slug = l.target_slug
+    WHERE l.source_slug = ?
+  `).all(note.slug) as Array<{ slug: string; title: string; type: string; tags: string }>;
+
+  for (const row of outgoingRows) {
+    bySlug.set(row.slug, {
+      slug: row.slug,
+      title: row.title,
+      type: row.type,
+      tags: parseJsonArray(row.tags),
+      source: 'outgoing',
+    });
+  }
+
+  const backlinkRows = db.prepare(`
+    SELECT DISTINCT n.slug, n.title, n.type, n.tags
+    FROM links l
+    JOIN notes n ON n.slug = l.source_slug
+    WHERE l.target_slug = ? AND n.slug != ?
+  `).all(note.slug, note.slug) as Array<{ slug: string; title: string; type: string; tags: string }>;
+
+  for (const row of backlinkRows) {
+    if (bySlug.has(row.slug)) continue;
+    bySlug.set(row.slug, {
+      slug: row.slug,
+      title: row.title,
+      type: row.type,
+      tags: parseJsonArray(row.tags),
+      source: 'backlink',
+    });
+  }
+
+  return [...bySlug.values()];
+}
+
+function mergeNearbyNotes(
+  nearbyNotes: NearbyNote[],
+  links: RankedLinkRecommendation[],
+): NearbyNote[] {
+  const merged = new Map<string, NearbyNote>();
+
+  for (const nearby of nearbyNotes) {
+    merged.set(nearby.slug, nearby);
+  }
+
+  for (const link of links) {
+    if (merged.has(link.slug)) continue;
+    merged.set(link.slug, {
+      slug: link.slug,
+      title: link.title,
+      type: link.type,
+      tags: link.tags,
+      source: link.source,
+    });
+  }
+
+  return [...merged.values()];
+}
+
+function getNearbyWeight(source: NearbyNote['source']): number {
+  switch (source) {
+    case 'outgoing':
+    case 'mention':
+      return 2;
+    case 'backlink':
+    case 'search':
+    default:
+      return 1;
+  }
+}
+
+function isSectionSparse(body: string, heading: string, templateBody?: string): boolean {
+  const section = getSectionContent(body, heading);
+  if (!section) return true;
+  const cleaned = section
+    .replace(/^- \[ \]\s*$/gm, '')
+    .replace(/^-\s*$/gm, '')
+    .trim();
+  const templateSection = templateBody ? getSectionContent(templateBody, heading).trim() : '';
+  if (templateSection && cleaned === templateSection) {
+    return true;
+  }
+  return cleaned.length < 8;
+}
+
+function hasMeaningfulBullets(body: string, heading: string): boolean {
+  const section = getSectionContent(body, heading);
+  if (!section) return false;
+  return section
+    .split('\n')
+    .some(line => /^-/.test(line.trim()) && line.replace(/^-+\s*/, '').trim().length > 2);
+}
+
+function getSectionContent(body: string, heading: string): string {
+  const lines = body.split('\n');
+  const headingLine = `## ${heading}`;
+  const startIndex = lines.findIndex(line => line.trim() === headingLine);
+
+  if (startIndex === -1) return '';
+
+  const collected: string[] = [];
+  for (let index = startIndex + 1; index < lines.length; index++) {
+    if (lines[index].startsWith('## ')) break;
+    collected.push(lines[index]);
+  }
+
+  return collected.join('\n');
+}
+
+function hasUrl(body: string): boolean {
+  return /https?:\/\/\S+/i.test(body);
+}
+
+function hasAnyWikilinks(body: string): boolean {
+  return parseWikilinks(body).length > 0;
+}
+
+function getNoteMetadata(db: Database.Database, slug: string | null | undefined): NoteMetadata | null {
+  if (!slug) return null;
+
+  const row = db.prepare(`
+    SELECT slug, title, type, tags
+    FROM notes
+    WHERE slug = ?
+  `).get(slug) as { slug: string; title: string; type: string; tags: string } | undefined;
+
+  if (!row) return null;
+
+  return {
+    slug: row.slug,
+    title: row.title,
+    type: row.type,
+    tags: parseJsonArray(row.tags),
+  };
+}
+
+function parseJsonArray(raw: string | null | undefined): string[] {
+  if (!raw) return [];
+
+  try {
+    const value = JSON.parse(raw);
+    return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : [];
+  } catch {
+    return [];
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { showCommand } from './commands/show.js';
 import { searchCommand } from './commands/search.js';
 import { backlinksCommand } from './commands/backlinks.js';
 import { suggestLinksCommand } from './commands/suggest-links.js';
+import { recommendCommand } from './commands/recommend.js';
 import { doctorCommand } from './commands/doctor.js';
 import { serveCommand } from './commands/serve.js';
 import { typesCommand } from './commands/types.js';
@@ -120,6 +121,15 @@ program
   .option('--json', 'Output as JSON (agent-friendly)')
   .action((slug: string, options: { json?: boolean }) => {
     suggestLinksCommand(slug, options);
+  });
+
+program
+  .command('recommend')
+  .description('Suggest links, tags, and the next note to create')
+  .argument('<slug>', 'Note slug')
+  .option('--json', 'Output as JSON (agent-friendly)')
+  .action((slug: string, options: { json?: boolean }) => {
+    recommendCommand(slug, options);
   });
 
 program

--- a/test/core/recommendations.test.ts
+++ b/test/core/recommendations.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { writeDefaultConfig, loadConfig } from '../../src/core/config.js';
+import { parseFrontmatter, serializeFrontmatter } from '../../src/core/frontmatter.js';
+import { createDatabase, rebuildIndex } from '../../src/core/index-db.js';
+import { createNote, readNote } from '../../src/core/note.js';
+import { getRecommendations } from '../../src/core/recommendations.js';
+import type { GraniteConfig } from '../../src/core/types.js';
+
+describe('recommendations', () => {
+  let tmpDir: string;
+  let config: GraniteConfig;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'granite-reco-'));
+    writeDefaultConfig(tmpDir);
+    config = loadConfig(tmpDir);
+
+    for (const tc of Object.values(config.note_types)) {
+      fs.mkdirSync(path.join(tmpDir, tc.folder), { recursive: true });
+    }
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('recommends linked notes, tags, and a next step from local context', () => {
+    const granite = createNote(tmpDir, config, 'project', 'Granite', 'Granite is a local-first memory tool.\n');
+    setTags(granite.filepath, ['local-first', 'knowledge-base']);
+
+    const githubSeo = createNote(tmpDir, config, 'reference', 'GitHub SEO', 'Repository discoverability on GitHub.\n');
+    setTags(githubSeo.filepath, ['github', 'seo']);
+
+    const stan = createNote(tmpDir, config, 'person', 'Stan Girard', 'Builder behind Granite and GitHub SEO.\n');
+    setTags(stan.filepath, ['founder', 'open-source']);
+
+    const note = createNote(
+      tmpDir,
+      config,
+      'reference',
+      'Launch notes',
+      'Granite should benefit from GitHub SEO. Stan Girard wrote about it.\n',
+    );
+
+    const db = createDatabase(path.join(tmpDir, '.granite', 'index.db'));
+    rebuildIndex(tmpDir, config, db);
+
+    const recommendations = getRecommendations(db, readNote(note.filepath), config);
+    db.close();
+
+    expect(recommendations.links.map(link => link.slug)).toEqual(
+      expect.arrayContaining(['granite', 'github-seo', 'stan-girard']),
+    );
+    expect(recommendations.links.some(link => link.reason.includes('mentioned'))).toBe(true);
+    expect(recommendations.additions.map(item => item.text)).toEqual(
+      expect.arrayContaining([
+        'Add the source URL or citation.',
+        'Write 2-3 key points in your own words.',
+      ]),
+    );
+    expect(recommendations.tags.map(tag => tag.tag)).toEqual(
+      expect.arrayContaining(['github', 'seo']),
+    );
+    expect(recommendations.next_steps[0]).toMatchObject({
+      type: 'permanent',
+      title_hint: 'Idea from Launch notes',
+    });
+  });
+
+  it('recommends related notes through local search when no title is mentioned exactly', () => {
+    const semantic = createNote(
+      tmpDir,
+      config,
+      'permanent',
+      'Semantic Search',
+      'Semantic retrieval helps a note system find related ideas.\n',
+    );
+    setTags(semantic.filepath, ['search']);
+
+    const vectors = createNote(
+      tmpDir,
+      config,
+      'permanent',
+      'Embeddings for Notes',
+      'Vector retrieval improves knowledge discovery in a note vault.\n',
+    );
+    setTags(vectors.filepath, ['embeddings']);
+
+    const target = createNote(
+      tmpDir,
+      config,
+      'permanent',
+      'Semantic retrieval for a vault',
+      'A local note system should surface related knowledge quickly.\n',
+    );
+
+    const db = createDatabase(path.join(tmpDir, '.granite', 'index.db'));
+    rebuildIndex(tmpDir, config, db);
+
+    const recommendations = getRecommendations(db, readNote(target.filepath), config);
+    db.close();
+
+    expect(recommendations.links.some(link => link.source === 'search')).toBe(true);
+    expect(recommendations.links.map(link => link.slug)).toEqual(
+      expect.arrayContaining(['semantic-search', 'embeddings-for-notes']),
+    );
+    expect(recommendations.tags.map(tag => tag.tag)).toContain('search');
+  });
+
+  it('does not re-suggest notes that are already linked', () => {
+    createNote(tmpDir, config, 'person', 'Stan Girard', 'Builder.\n');
+    const launch = createNote(
+      tmpDir,
+      config,
+      'permanent',
+      'Launch note',
+      'We worked with [[Stan Girard]] on Granite.\n',
+    );
+
+    const db = createDatabase(path.join(tmpDir, '.granite', 'index.db'));
+    rebuildIndex(tmpDir, config, db);
+
+    const recommendations = getRecommendations(db, readNote(launch.filepath), config);
+    db.close();
+
+    expect(recommendations.links.map(link => link.slug)).not.toContain('stan-girard');
+  });
+
+  it('uses existing linked notes to improve next-step recommendations', () => {
+    createNote(tmpDir, config, 'project', 'Granite', 'Granite is a local-first memory system.\n');
+    const stan = createNote(
+      tmpDir,
+      config,
+      'person',
+      'Stan Girard',
+      '## Role\n\nBuilder behind Granite.\n\n## Context\n\nWorks on Granite.\n\n## Links\n\n- [[granite]]\n',
+    );
+
+    const db = createDatabase(path.join(tmpDir, '.granite', 'index.db'));
+    rebuildIndex(tmpDir, config, db);
+
+    const recommendations = getRecommendations(db, readNote(stan.filepath), config);
+    db.close();
+
+    expect(recommendations.next_steps[0]).toMatchObject({
+      type: 'meeting',
+      title_hint: 'Stan Girard + Granite',
+    });
+  });
+
+  it('gives add-now guidance for a newly created person card', () => {
+    const stan = createNote(tmpDir, config, 'person', 'Stan Girard');
+
+    const db = createDatabase(path.join(tmpDir, '.granite', 'index.db'));
+    rebuildIndex(tmpDir, config, db);
+
+    const recommendations = getRecommendations(db, readNote(stan.filepath), config);
+    db.close();
+
+    expect(recommendations.additions.map(item => item.text)).toEqual(
+      expect.arrayContaining([
+        'Add a one-line role, company, or why this person matters.',
+        'Add how you know them or what you work on together.',
+        'Link one project, company, or topic in the Links section.',
+      ]),
+    );
+  });
+});
+
+function setTags(filepath: string, tags: string[]): void {
+  const content = fs.readFileSync(filepath, 'utf-8');
+  const { frontmatter, body } = parseFrontmatter(content);
+  frontmatter.tags = tags;
+  frontmatter.modified = new Date().toISOString();
+  fs.writeFileSync(filepath, serializeFrontmatter(frontmatter, body), 'utf-8');
+}


### PR DESCRIPTION
## Summary
Add a local-first recommendation engine for note capture and note maintenance.

## What changed
- added `mem recommend <slug>` to suggest links, tags, and the next note to create
- show recommendations automatically after `mem new`, `mem add`, and programmatic `mem edit`
- added `Add now` guidance for structured note templates so fresh person/project/reference notes get actionable next additions
- improved recommendation quality by using existing links/backlinks, skipping already-linked notes, and reusing nearby-note tags
- switched capture flows to incremental index sync instead of full vault rebuilds
- hardened frontmatter parsing so YAML dates written without quotes do not break indexing

## Why
The previous recommendation behavior was only useful for simple text captures. It underperformed on structured cards, could re-suggest notes that were already linked, and rebuilt the whole index on every capture.

## User impact
Creating or editing notes now surfaces concrete local recommendations immediately, especially for people cards and other templates.

## Validation
- `npm test`
- `npm run lint`
- manual CLI smoke tests for `mem recommend`, `mem new`, and `mem edit`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a local-first recommendation engine that suggests links, tags, next steps, and “Add now” prompts during capture and edit. Adds a project README and `AGENTS.md` to document the system and CLI.

- New Features
  - New command: `mem recommend <slug>` (supports `--json`) to suggest links, tags, and next note.
  - Shows recommendations automatically after `mem new`, `mem add`, and `mem edit` (also in JSON output).
  - Higher-quality suggestions: uses mentions, backlinks, and local search; avoids already-linked notes; reuses nearby-note tags; adds template-aware “Add now” prompts.
  - Docs: added `README.md` and `AGENTS.md`.

- Refactors
  - Switched capture flows to incremental index sync instead of full vault rebuilds.
  - Frontmatter parsing now normalizes Date values and handles unquoted YAML dates safely.

<sup>Written for commit daccd01c89c705153dc1fd61cd0c0bcba35de2e1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new recommendation engine and CLI command that depend on SQLite index state, plus introduces incremental index updates that could affect search/link accuracy if syncing logic misses edge cases.
> 
> **Overview**
> Introduces a local-first recommendation system surfaced via new `mem recommend <slug>` and automatically after `mem new`, `mem add`, and flag-based `mem edit`, with both human-readable output and `--json` payloads.
> 
> Adds `src/core/recommendations.ts` to suggest **links** (mentions + FTS similarity), **tags** (inferred from nearby notes), **next notes** (type-based prompts), and template-aware **“Add now”** guidance, while avoiding already-linked targets.
> 
> Updates indexing to support faster capture/edit flows by syncing a single note into SQLite (`syncNoteInIndex`) instead of rebuilding the full index each time, and hardens frontmatter parsing by normalizing YAML values (including unquoted dates) to strings. Includes new tests for recommendation behavior plus new `README.md`/`AGENTS.md` documentation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit daccd01c89c705153dc1fd61cd0c0bcba35de2e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->