### PR TITLE
[codex] fix default vault location for mem init

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ npm run build
 npm link
 ```
 
-Create a vault and start capturing:
+Create the default vault in `~/.granite` and start capturing:
 
 ```bash
 mem init
@@ -153,8 +153,9 @@ Granite keeps the source of truth boring and durable:
 
 - notes are Markdown files
 - metadata lives in YAML frontmatter
-- vault configuration lives in `granite.yml`
-- full-text search and link resolution are backed by a local SQLite index in `.granite/index.db`
+- the default vault lives in `~/.granite`
+- vault configuration lives in `~/.granite/granite.yml`
+- full-text search and link resolution are backed by a local SQLite index in `~/.granite/index.db`
 - the index can be rebuilt from the files at any time
 
 This keeps the system transparent, portable, and inspectable.

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,9 +1,11 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { writeDefaultConfig, CONFIG_FILENAME, loadConfig } from '../core/config.js';
+import { getDefaultVaultRoot, getIndexDbPath } from '../core/vault.js';
 
-export function initVault(dir: string): void {
+export function initVault(dir = getDefaultVaultRoot()): void {
   const targetDir = path.resolve(dir);
+  fs.mkdirSync(targetDir, { recursive: true });
 
   if (fs.existsSync(path.join(targetDir, CONFIG_FILENAME))) {
     console.error(`Vault already exists in ${targetDir}`);
@@ -13,8 +15,7 @@ export function initVault(dir: string): void {
   // Write config
   writeDefaultConfig(targetDir);
 
-  // Create .granite directory
-  fs.mkdirSync(path.join(targetDir, '.granite'), { recursive: true });
+  fs.mkdirSync(path.dirname(getIndexDbPath(targetDir)), { recursive: true });
 
   // Create default note type folders
   const config = loadConfig(targetDir);
@@ -26,10 +27,13 @@ export function initVault(dir: string): void {
   console.log('');
   console.log('Created:');
   console.log(`  ${CONFIG_FILENAME}`);
-  console.log('  .granite/');
+  const indexDir = path.relative(targetDir, path.dirname(getIndexDbPath(targetDir)));
+  if (indexDir) {
+    console.log(`  ${indexDir}/`);
+  }
   for (const [name, typeConfig] of Object.entries(config.note_types)) {
     console.log(`  ${typeConfig.folder}/  (${name})`);
   }
   console.log('');
-  console.log('Next: mem new fleeting "My first note"');
+  console.log('Next: mem new "My first note" --type fleeting');
 }

--- a/src/core/vault.ts
+++ b/src/core/vault.ts
@@ -1,28 +1,45 @@
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { CONFIG_FILENAME } from './config.js';
+
+const DEFAULT_VAULT_DIRNAME = '.granite';
+
+function hasVaultConfig(dir: string): boolean {
+  return fs.existsSync(path.join(dir, CONFIG_FILENAME));
+}
+
+export function getDefaultVaultRoot(homeDir = os.homedir()): string {
+  return path.resolve(homeDir, DEFAULT_VAULT_DIRNAME);
+}
 
 export function findVaultRoot(from?: string): string | null {
   let dir = from ? path.resolve(from) : process.cwd();
   while (true) {
-    if (fs.existsSync(path.join(dir, CONFIG_FILENAME))) {
+    if (hasVaultConfig(dir)) {
       return dir;
     }
     const parent = path.dirname(dir);
-    if (parent === dir) return null;
+    if (parent === dir) break;
     dir = parent;
   }
+
+  const defaultVaultRoot = getDefaultVaultRoot();
+  return hasVaultConfig(defaultVaultRoot) ? defaultVaultRoot : null;
 }
 
 export function requireVaultRoot(from?: string): string {
   const root = findVaultRoot(from);
   if (!root) {
-    throw new Error('Not inside a Granite vault. Run "mem init" to create one.');
+    throw new Error(`No Granite vault found. Run "mem init" to create ${getDefaultVaultRoot()}.`);
   }
   return root;
 }
 
 export function getIndexDbPath(vaultRoot: string): string {
+  if (path.basename(path.resolve(vaultRoot)) === DEFAULT_VAULT_DIRNAME) {
+    return path.join(vaultRoot, 'index.db');
+  }
   return path.join(vaultRoot, '.granite', 'index.db');
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,9 +23,9 @@ program
 
 program
   .command('init')
-  .description('Initialize a new vault in the current directory')
+  .description('Initialize the default vault in ~/.granite')
   .action(() => {
-    initVault(process.cwd());
+    initVault();
   });
 
 program

--- a/test/commands/init.test.ts
+++ b/test/commands/init.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { initVault } from '../../src/commands/init.js';
+import { loadConfig } from '../../src/core/config.js';
+import { getDefaultVaultRoot, getIndexDbPath } from '../../src/core/vault.js';
+
+describe('initVault', () => {
+  let tmpHome: string;
+  let tmpCwd: string;
+  let previousHome: string | undefined;
+  let previousCwd: string;
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'granite-init-home-'));
+    tmpCwd = fs.mkdtempSync(path.join(os.tmpdir(), 'granite-init-cwd-'));
+    previousHome = process.env.HOME;
+    previousCwd = process.cwd();
+    process.env.HOME = tmpHome;
+    process.chdir(tmpCwd);
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.chdir(previousCwd);
+    if (previousHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = previousHome;
+    }
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+    fs.rmSync(tmpCwd, { recursive: true, force: true });
+  });
+
+  it('initializes the default vault in the home directory instead of the current working directory', () => {
+    initVault();
+
+    const vaultRoot = getDefaultVaultRoot();
+    const config = loadConfig(vaultRoot);
+
+    expect(vaultRoot).toBe(path.join(tmpHome, '.granite'));
+    expect(fs.existsSync(path.join(vaultRoot, 'granite.yml'))).toBe(true);
+    expect(fs.existsSync(path.join(tmpCwd, 'granite.yml'))).toBe(false);
+    expect(path.dirname(getIndexDbPath(vaultRoot))).toBe(vaultRoot);
+
+    for (const typeConfig of Object.values(config.note_types)) {
+      expect(fs.existsSync(path.join(vaultRoot, typeConfig.folder))).toBe(true);
+    }
+  });
+});

--- a/test/core/vault.test.ts
+++ b/test/core/vault.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { writeDefaultConfig } from '../../src/core/config.js';
+import { findVaultRoot, getDefaultVaultRoot, getIndexDbPath, requireVaultRoot } from '../../src/core/vault.js';
+
+describe('vault', () => {
+  let tmpHome: string;
+  let previousHome: string | undefined;
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'granite-home-'));
+    previousHome = process.env.HOME;
+    process.env.HOME = tmpHome;
+  });
+
+  afterEach(() => {
+    if (previousHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = previousHome;
+    }
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  function createGlobalVault(): string {
+    const vaultRoot = getDefaultVaultRoot();
+    fs.mkdirSync(vaultRoot, { recursive: true });
+    writeDefaultConfig(vaultRoot);
+    return vaultRoot;
+  }
+
+  it('falls back to the default vault in the home directory', () => {
+    const vaultRoot = createGlobalVault();
+    const outsideDir = path.join(tmpHome, 'workspace');
+    fs.mkdirSync(outsideDir, { recursive: true });
+
+    expect(findVaultRoot(outsideDir)).toBe(vaultRoot);
+  });
+
+  it('prefers the nearest local vault over the default home vault', () => {
+    createGlobalVault();
+    const localVaultRoot = path.join(tmpHome, 'projects', 'local-vault');
+    const nestedDir = path.join(localVaultRoot, 'notes', 'scratch');
+
+    fs.mkdirSync(localVaultRoot, { recursive: true });
+    writeDefaultConfig(localVaultRoot);
+    fs.mkdirSync(nestedDir, { recursive: true });
+
+    expect(findVaultRoot(nestedDir)).toBe(localVaultRoot);
+  });
+
+  it('stores the index at the vault root when the vault itself is ~/.granite', () => {
+    const vaultRoot = getDefaultVaultRoot();
+    const localVaultRoot = path.join(tmpHome, 'projects', 'vault');
+
+    expect(getIndexDbPath(vaultRoot)).toBe(path.join(vaultRoot, 'index.db'));
+    expect(getIndexDbPath(localVaultRoot)).toBe(path.join(localVaultRoot, '.granite', 'index.db'));
+  });
+
+  it('mentions the default vault path when no vault can be found', () => {
+    expect(() => requireVaultRoot(path.join(tmpHome, 'nowhere'))).toThrow(
+      `No Granite vault found. Run "mem init" to create ${getDefaultVaultRoot()}.`,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- make `mem init` create the default vault in `~/.granite` instead of the current working directory
- update vault resolution so commands fall back to the global home vault while still preferring a nearer local vault
- add regression tests for init behavior and vault lookup, and align the CLI help and README with the new default

## Why
`mem init` was creating a vault in whichever directory the command was run from, which made the default onboarding flow inconsistent with the intended hidden home-directory vault. Once that happened, later commands only worked when invoked from inside that directory tree.

## Impact
Users now get a predictable default vault at `~/.granite`, with the SQLite index stored at `~/.granite/index.db`. Existing local vaults still resolve correctly because local ancestor lookup takes precedence over the home fallback.

## Validation
- `npm run test`
- `npm run lint`
- `npm run build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set `mem init` to create the default vault in `~/.granite` and updated vault resolution to prefer the nearest local vault and fall back to the home vault. This makes onboarding predictable and avoids commands breaking outside a project directory.

- **Bug Fixes**
  - Default vault now lives in `~/.granite`; index stored at `~/.granite/index.db`.
  - Vault lookup falls back to the home vault when no local vault is found; error message points to the default path.
  - Updated CLI help and README; added regression tests for init and vault lookup.

<sup>Written for commit 05d3aa3b4575cac08ad5b42a311c259d0868fb1d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes vault discovery and default index location used by most CLI commands, which could affect existing workflows or where data/index files are created. Scope is contained and covered by new regression tests.
> 
> **Overview**
> `mem init` now creates the *default* vault at `~/.granite` (and ensures the index directory exists) instead of initializing in the current working directory, with updated CLI help, README wording, and init output.
> 
> Vault resolution (`findVaultRoot`/`requireVaultRoot`) now falls back to the home default vault when no ancestor vault is found, while still preferring the nearest local vault; `getIndexDbPath` stores the SQLite index at `~/.granite/index.db` for the default vault but keeps `.granite/index.db` for other vaults. Adds Vitest coverage for the new init behavior, fallback precedence, index path rules, and improved error messaging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 05d3aa3b4575cac08ad5b42a311c259d0868fb1d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->