### PR TITLE
fix: rebuild recommendations after durable note updates

### DIFF
--- a/src/commands/edit.ts
+++ b/src/commands/edit.ts
@@ -73,7 +73,8 @@ export function editCommand(slug: string, options: EditOptions): void {
     fs.writeFileSync(note.filepath, serializeFrontmatter(frontmatter, body), 'utf-8');
 
     console.log(note.filepath);
-    printRecommendations(vaultRoot, config, note.filepath);
+    const recommendationStrategy = options.title !== undefined || options.alias !== undefined ? 'rebuild' : 'incremental';
+    printRecommendations(vaultRoot, config, note.filepath, recommendationStrategy);
   } else {
     // Interactive edit (human mode) — open in $EDITOR
     const editor = process.env.EDITOR || 'vi';
@@ -93,14 +94,19 @@ export function editCommand(slug: string, options: EditOptions): void {
       frontmatter.modified = new Date().toISOString();
       fs.writeFileSync(note.filepath, serializeFrontmatter(frontmatter, body), 'utf-8');
       console.log(`Updated: ${note.filepath}`);
-      printRecommendations(vaultRoot, config, note.filepath);
+      printRecommendations(vaultRoot, config, note.filepath, 'rebuild');
     }
   }
 }
 
-function printRecommendations(vaultRoot: string, config: ReturnType<typeof loadConfig>, filepath: string): void {
+function printRecommendations(
+  vaultRoot: string,
+  config: ReturnType<typeof loadConfig>,
+  filepath: string,
+  strategy: 'rebuild' | 'incremental',
+): void {
   const updatedNote = readNote(filepath);
-  const recommendations = recommendNote(vaultRoot, config, updatedNote, { strategy: 'incremental' });
+  const recommendations = recommendNote(vaultRoot, config, updatedNote, { strategy });
   const lines = formatRecommendations(recommendations);
 
   if (lines.length === 0) return;

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -28,7 +28,8 @@ export function newNote(title: string, options: { type?: string; source?: string
     note.frontmatter = frontmatter;
   }
 
-  const recommendations = recommendNote(vaultRoot, config, note, { strategy: 'incremental' });
+  const recommendationStrategy = typeConfig?.slug_format === 'date' ? 'incremental' : 'rebuild';
+  const recommendations = recommendNote(vaultRoot, config, note, { strategy: recommendationStrategy });
 
   const lines = note.body.split('\n').length;
   const overLimit = typeConfig && typeConfig.line_limit && lines > typeConfig.line_limit;


### PR DESCRIPTION
## Summary
- use a full index rebuild for durable note creation so new cards can immediately see resolved backlinks
- rebuild after title and alias edits so post-edit recommendations reflect newly resolvable links
- keep incremental sync for cheap body/tag updates and fleeting note creation

## Validation
- npm test
- npm run lint
- manual CLI smoke test covering `Stan Girard` creation after an existing `[[Stan Girard]]` mention
- manual CLI smoke test covering `edit stan-girard --alias SG` resolving an existing `[[SG]]` backlink immediately

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trigger a full recommendation rebuild for durable note creation and for title/alias edits so backlinks resolve immediately. Keep incremental sync for body/tag-only updates and date-slug notes to stay fast.

- **Bug Fixes**
  - `src/commands/new.ts`: use 'rebuild' unless `slug_format` is 'date'; otherwise use 'incremental'.
  - `src/commands/edit.ts`: pass a strategy to `recommendNote`; use 'rebuild' for title/alias edits and interactive saves, 'incremental' otherwise.

<sup>Written for commit e9207a5944c721f3d9fba9c4840704e20edf6c2b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes when the recommendations index is rebuilt vs incrementally synced, which can affect both backlink correctness and CLI performance on large vaults.
> 
> **Overview**
> **Recommendation generation now chooses between `rebuild` and `incremental` indexing based on the kind of note change.**
> 
> `new` uses a full rebuild for most note types so newly created durable notes immediately resolve existing backlinks, but keeps incremental sync for date-slug (fleeting-style) notes.
> 
> `edit` now passes an explicit strategy into recommendation printing: title/alias edits (and interactive editor saves) force a rebuild, while simple body/tag/status/source updates remain incremental.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e9207a5944c721f3d9fba9c4840704e20edf6c2b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->