### PR TITLE
feat: Add Granite MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,13 @@ mem add "Talked to Alice about local-first sync tradeoffs"
 mem new "Local-first sync tradeoffs" --type permanent
 mem list
 mem search "sync"
-mem serve
-mem mcp
+```
+
+Start one long-running interface when you need it:
+
+```bash
+mem serve   # local web UI
+mem mcp     # MCP server for agent clients
 ```
 
 `mem new` does more than create a file. It can immediately suggest related links, tags, and the next note to create, which is the core of Granite's value loop.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Granite is designed to be easy for agents to read and act on:
 - notes are plain files
 - metadata is explicit
 - commands support `--json`
+- Granite ships with an MCP server
 - vault structure is predictable
 - search, backlinks, and recommendations are available from the CLI
 
@@ -86,6 +87,7 @@ mem new "Local-first sync tradeoffs" --type permanent
 mem list
 mem search "sync"
 mem serve
+mem mcp
 ```
 
 `mem new` does more than create a file. It can immediately suggest related links, tags, and the next note to create, which is the core of Granite's value loop.
@@ -174,6 +176,37 @@ mem recommend sync-constraints --json
 
 That makes Granite a useful substrate for local workflows, scripts, and agent memory.
 
+## MCP Server
+
+Granite ships with an MCP server so LLM clients can control the vault directly through tools, resources, and prompts.
+
+Start it over stdio for local MCP clients:
+
+```bash
+mem mcp --vault /path/to/vault
+```
+
+Start it over Streamable HTTP:
+
+```bash
+mem mcp --transport http --host 127.0.0.1 --port 3321
+```
+
+The server exposes:
+
+- tools for vault overview, list/get/search, create/update, backlinks, link suggestions, recommendations, and doctor
+- resources for `granite.yml`, vault overview, note types, and individual notes via `granite://notes/{slug}`
+- prompts for refining notes and reviewing links/next steps
+
+Example stdio client configuration:
+
+```json
+{
+  "command": "mem",
+  "args": ["mcp", "--vault", "/path/to/vault"]
+}
+```
+
 ## Commands
 
 ```bash
@@ -191,6 +224,7 @@ mem recommend <slug> [--json]
 mem types
 mem doctor
 mem serve [-p <port>]
+mem mcp [--vault <path>] [--transport <stdio|http>]
 ```
 
 ## Development

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,14 @@
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.13.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "better-sqlite3": "^11.0.0",
         "commander": "^13.0.0",
         "gray-matter": "^4.0.3",
         "hono": "^4.0.0",
         "js-yaml": "^4.1.0",
-        "uuid": "^11.0.0"
+        "uuid": "^11.0.0",
+        "zod": "^3.25.76"
       },
       "bin": {
         "mem": "dist/index.js"
@@ -864,6 +866,46 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
@@ -1417,6 +1459,19 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1434,7 +1489,6 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -1445,6 +1499,23 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-escapes": {
@@ -1584,6 +1655,46 @@
         "readable-stream": "^3.4.0"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
@@ -1648,6 +1759,15 @@
         "esbuild": ">=0.18"
       }
     },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -1666,6 +1786,35 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -1925,6 +2074,28 @@
         "node": "^14.18.0 || >=16.10.0"
       }
     },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/conventional-changelog-angular": {
       "version": "8.3.1",
       "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.1.tgz",
@@ -1975,6 +2146,41 @@
         "node": ">=18"
       }
     },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cosmiconfig": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
@@ -2020,6 +2226,35 @@
         "typescript": ">=5"
       }
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cross-spawn/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/cz-conventional-changelog": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-3.3.0.tgz",
@@ -2045,7 +2280,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2113,6 +2347,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/detect-file": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
@@ -2155,12 +2398,41 @@
         "node": ">=8"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
@@ -2191,12 +2463,42 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.27.4",
@@ -2250,6 +2552,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -2281,6 +2589,36 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/expand-template": {
@@ -2315,6 +2653,67 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/extend-shallow": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
@@ -2346,14 +2745,12 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
       "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2419,6 +2816,27 @@
         "node": ">=8"
       }
     },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/find-node-modules": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/find-node-modules/-/find-node-modules-2.1.3.tgz",
@@ -2465,6 +2883,24 @@
         "rollup": "^4.34.8"
       }
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -2509,6 +2945,15 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -2517,6 +2962,43 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-tsconfig": {
@@ -2635,6 +3117,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -2689,6 +3183,30 @@
         "node": ">=4"
       }
     },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/homedir-polyfill": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
@@ -2709,6 +3227,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/husky": {
@@ -2925,6 +3463,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -3017,6 +3573,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
@@ -3051,7 +3613,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/jiti": {
@@ -3062,6 +3623,15 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/joycon": {
@@ -3104,8 +3674,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/jsonfile": {
       "version": "6.2.0",
@@ -3335,6 +3910,24 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/meow": {
       "version": "13.2.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
@@ -3354,6 +3947,18 @@
       "integrity": "sha512-jz+Cfrg9GWOZbQAnDQ4hlVnQky+341Yk5ru8bZSe6sIDTCIg8n9i/u7hSQGSVOF3C7lH6mGtqjkiT9G4wFLL0w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -3380,6 +3985,31 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/mimic-fn": {
@@ -3449,7 +4079,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mute-stream": {
@@ -3496,6 +4125,15 @@
       "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
       "license": "MIT"
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/node-abi": {
       "version": "3.89.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
@@ -3512,10 +4150,33 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/once": {
@@ -3695,6 +4356,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -3703,6 +4373,25 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.1.tgz",
+      "integrity": "sha512-fvU78fIjZ+SBM9YwCknCvKOUKkLVqtWDVctl0s7xIqfmfb38t2TT4ZU2gHm+Z8xGwgW+QWEU3oQSAzIbo89Ggw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/pathe": {
@@ -3750,6 +4439,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/pkg-types": {
@@ -3863,6 +4561,19 @@
         "node": ">=10"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/pump": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
@@ -3871,6 +4582,61 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/rc": {
@@ -3930,7 +4696,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4029,6 +4794,22 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/run-async": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
@@ -4073,7 +4854,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/section-matter": {
@@ -4099,6 +4879,150 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/siginfo": {
@@ -4192,6 +5116,15 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/std-env": {
       "version": "3.10.0",
@@ -4469,6 +5402,15 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/tree-kill": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
@@ -4591,6 +5533,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -4629,6 +5585,15 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -4646,6 +5611,15 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/vite": {
@@ -4966,6 +5940,24 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -32,13 +32,15 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@hono/node-server": "^1.13.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "better-sqlite3": "^11.0.0",
     "commander": "^13.0.0",
     "gray-matter": "^4.0.3",
     "hono": "^4.0.0",
-    "@hono/node-server": "^1.13.0",
     "js-yaml": "^4.1.0",
-    "uuid": "^11.0.0"
+    "uuid": "^11.0.0",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@commitlint/cli": "^20.0.0",

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -13,7 +13,7 @@ interface McpCommandOptions {
 }
 
 export async function mcpCommand(options: McpCommandOptions): Promise<void> {
-  const transport = options.transport ?? 'stdio';
+  const transport = parseTransport(options.transport);
   const vaultRoot = resolveVaultRoot(options.vault);
   const runtime = new GraniteMcpRuntime(vaultRoot);
 
@@ -50,10 +50,23 @@ function resolveVaultRoot(explicitVault?: string): string {
   return requireVaultRoot();
 }
 
-function parsePort(value?: string): number {
-  const parsed = Number.parseInt(process.env.MCP_PORT || value || '3321', 10);
-  if (Number.isNaN(parsed) || parsed <= 0) {
-    throw new Error(`Invalid MCP port: ${value ?? process.env.MCP_PORT}`);
+export function parseTransport(value?: string): 'stdio' | 'http' {
+  const transport = value ?? 'stdio';
+  if (transport !== 'stdio' && transport !== 'http') {
+    throw new Error(`Invalid MCP transport: ${transport}. Expected "stdio" or "http".`);
+  }
+  return transport;
+}
+
+export function parsePort(value?: string): number {
+  const raw = (value ?? process.env.MCP_PORT ?? '3321').trim();
+  if (!/^\d+$/.test(raw)) {
+    throw new Error(`Invalid MCP port: ${raw}`);
+  }
+
+  const parsed = Number.parseInt(raw, 10);
+  if (parsed <= 0) {
+    throw new Error(`Invalid MCP port: ${raw}`);
   }
   return parsed;
 }

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -1,0 +1,59 @@
+import path from 'node:path';
+import { requireVaultRoot } from '../core/vault.js';
+import { startGraniteMcpHttpServer, startGraniteMcpStdioServer } from '../mcp/server.js';
+import { GraniteMcpRuntime } from '../mcp/runtime.js';
+
+interface McpCommandOptions {
+  vault?: string;
+  transport?: 'stdio' | 'http';
+  host?: string;
+  port?: string;
+  allowOrigin?: string[];
+  jsonResponse?: boolean;
+}
+
+export async function mcpCommand(options: McpCommandOptions): Promise<void> {
+  const transport = options.transport ?? 'stdio';
+  const vaultRoot = resolveVaultRoot(options.vault);
+  const runtime = new GraniteMcpRuntime(vaultRoot);
+
+  const shutdown = () => {
+    runtime.close();
+    process.exit(0);
+  };
+
+  process.once('SIGINT', shutdown);
+  process.once('SIGTERM', shutdown);
+
+  if (transport === 'http') {
+    const port = parsePort(options.port);
+    startGraniteMcpHttpServer(runtime, {
+      host: options.host ?? '127.0.0.1',
+      port,
+      allowedOrigins: options.allowOrigin ?? [],
+      jsonResponse: options.jsonResponse ?? false,
+    });
+    return;
+  }
+
+  await startGraniteMcpStdioServer(runtime);
+}
+
+function resolveVaultRoot(explicitVault?: string): string {
+  const fromEnv = process.env.GRANITE_VAULT;
+  if (explicitVault) {
+    return path.resolve(explicitVault);
+  }
+  if (fromEnv) {
+    return path.resolve(fromEnv);
+  }
+  return requireVaultRoot();
+}
+
+function parsePort(value?: string): number {
+  const parsed = Number.parseInt(process.env.MCP_PORT || value || '3321', 10);
+  if (Number.isNaN(parsed) || parsed <= 0) {
+    throw new Error(`Invalid MCP port: ${value ?? process.env.MCP_PORT}`);
+  }
+  return parsed;
+}

--- a/src/core/index-db.ts
+++ b/src/core/index-db.ts
@@ -198,8 +198,8 @@ function countNoteFiles(vaultRoot: string, config: GraniteConfig): number {
 
 function upsertNoteAndLinks(db: Database.Database, note: Note): void {
   const upsertNote = db.prepare(`
-    INSERT INTO notes (slug, id, title, type, created, modified, tags, aliases, body, filepath)
-    VALUES (@slug, @id, @title, @type, @created, @modified, @tags, @aliases, @body, @filepath)
+    INSERT INTO notes (slug, id, title, type, created, modified, tags, aliases, body, filepath, status, source)
+    VALUES (@slug, @id, @title, @type, @created, @modified, @tags, @aliases, @body, @filepath, @status, @source)
     ON CONFLICT(slug) DO UPDATE SET
       id = excluded.id,
       title = excluded.title,
@@ -209,7 +209,9 @@ function upsertNoteAndLinks(db: Database.Database, note: Note): void {
       tags = excluded.tags,
       aliases = excluded.aliases,
       body = excluded.body,
-      filepath = excluded.filepath
+      filepath = excluded.filepath,
+      status = excluded.status,
+      source = excluded.source
   `);
 
   const deleteLinks = db.prepare('DELETE FROM links WHERE source_slug = ?');
@@ -230,6 +232,8 @@ function upsertNoteAndLinks(db: Database.Database, note: Note): void {
       aliases: JSON.stringify(note.frontmatter.aliases),
       body: note.body,
       filepath: note.filepath,
+      status: note.frontmatter.status ?? 'active',
+      source: note.frontmatter.source ?? 'human',
     });
 
     deleteLinks.run(note.slug);

--- a/src/core/search.ts
+++ b/src/core/search.ts
@@ -1,7 +1,8 @@
 import type Database from 'better-sqlite3';
 import type { SearchResult } from './types.js';
 
-export function searchNotes(db: Database.Database, query: string): SearchResult[] {
+export function searchNotes(db: Database.Database, query: string, limit = 20): SearchResult[] {
+  const cappedLimit = Math.max(1, Math.min(limit, 100));
   const stmt = db.prepare(`
     SELECT
       n.slug,
@@ -12,10 +13,10 @@ export function searchNotes(db: Database.Database, query: string): SearchResult[
     JOIN notes n ON n.rowid = notes_fts.rowid
     WHERE notes_fts MATCH ?
     ORDER BY rank
-    LIMIT 20
+    LIMIT ?
   `);
 
-  const rows = stmt.all(query) as Array<{
+  const rows = stmt.all(query, cappedLimit) as Array<{
     slug: string;
     title: string;
     snippet: string;

--- a/src/core/suggest.ts
+++ b/src/core/suggest.ts
@@ -2,7 +2,7 @@ import type Database from 'better-sqlite3';
 import type { Note } from './types.js';
 import { parseWikilinks } from './wikilinks.js';
 
-interface LinkSuggestion {
+export interface LinkSuggestion {
   target_slug: string;
   target_title: string;
   mentions: number;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { Command } from 'commander';
+import { Command, InvalidArgumentError } from 'commander';
 import { initVault } from './commands/init.js';
 import { newNote } from './commands/new.js';
 import { addNote } from './commands/add.js';
@@ -13,7 +13,7 @@ import { serveCommand } from './commands/serve.js';
 import { typesCommand } from './commands/types.js';
 import { listCommand } from './commands/list.js';
 import { editCommand } from './commands/edit.js';
-import { mcpCommand } from './commands/mcp.js';
+import { mcpCommand, parseTransport } from './commands/mcp.js';
 import { GRANITE_VERSION } from './version.js';
 
 const program = new Command();
@@ -160,7 +160,7 @@ program
   .command('mcp')
   .description('Start Granite as an MCP server')
   .option('--vault <path>', 'Vault root. Defaults to the current Granite vault or $GRANITE_VAULT')
-  .option('--transport <transport>', 'Transport to use: stdio or http', 'stdio')
+  .option('--transport <transport>', 'Transport to use: stdio or http', parseTransportOption, 'stdio')
   .option('--host <host>', 'Host for HTTP transport', '127.0.0.1')
   .option('--port <port>', 'Port for HTTP transport', '3321')
   .option('--allow-origin <origin>', 'Allow an HTTP Origin for browser-based HTTP clients', collectValues, [])
@@ -180,4 +180,12 @@ await program.parseAsync();
 
 function collectValues(value: string, previous: string[]): string[] {
   return [...previous, value];
+}
+
+function parseTransportOption(value: string): 'stdio' | 'http' {
+  try {
+    return parseTransport(value);
+  } catch (error) {
+    throw new InvalidArgumentError(error instanceof Error ? error.message : String(error));
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,13 +13,15 @@ import { serveCommand } from './commands/serve.js';
 import { typesCommand } from './commands/types.js';
 import { listCommand } from './commands/list.js';
 import { editCommand } from './commands/edit.js';
+import { mcpCommand } from './commands/mcp.js';
+import { GRANITE_VERSION } from './version.js';
 
 const program = new Command();
 
 program
   .name('mem')
   .description('Granite — a local-first markdown memory system')
-  .version('0.1.0');
+  .version(GRANITE_VERSION);
 
 program
   .command('init')
@@ -154,4 +156,28 @@ program
     serveCommand(options);
   });
 
-program.parse();
+program
+  .command('mcp')
+  .description('Start Granite as an MCP server')
+  .option('--vault <path>', 'Vault root. Defaults to the current Granite vault or $GRANITE_VAULT')
+  .option('--transport <transport>', 'Transport to use: stdio or http', 'stdio')
+  .option('--host <host>', 'Host for HTTP transport', '127.0.0.1')
+  .option('--port <port>', 'Port for HTTP transport', '3321')
+  .option('--allow-origin <origin>', 'Allow an HTTP Origin for browser-based HTTP clients', collectValues, [])
+  .option('--json-response', 'Prefer JSON HTTP responses instead of SSE streams')
+  .action(async (options: {
+    vault?: string;
+    transport?: 'stdio' | 'http';
+    host?: string;
+    port?: string;
+    allowOrigin?: string[];
+    jsonResponse?: boolean;
+  }) => {
+    await mcpCommand(options);
+  });
+
+await program.parseAsync();
+
+function collectValues(value: string, previous: string[]): string[] {
+  return [...previous, value];
+}

--- a/src/mcp/runtime.ts
+++ b/src/mcp/runtime.ts
@@ -180,6 +180,10 @@ export class GraniteMcpRuntime {
     }));
   }
 
+  getDefaultNoteType(): string {
+    return this.config.defaults.note_type;
+  }
+
   listNotes(input: ListNotesInput = {}): NoteSummary[] {
     let notes = this.readAllNotes();
 
@@ -373,7 +377,9 @@ export class GraniteMcpRuntime {
       shouldRebuild = true;
     } else if (this.config.index.auto_rebuild) {
       if (!this.lastSignature) {
-        shouldRebuild = signature.latestMutationMs > this.getLastRebuildMs();
+        shouldRebuild =
+          signature.noteCount !== this.getIndexedNoteCount() ||
+          signature.latestMutationMs > this.getLastRebuildMs();
       } else {
         shouldRebuild =
           signature.noteCount !== this.lastSignature.noteCount ||
@@ -523,6 +529,11 @@ export class GraniteMcpRuntime {
   private getMetaValue(key: string): string | undefined {
     const row = this.db.prepare('SELECT value FROM meta WHERE key = ?').get(key) as { value: string } | undefined;
     return row?.value;
+  }
+
+  private getIndexedNoteCount(): number {
+    const row = this.db.prepare('SELECT COUNT(*) as count FROM notes').get() as { count: number };
+    return row.count;
   }
 }
 

--- a/src/mcp/runtime.ts
+++ b/src/mcp/runtime.ts
@@ -275,12 +275,17 @@ export class GraniteMcpRuntime {
         : undefined;
 
     const created = createNote(this.vaultRoot, this.config, resolvedType, input.title, bodyOverride);
-    this.applyMutations(created.filepath, {
+    const metadataMutations = {
       tags: input.tags,
       aliases: input.aliases,
       status: input.status,
       source: input.source,
-    });
+    };
+
+    if (hasMetadataMutations(metadataMutations)) {
+      this.applyMutations(created.filepath, metadataMutations);
+    }
+
     return this.afterWrite(created.slug, true);
   }
 
@@ -554,4 +559,13 @@ function mergeUnique(existing: string[], incoming: string[]): string[] {
     }
   }
   return [...merged];
+}
+
+function hasMetadataMutations(input: Pick<CreateNoteInput, 'tags' | 'aliases' | 'status' | 'source'>): boolean {
+  return (
+    (input.tags?.length ?? 0) > 0 ||
+    (input.aliases?.length ?? 0) > 0 ||
+    input.status !== undefined ||
+    input.source !== undefined
+  );
 }

--- a/src/mcp/runtime.ts
+++ b/src/mcp/runtime.ts
@@ -1,0 +1,546 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import type Database from 'better-sqlite3';
+import { CONFIG_FILENAME, loadConfig } from '../core/config.js';
+import { runDoctor } from '../core/doctor.js';
+import { parseFrontmatter, serializeFrontmatter } from '../core/frontmatter.js';
+import { openDatabase, rebuildIndex, syncNoteInIndex } from '../core/index-db.js';
+import { findNoteBySlug, listNotes, createNote, readNote } from '../core/note.js';
+import { getRecommendations } from '../core/recommendations.js';
+import { searchNotes } from '../core/search.js';
+import { suggestLinks } from '../core/suggest.js';
+import type {
+  BacklinkEntry,
+  DoctorIssue,
+  GraniteConfig,
+  Note,
+  NoteFrontmatter,
+  SearchResult,
+  WikiLink,
+} from '../core/types.js';
+import { parseWikilinks, resolveWikilinks } from '../core/wikilinks.js';
+import { getBacklinks } from '../core/backlinks.js';
+import { validateSource, validateStatus } from '../core/json-output.js';
+
+type NoteStatus = 'inbox' | 'active' | 'archived';
+type NoteSource = 'human' | 'agent' | 'extraction';
+
+interface VaultSignature {
+  noteCount: number;
+  latestMutationMs: number;
+  configMtimeMs: number;
+}
+
+export interface GraniteMcpRuntimeOptions {
+  indexCheckIntervalMs?: number;
+}
+
+export interface NoteSummary {
+  slug: string;
+  title: string;
+  type: string;
+  created: string;
+  modified: string;
+  tags: string[];
+  aliases: string[];
+  status: NoteStatus;
+  source: NoteSource;
+  filepath: string;
+  resource_uri: string;
+}
+
+export interface NoteDetails extends NoteSummary {
+  body: string;
+  frontmatter: NoteFrontmatter;
+  outgoing_links: WikiLink[];
+}
+
+export interface NoteTypeInfo {
+  name: string;
+  description: string;
+  folder: string;
+  line_limit: number;
+  warn_only: boolean;
+  slug_format: 'title' | 'date';
+  instructions?: string;
+  fields?: GraniteConfig['note_types'][string]['fields'];
+}
+
+export interface VaultOverview {
+  vault_root: string;
+  vault_name: string;
+  default_type: string;
+  auto_rebuild: boolean;
+  index_last_rebuild?: string;
+  note_count: number;
+  notes_by_type: Record<string, number>;
+  recent_notes: NoteSummary[];
+}
+
+export interface NoteRecommendations {
+  additions: Array<{ text: string }>;
+  links: Array<{ slug: string; title: string; type: string; reason: string; source: 'mention' | 'search' }>;
+  tags: Array<{ tag: string; weight: number; source_slugs: string[] }>;
+  next_steps: Array<{ type: string; title_hint?: string; reason: string }>;
+}
+
+export interface CreateNoteInput {
+  title: string;
+  type?: string;
+  body?: string;
+  tags?: string[];
+  aliases?: string[];
+  status?: NoteStatus;
+  source?: NoteSource;
+}
+
+export interface CaptureNoteInput {
+  text: string;
+  type?: string;
+  tags?: string[];
+  aliases?: string[];
+  status?: NoteStatus;
+  source?: NoteSource;
+}
+
+export interface UpdateNoteInput {
+  title?: string;
+  body?: string;
+  append?: string;
+  tags?: string[];
+  aliases?: string[];
+  status?: NoteStatus;
+  source?: NoteSource;
+}
+
+export interface ListNotesInput {
+  type?: string;
+  status?: NoteStatus;
+  source?: NoteSource;
+  since?: string;
+  limit?: number;
+}
+
+export interface NoteMutationResult {
+  note: NoteDetails;
+  recommendations: NoteRecommendations;
+}
+
+export class GraniteMcpRuntime {
+  readonly vaultRoot: string;
+
+  private config: GraniteConfig;
+  private readonly db: Database.Database;
+  private readonly indexCheckIntervalMs: number;
+  private lastSignature?: VaultSignature;
+  private lastIndexCheckAt = 0;
+
+  constructor(vaultRoot: string, options: GraniteMcpRuntimeOptions = {}) {
+    this.vaultRoot = path.resolve(vaultRoot);
+    this.config = loadConfig(this.vaultRoot);
+    this.db = openDatabase(this.vaultRoot);
+    this.indexCheckIntervalMs = options.indexCheckIntervalMs ?? 1500;
+  }
+
+  close(): void {
+    this.db.close();
+  }
+
+  getVaultOverview(recentLimit = 10): VaultOverview {
+    const notes = this.readAllNotes()
+      .sort((a, b) => b.frontmatter.modified.localeCompare(a.frontmatter.modified));
+    const byType: Record<string, number> = {};
+
+    for (const note of notes) {
+      byType[note.frontmatter.type] = (byType[note.frontmatter.type] ?? 0) + 1;
+    }
+
+    return {
+      vault_root: this.vaultRoot,
+      vault_name: this.config.vault_name,
+      default_type: this.config.defaults.note_type,
+      auto_rebuild: this.config.index.auto_rebuild,
+      index_last_rebuild: this.getMetaValue('last_rebuild'),
+      note_count: notes.length,
+      notes_by_type: byType,
+      recent_notes: notes.slice(0, clampLimit(recentLimit, 20)).map(note => this.toNoteSummary(note)),
+    };
+  }
+
+  listNoteTypes(): NoteTypeInfo[] {
+    return Object.entries(this.config.note_types).map(([name, typeConfig]) => ({
+      name,
+      description: typeConfig.description,
+      folder: typeConfig.folder,
+      line_limit: typeConfig.line_limit,
+      warn_only: typeConfig.warn_only,
+      slug_format: typeConfig.slug_format ?? 'title',
+      instructions: typeConfig.instructions,
+      fields: typeConfig.fields,
+    }));
+  }
+
+  listNotes(input: ListNotesInput = {}): NoteSummary[] {
+    let notes = this.readAllNotes();
+
+    if (input.type) {
+      notes = notes.filter(note => note.frontmatter.type === input.type);
+    }
+
+    if (input.status) {
+      notes = notes.filter(note => note.frontmatter.status === input.status);
+    }
+
+    if (input.source) {
+      notes = notes.filter(note => note.frontmatter.source === input.source);
+    }
+
+    if (input.since) {
+      const since = input.since;
+      notes = notes.filter(note => note.frontmatter.modified >= since);
+    }
+
+    notes.sort((a, b) => b.frontmatter.modified.localeCompare(a.frontmatter.modified));
+
+    return notes
+      .slice(0, clampLimit(input.limit ?? 25, 200))
+      .map(note => this.toNoteSummary(note));
+  }
+
+  getNote(slug: string): NoteDetails {
+    const note = this.requireNote(slug);
+    const allNotes = this.readAllNotes();
+    const outgoingLinks = resolveWikilinks(parseWikilinks(note.body), allNotes);
+
+    return {
+      ...this.toNoteSummary(note),
+      body: note.body,
+      frontmatter: note.frontmatter,
+      outgoing_links: outgoingLinks,
+    };
+  }
+
+  search(query: string, limit = 10): SearchResult[] {
+    this.refreshIndex();
+    return searchNotes(this.db, query, clampLimit(limit, 50));
+  }
+
+  getBacklinks(slug: string): BacklinkEntry[] {
+    this.requireNote(slug);
+    this.refreshIndex();
+    return getBacklinks(this.db, slug);
+  }
+
+  suggestLinks(slug: string) {
+    const note = this.requireNote(slug);
+    this.refreshIndex();
+    return suggestLinks(this.db, note);
+  }
+
+  recommend(slug: string): NoteRecommendations {
+    const note = this.requireNote(slug);
+    this.refreshIndex();
+    return getRecommendations(this.db, note, this.config);
+  }
+
+  runDoctor(): { issues: DoctorIssue[]; counts: { errors: number; warnings: number; info: number } } {
+    this.refreshIndex();
+    const issues = runDoctor(this.vaultRoot, this.config, this.db);
+
+    return {
+      counts: {
+        errors: issues.filter(issue => issue.level === 'error').length,
+        warnings: issues.filter(issue => issue.level === 'warning').length,
+        info: issues.filter(issue => issue.level === 'info').length,
+      },
+      issues,
+    };
+  }
+
+  createNote(input: CreateNoteInput): NoteMutationResult {
+    const resolvedType = input.type ?? this.config.defaults.note_type;
+    const typeConfig = this.config.note_types[resolvedType];
+    if (!typeConfig) {
+      throw new Error(`Unknown note type: "${resolvedType}"`);
+    }
+
+    const bodyOverride = input.body !== undefined
+      ? ensureTrailingNewline(input.body)
+      : typeConfig.slug_format === 'date'
+        ? ensureTrailingNewline(input.title)
+        : undefined;
+
+    const created = createNote(this.vaultRoot, this.config, resolvedType, input.title, bodyOverride);
+    this.applyMutations(created.filepath, {
+      tags: input.tags,
+      aliases: input.aliases,
+      status: input.status,
+      source: input.source,
+    });
+    return this.afterWrite(created.slug, true);
+  }
+
+  captureNote(input: CaptureNoteInput): NoteMutationResult {
+    const content = input.text.trim();
+    if (!content) {
+      throw new Error('Capture text cannot be empty.');
+    }
+
+    const firstLine = content.split('\n')[0] ?? 'Untitled';
+    const title = firstLine.length > 60 ? `${firstLine.slice(0, 60).trim()}...` : firstLine;
+
+    return this.createNote({
+      title,
+      type: input.type,
+      body: ensureTrailingNewline(content),
+      tags: input.tags,
+      aliases: input.aliases,
+      status: input.status,
+      source: input.source,
+    });
+  }
+
+  updateNote(slug: string, input: UpdateNoteInput): NoteMutationResult {
+    const note = this.requireNote(slug);
+    const needsFullRebuild = input.title !== undefined || (input.aliases?.length ?? 0) > 0;
+
+    this.applyMutations(note.filepath, input);
+
+    if (needsFullRebuild) {
+      return this.afterWrite(slug, true);
+    }
+
+    this.refreshIndex();
+    const updated = readNote(note.filepath);
+    syncNoteInIndex(this.vaultRoot, this.config, this.db, updated);
+    this.captureSignature();
+
+    return {
+      note: this.getNote(updated.slug),
+      recommendations: getRecommendations(this.db, updated, this.config),
+    };
+  }
+
+  readVaultConfigRaw(): string {
+    return fs.readFileSync(path.join(this.vaultRoot, CONFIG_FILENAME), 'utf-8');
+  }
+
+  readVaultTypesJson(): string {
+    return JSON.stringify({
+      default_type: this.config.defaults.note_type,
+      note_types: this.listNoteTypes(),
+    }, null, 2);
+  }
+
+  readVaultOverviewJson(): string {
+    return JSON.stringify(this.getVaultOverview(), null, 2);
+  }
+
+  readNoteMarkdown(slug: string): string {
+    const note = this.requireNote(slug);
+    return fs.readFileSync(note.filepath, 'utf-8');
+  }
+
+  completeSlugs(prefix = ''): string[] {
+    const normalizedPrefix = prefix.toLowerCase();
+
+    return this.readAllNotes()
+      .sort((a, b) => b.frontmatter.modified.localeCompare(a.frontmatter.modified))
+      .map(note => note.slug)
+      .filter(slug => slug.toLowerCase().startsWith(normalizedPrefix))
+      .slice(0, 25);
+  }
+
+  noteResourceUri(slug: string): string {
+    return `granite://notes/${encodeURIComponent(slug)}`;
+  }
+
+  private refreshIndex(force = false): void {
+    const now = Date.now();
+    if (!force && now - this.lastIndexCheckAt < this.indexCheckIntervalMs) {
+      return;
+    }
+
+    const currentConfigMtimeMs = this.getConfigMtimeMs();
+    if (!this.lastSignature || currentConfigMtimeMs !== this.lastSignature.configMtimeMs) {
+      this.config = loadConfig(this.vaultRoot);
+    }
+
+    const signature = this.computeSignature();
+    let shouldRebuild = false;
+
+    if (force) {
+      shouldRebuild = true;
+    } else if (this.config.index.auto_rebuild) {
+      if (!this.lastSignature) {
+        shouldRebuild = signature.latestMutationMs > this.getLastRebuildMs();
+      } else {
+        shouldRebuild =
+          signature.noteCount !== this.lastSignature.noteCount ||
+          signature.latestMutationMs !== this.lastSignature.latestMutationMs ||
+          signature.configMtimeMs !== this.lastSignature.configMtimeMs;
+      }
+    }
+
+    if (shouldRebuild) {
+      rebuildIndex(this.vaultRoot, this.config, this.db);
+    }
+
+    this.lastSignature = signature;
+    this.lastIndexCheckAt = now;
+  }
+
+  private readAllNotes(): Note[] {
+    return listNotes(this.vaultRoot, this.config);
+  }
+
+  private requireNote(slug: string): Note {
+    const note = findNoteBySlug(this.vaultRoot, this.config, slug);
+    if (!note) {
+      throw new Error(`Note not found: ${slug}`);
+    }
+    return note;
+  }
+
+  private toNoteSummary(note: Note): NoteSummary {
+    return {
+      slug: note.slug,
+      title: note.frontmatter.title,
+      type: note.frontmatter.type,
+      created: note.frontmatter.created,
+      modified: note.frontmatter.modified,
+      tags: note.frontmatter.tags,
+      aliases: note.frontmatter.aliases,
+      status: note.frontmatter.status,
+      source: note.frontmatter.source,
+      filepath: note.filepath,
+      resource_uri: this.noteResourceUri(note.slug),
+    };
+  }
+
+  private applyMutations(filepath: string, input: Omit<UpdateNoteInput, 'append'> & { append?: string }): void {
+    const raw = fs.readFileSync(filepath, 'utf-8');
+    const { frontmatter, body: existingBody } = parseFrontmatter(raw);
+    let body = existingBody;
+
+    if (input.title !== undefined) {
+      frontmatter.title = input.title;
+    }
+
+    if (input.tags && input.tags.length > 0) {
+      frontmatter.tags = mergeUnique(frontmatter.tags, input.tags);
+    }
+
+    if (input.aliases && input.aliases.length > 0) {
+      frontmatter.aliases = mergeUnique(frontmatter.aliases, input.aliases);
+    }
+
+    if (input.status !== undefined) {
+      validateStatus(input.status);
+      frontmatter.status = input.status;
+    }
+
+    if (input.source !== undefined) {
+      validateSource(input.source);
+      frontmatter.source = input.source;
+    }
+
+    if (input.body !== undefined) {
+      body = ensureTrailingNewline(input.body);
+    }
+
+    if (input.append !== undefined) {
+      body = `${body.trimEnd()}\n${input.append}\n`;
+    }
+
+    frontmatter.modified = new Date().toISOString();
+    fs.writeFileSync(filepath, serializeFrontmatter(frontmatter, body), 'utf-8');
+  }
+
+  private afterWrite(slug: string, fullRebuild: boolean): NoteMutationResult {
+    if (fullRebuild) {
+      this.refreshIndex(true);
+    } else {
+      this.refreshIndex();
+      const note = this.requireNote(slug);
+      syncNoteInIndex(this.vaultRoot, this.config, this.db, note);
+      this.captureSignature();
+    }
+
+    const note = this.requireNote(slug);
+
+    return {
+      note: this.getNote(note.slug),
+      recommendations: getRecommendations(this.db, note, this.config),
+    };
+  }
+
+  private captureSignature(): void {
+    this.lastSignature = this.computeSignature();
+    this.lastIndexCheckAt = Date.now();
+  }
+
+  private computeSignature(): VaultSignature {
+    let noteCount = 0;
+    let latestNoteMtimeMs = 0;
+
+    for (const typeConfig of Object.values(this.config.note_types)) {
+      const folder = path.join(this.vaultRoot, typeConfig.folder);
+      if (!fs.existsSync(folder)) {
+        continue;
+      }
+
+      for (const entry of fs.readdirSync(folder)) {
+        if (!entry.endsWith('.md')) {
+          continue;
+        }
+
+        noteCount += 1;
+        const stat = fs.statSync(path.join(folder, entry));
+        latestNoteMtimeMs = Math.max(latestNoteMtimeMs, stat.mtimeMs);
+      }
+    }
+
+    const configMtimeMs = this.getConfigMtimeMs();
+
+    return {
+      noteCount,
+      latestMutationMs: Math.max(latestNoteMtimeMs, configMtimeMs),
+      configMtimeMs,
+    };
+  }
+
+  private getConfigMtimeMs(): number {
+    const configPath = path.join(this.vaultRoot, CONFIG_FILENAME);
+    return fs.existsSync(configPath) ? fs.statSync(configPath).mtimeMs : 0;
+  }
+
+  private getLastRebuildMs(): number {
+    const value = this.getMetaValue('last_rebuild');
+    return value ? Date.parse(value) || 0 : 0;
+  }
+
+  private getMetaValue(key: string): string | undefined {
+    const row = this.db.prepare('SELECT value FROM meta WHERE key = ?').get(key) as { value: string } | undefined;
+    return row?.value;
+  }
+}
+
+function ensureTrailingNewline(value: string): string {
+  return value.endsWith('\n') ? value : `${value}\n`;
+}
+
+function clampLimit(value: number, max: number): number {
+  return Math.max(1, Math.min(value, max));
+}
+
+function mergeUnique(existing: string[], incoming: string[]): string[] {
+  const merged = new Set(existing);
+  for (const value of incoming) {
+    const trimmed = value.trim();
+    if (trimmed) {
+      merged.add(trimmed);
+    }
+  }
+  return [...merged];
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -179,6 +179,58 @@ export function startGraniteMcpHttpServer(runtime: GraniteMcpRuntime, options: G
   });
 }
 
+export async function withResponseCleanup(
+  response: Response,
+  cleanup: () => Promise<void> | void,
+): Promise<Response> {
+  let cleanedUp = false;
+
+  const cleanupOnce = async () => {
+    if (cleanedUp) {
+      return;
+    }
+    cleanedUp = true;
+    await cleanup();
+  };
+
+  if (!response.body) {
+    await cleanupOnce();
+    return response;
+  }
+
+  const reader = response.body.getReader();
+  const wrappedBody = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        const { done, value } = await reader.read();
+        if (done) {
+          controller.close();
+          await cleanupOnce();
+          return;
+        }
+
+        controller.enqueue(value);
+      } catch (error) {
+        controller.error(error);
+        await cleanupOnce();
+      }
+    },
+    async cancel(reason) {
+      try {
+        await reader.cancel(reason);
+      } finally {
+        await cleanupOnce();
+      }
+    },
+  });
+
+  return new Response(wrappedBody, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
+}
+
 function registerTools(server: McpServer, runtime: GraniteMcpRuntime): void {
   server.registerTool('granite_get_vault_overview', {
     title: 'Granite Vault Overview',
@@ -635,14 +687,23 @@ function createGraniteMcpHttpApp(runtime: GraniteMcpRuntime, options: GraniteMcp
 
   app.all('/mcp', async (c) => {
     const origin = c.req.header('origin');
+    const server = createGraniteMcpServer(runtime);
     const transport = new WebStandardStreamableHTTPServerTransport({
       sessionIdGenerator: undefined,
       enableJsonResponse: options.jsonResponse ?? false,
     });
-    const server = createGraniteMcpServer(runtime);
-    await server.connect(transport);
-    const response = await transport.handleRequest(c.req.raw);
-    return withCors(response, origin, allowedOrigins);
+
+    try {
+      await server.connect(transport);
+      const response = await transport.handleRequest(c.req.raw);
+      const managedResponse = await withResponseCleanup(response, async () => {
+        await server.close();
+      });
+      return withCors(managedResponse, origin, allowedOrigins);
+    } catch (error) {
+      await server.close();
+      throw error;
+    }
   });
 
   return app;

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -207,7 +207,7 @@ function registerTools(server: McpServer, runtime: GraniteMcpRuntime): void {
   }, async () => {
     const noteTypes = runtime.listNoteTypes();
     return toolResult({
-      default_type: runtime.getVaultOverview(1).default_type,
+      default_type: runtime.getDefaultNoteType(),
       note_types: noteTypes,
     }, `Loaded ${noteTypes.length} Granite note types.`);
   });

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,0 +1,713 @@
+import { serve } from '@hono/node-server';
+import { Hono } from 'hono';
+import { McpServer, ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js';
+import * as z from 'zod/v4';
+import { GRANITE_VERSION } from '../version.js';
+import type { GraniteMcpRuntime, NoteRecommendations } from './runtime.js';
+
+const readOnlyAnnotations = {
+  readOnlyHint: true,
+  destructiveHint: false,
+  idempotentHint: true,
+  openWorldHint: false,
+} as const;
+
+const writeAnnotations = {
+  readOnlyHint: false,
+  destructiveHint: false,
+  idempotentHint: false,
+  openWorldHint: false,
+} as const;
+
+const fieldDefinitionSchema = z.object({
+  type: z.enum(['text', 'date', 'number', 'boolean', 'wikilink', 'list', 'enum']),
+  of: z.string().optional(),
+  options: z.array(z.string()).optional(),
+  required: z.boolean().optional(),
+  default: z.string().optional(),
+  description: z.string().optional(),
+});
+
+const noteTypeInfoSchema = z.object({
+  name: z.string(),
+  description: z.string(),
+  folder: z.string(),
+  line_limit: z.number(),
+  warn_only: z.boolean(),
+  slug_format: z.enum(['title', 'date']),
+  instructions: z.string().optional(),
+  fields: z.record(z.string(), fieldDefinitionSchema).optional(),
+});
+
+const noteSummarySchema = z.object({
+  slug: z.string(),
+  title: z.string(),
+  type: z.string(),
+  created: z.string(),
+  modified: z.string(),
+  tags: z.array(z.string()),
+  aliases: z.array(z.string()),
+  status: z.enum(['inbox', 'active', 'archived']),
+  source: z.enum(['human', 'agent', 'extraction']),
+  filepath: z.string(),
+  resource_uri: z.string(),
+});
+
+const wikiLinkSchema = z.object({
+  raw: z.string(),
+  target: z.string(),
+  display: z.string(),
+  resolved: z.boolean(),
+  resolved_slug: z.string().optional(),
+});
+
+const noteDetailsSchema = noteSummarySchema.extend({
+  body: z.string(),
+  frontmatter: z.record(z.string(), z.unknown()),
+  outgoing_links: z.array(wikiLinkSchema),
+});
+
+const searchResultSchema = z.object({
+  slug: z.string(),
+  title: z.string(),
+  snippet: z.string(),
+  score: z.number(),
+});
+
+const backlinkSchema = z.object({
+  source_slug: z.string(),
+  source_title: z.string(),
+  context: z.string(),
+});
+
+const linkSuggestionSchema = z.object({
+  target_slug: z.string(),
+  target_title: z.string(),
+  mentions: z.number(),
+});
+
+const recommendationSchema = z.object({
+  additions: z.array(z.object({ text: z.string() })),
+  links: z.array(z.object({
+    slug: z.string(),
+    title: z.string(),
+    type: z.string(),
+    reason: z.string(),
+    source: z.enum(['mention', 'search']),
+  })),
+  tags: z.array(z.object({
+    tag: z.string(),
+    weight: z.number(),
+    source_slugs: z.array(z.string()),
+  })),
+  next_steps: z.array(z.object({
+    type: z.string(),
+    title_hint: z.string().optional(),
+    reason: z.string(),
+  })),
+});
+
+const doctorIssueSchema = z.object({
+  level: z.enum(['error', 'warning', 'info']),
+  file: z.string(),
+  message: z.string(),
+});
+
+const vaultOverviewSchema = z.object({
+  vault_root: z.string(),
+  vault_name: z.string(),
+  default_type: z.string(),
+  auto_rebuild: z.boolean(),
+  index_last_rebuild: z.string().optional(),
+  note_count: z.number(),
+  notes_by_type: z.record(z.string(), z.number()),
+  recent_notes: z.array(noteSummarySchema),
+});
+
+export interface GraniteMcpHttpServerOptions {
+  host: string;
+  port: number;
+  allowedOrigins?: string[];
+  jsonResponse?: boolean;
+}
+
+export function createGraniteMcpServer(runtime: GraniteMcpRuntime): McpServer {
+  const server = new McpServer(
+    {
+      name: 'granite',
+      version: GRANITE_VERSION,
+      title: 'Granite MCP Server',
+    },
+    {
+      capabilities: { logging: {} },
+      instructions: [
+        'Granite exposes a local-first markdown vault.',
+        'Prefer read tools and resources first, then write with granite_create_note or granite_update_note.',
+        'Resources are read-only views; notes live on disk and the SQLite index is derived state.',
+        'Use granite_recommend_note_actions to preserve Granite’s capture -> link -> recommend loop.',
+      ].join(' '),
+    },
+  );
+
+  registerTools(server, runtime);
+  registerResources(server, runtime);
+  registerPrompts(server, runtime);
+
+  return server;
+}
+
+export async function startGraniteMcpStdioServer(runtime: GraniteMcpRuntime): Promise<void> {
+  const server = createGraniteMcpServer(runtime);
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error(`Granite MCP server listening on stdio for ${runtime.vaultRoot}`);
+}
+
+export function startGraniteMcpHttpServer(runtime: GraniteMcpRuntime, options: GraniteMcpHttpServerOptions): void {
+  const app = createGraniteMcpHttpApp(runtime, options);
+
+  console.error(`Granite MCP server listening on http://${options.host}:${options.port}/mcp`);
+  console.error(`Health check: http://${options.host}:${options.port}/health`);
+  console.error(`Vault: ${runtime.vaultRoot}`);
+
+  serve({
+    fetch: app.fetch,
+    hostname: options.host,
+    port: options.port,
+  });
+}
+
+function registerTools(server: McpServer, runtime: GraniteMcpRuntime): void {
+  server.registerTool('granite_get_vault_overview', {
+    title: 'Granite Vault Overview',
+    description: 'Summarize the current Granite vault, including counts by type and recent notes.',
+    inputSchema: {
+      recent_limit: z.number().int().min(1).max(20).optional().describe('How many recent notes to include. Defaults to 10.'),
+    },
+    outputSchema: vaultOverviewSchema,
+    annotations: readOnlyAnnotations,
+  }, async ({ recent_limit }) => {
+    const overview = runtime.getVaultOverview(recent_limit ?? 10);
+    return toolResult(
+      overview,
+      `Vault "${overview.vault_name}" with ${overview.note_count} notes.`,
+    );
+  });
+
+  server.registerTool('granite_list_note_types', {
+    title: 'Granite Note Types',
+    description: 'List the note types configured in the vault.',
+    outputSchema: z.object({
+      default_type: z.string(),
+      note_types: z.array(noteTypeInfoSchema),
+    }),
+    annotations: readOnlyAnnotations,
+  }, async () => {
+    const noteTypes = runtime.listNoteTypes();
+    return toolResult({
+      default_type: runtime.getVaultOverview(1).default_type,
+      note_types: noteTypes,
+    }, `Loaded ${noteTypes.length} Granite note types.`);
+  });
+
+  server.registerTool('granite_list_notes', {
+    title: 'List Granite Notes',
+    description: 'List notes from the Granite vault with optional filters.',
+    inputSchema: {
+      type: z.string().optional().describe('Filter by note type.'),
+      status: z.enum(['inbox', 'active', 'archived']).optional().describe('Filter by note status.'),
+      source: z.enum(['human', 'agent', 'extraction']).optional().describe('Filter by note source.'),
+      since: z.string().optional().describe('Only notes modified on or after this ISO or YYYY-MM-DD value.'),
+      limit: z.number().int().min(1).max(200).optional().describe('Maximum number of notes to return. Defaults to 25.'),
+    },
+    outputSchema: z.object({
+      notes: z.array(noteSummarySchema),
+      total: z.number(),
+    }),
+    annotations: readOnlyAnnotations,
+  }, async (args) => {
+    const notes = runtime.listNotes(args);
+    return toolResult({
+      notes,
+      total: notes.length,
+    }, `Returned ${notes.length} note(s).`);
+  });
+
+  server.registerTool('granite_get_note', {
+    title: 'Get Granite Note',
+    description: 'Read a Granite note by slug, including frontmatter, body, and resolved outgoing links.',
+    inputSchema: {
+      slug: z.string().describe('The note slug.'),
+    },
+    outputSchema: noteDetailsSchema,
+    annotations: readOnlyAnnotations,
+  }, async ({ slug }) => {
+    const note = runtime.getNote(slug);
+    return {
+      ...toolResult(note, `Loaded "${note.title}" (${note.slug}).`),
+      content: [
+        { type: 'text', text: `Loaded "${note.title}" (${note.slug}).` },
+        createNoteResourceLink(note.title, note.resource_uri),
+      ],
+    };
+  });
+
+  server.registerTool('granite_search_notes', {
+    title: 'Search Granite Notes',
+    description: 'Run full-text search against the Granite index.',
+    inputSchema: {
+      query: z.string().describe('Full-text query for the SQLite FTS index.'),
+      limit: z.number().int().min(1).max(50).optional().describe('Maximum number of search results. Defaults to 10.'),
+    },
+    outputSchema: z.object({
+      query: z.string(),
+      results: z.array(searchResultSchema),
+    }),
+    annotations: readOnlyAnnotations,
+  }, async ({ query, limit }) => {
+    const results = runtime.search(query, limit ?? 10);
+    return toolResult({
+      query,
+      results,
+    }, `Found ${results.length} result(s) for "${query}".`);
+  });
+
+  server.registerTool('granite_create_note', {
+    title: 'Create Granite Note',
+    description: 'Create a new note in the Granite vault.',
+    inputSchema: {
+      title: z.string().describe('Note title.'),
+      type: z.string().optional().describe('Note type. Defaults to the vault default type.'),
+      body: z.string().optional().describe('Optional note body. If omitted, Granite uses the type template.'),
+      tags: z.array(z.string()).optional().describe('Tags to add immediately.'),
+      aliases: z.array(z.string()).optional().describe('Aliases to add immediately.'),
+      status: z.enum(['inbox', 'active', 'archived']).optional().describe('Initial note status.'),
+      source: z.enum(['human', 'agent', 'extraction']).optional().describe('Initial note source.'),
+    },
+    outputSchema: z.object({
+      note: noteDetailsSchema,
+      recommendations: recommendationSchema,
+    }),
+    annotations: writeAnnotations,
+  }, async (args) => {
+    const result = runtime.createNote(args);
+    return toolResult(result, `Created "${result.note.title}" (${result.note.slug}).`);
+  });
+
+  server.registerTool('granite_capture_note', {
+    title: 'Capture Granite Note',
+    description: 'Quick-capture a note from free-form text, similar to mem add.',
+    inputSchema: {
+      text: z.string().describe('Raw capture text.'),
+      type: z.string().optional().describe('Optional note type override. Defaults to the vault default type.'),
+      tags: z.array(z.string()).optional().describe('Tags to add immediately.'),
+      aliases: z.array(z.string()).optional().describe('Aliases to add immediately.'),
+      status: z.enum(['inbox', 'active', 'archived']).optional().describe('Initial note status.'),
+      source: z.enum(['human', 'agent', 'extraction']).optional().describe('Initial note source.'),
+    },
+    outputSchema: z.object({
+      note: noteDetailsSchema,
+      recommendations: recommendationSchema,
+    }),
+    annotations: writeAnnotations,
+  }, async (args) => {
+    const result = runtime.captureNote(args);
+    return toolResult(result, `Captured "${result.note.title}" (${result.note.slug}).`);
+  });
+
+  server.registerTool('granite_update_note', {
+    title: 'Update Granite Note',
+    description: 'Update frontmatter or body fields for an existing Granite note.',
+    inputSchema: {
+      slug: z.string().describe('Slug of the note to update.'),
+      title: z.string().optional().describe('Replace the note title.'),
+      body: z.string().optional().describe('Replace the entire note body.'),
+      append: z.string().optional().describe('Append text to the existing note body.'),
+      tags: z.array(z.string()).optional().describe('Tags to add.'),
+      aliases: z.array(z.string()).optional().describe('Aliases to add.'),
+      status: z.enum(['inbox', 'active', 'archived']).optional().describe('New note status.'),
+      source: z.enum(['human', 'agent', 'extraction']).optional().describe('New note source.'),
+    },
+    outputSchema: z.object({
+      note: noteDetailsSchema,
+      recommendations: recommendationSchema,
+    }),
+    annotations: writeAnnotations,
+  }, async ({ slug, ...updates }) => {
+    const result = runtime.updateNote(slug, updates);
+    return toolResult(result, `Updated "${result.note.title}" (${result.note.slug}).`);
+  });
+
+  server.registerTool('granite_get_backlinks', {
+    title: 'Granite Backlinks',
+    description: 'List notes that link to a given Granite note.',
+    inputSchema: {
+      slug: z.string().describe('Slug of the target note.'),
+    },
+    outputSchema: z.object({
+      slug: z.string(),
+      backlinks: z.array(backlinkSchema),
+    }),
+    annotations: readOnlyAnnotations,
+  }, async ({ slug }) => {
+    const backlinks = runtime.getBacklinks(slug);
+    return toolResult({
+      slug,
+      backlinks,
+    }, `Found ${backlinks.length} backlink(s) for "${slug}".`);
+  });
+
+  server.registerTool('granite_suggest_links', {
+    title: 'Suggest Granite Links',
+    description: 'Suggest missing wikilinks for a Granite note based on mentions.',
+    inputSchema: {
+      slug: z.string().describe('Slug of the note to inspect.'),
+    },
+    outputSchema: z.object({
+      slug: z.string(),
+      suggestions: z.array(linkSuggestionSchema),
+    }),
+    annotations: readOnlyAnnotations,
+  }, async ({ slug }) => {
+    const suggestions = runtime.suggestLinks(slug);
+    return toolResult({
+      slug,
+      suggestions,
+    }, `Found ${suggestions.length} suggested link(s) for "${slug}".`);
+  });
+
+  server.registerTool('granite_recommend_note_actions', {
+    title: 'Recommend Granite Actions',
+    description: 'Recommend follow-up links, tags, additions, and next notes for a Granite note.',
+    inputSchema: {
+      slug: z.string().describe('Slug of the note to analyze.'),
+    },
+    outputSchema: z.object({
+      slug: z.string(),
+      recommendations: recommendationSchema,
+    }),
+    annotations: readOnlyAnnotations,
+  }, async ({ slug }) => {
+    const recommendations = runtime.recommend(slug);
+    return toolResult({
+      slug,
+      recommendations,
+    }, recommendationSummary(recommendations));
+  });
+
+  server.registerTool('granite_run_doctor', {
+    title: 'Run Granite Doctor',
+    description: 'Validate vault health and report structural issues.',
+    outputSchema: z.object({
+      issues: z.array(doctorIssueSchema),
+      counts: z.object({
+        errors: z.number(),
+        warnings: z.number(),
+        info: z.number(),
+      }),
+    }),
+    annotations: readOnlyAnnotations,
+  }, async () => {
+    const result = runtime.runDoctor();
+    return toolResult(
+      result,
+      `${result.counts.errors} error(s), ${result.counts.warnings} warning(s), ${result.counts.info} info item(s).`,
+    );
+  });
+}
+
+function registerResources(server: McpServer, runtime: GraniteMcpRuntime): void {
+  server.registerResource('granite-vault-config', 'granite://vault/config', {
+    title: 'Granite Config',
+    description: 'Raw granite.yml configuration for the current vault.',
+    mimeType: 'text/yaml',
+  }, async () => ({
+    contents: [{
+      uri: 'granite://vault/config',
+      text: runtime.readVaultConfigRaw(),
+      mimeType: 'text/yaml',
+    }],
+  }));
+
+  server.registerResource('granite-vault-overview', 'granite://vault/overview', {
+    title: 'Granite Vault Overview',
+    description: 'Structured summary of the current vault.',
+    mimeType: 'application/json',
+  }, async () => ({
+    contents: [{
+      uri: 'granite://vault/overview',
+      text: runtime.readVaultOverviewJson(),
+      mimeType: 'application/json',
+    }],
+  }));
+
+  server.registerResource('granite-note-types', 'granite://vault/types', {
+    title: 'Granite Note Types',
+    description: 'Structured list of the note types configured in the current vault.',
+    mimeType: 'application/json',
+  }, async () => ({
+    contents: [{
+      uri: 'granite://vault/types',
+      text: runtime.readVaultTypesJson(),
+      mimeType: 'application/json',
+    }],
+  }));
+
+  const noteTemplate = new ResourceTemplate('granite://notes/{slug}', {
+    list: undefined,
+    complete: {
+      slug: async (value) => runtime.completeSlugs(value),
+    },
+  });
+
+  server.registerResource('granite-note', noteTemplate, {
+    title: 'Granite Note',
+    description: 'Read a Granite note as markdown with YAML frontmatter.',
+    mimeType: 'text/markdown',
+  }, async (uri, variables) => {
+    const variable = variables.slug;
+    const slug = Array.isArray(variable) ? variable[0] : variable;
+    if (!slug) {
+      throw new Error('Resource URI is missing the note slug.');
+    }
+
+    return {
+      contents: [{
+        uri: uri.toString(),
+        text: runtime.readNoteMarkdown(decodeURIComponent(slug)),
+        mimeType: 'text/markdown',
+      }],
+    };
+  });
+}
+
+function registerPrompts(server: McpServer, runtime: GraniteMcpRuntime): void {
+  server.registerPrompt('granite_refine_note', {
+    title: 'Refine Granite Note',
+    description: 'Create a prompt for turning a note into a cleaner permanent note draft.',
+    argsSchema: {
+      slug: z.string().describe('Slug of the note to refine.'),
+    },
+  }, async ({ slug }) => {
+    const note = runtime.getNote(slug);
+
+    return {
+      description: `Refine ${note.slug} into a durable Granite note.`,
+      messages: [
+        {
+          role: 'user',
+          content: {
+            type: 'text',
+            text: [
+              'Refine the attached Granite note into a durable, well-structured permanent note.',
+              'Keep the meaning intact, avoid inventing facts, preserve useful wikilinks, and use Granite-style headings when appropriate.',
+            ].join(' '),
+          },
+        },
+        {
+          role: 'user',
+          content: {
+            type: 'resource',
+            resource: {
+              uri: note.resource_uri,
+              text: runtime.readNoteMarkdown(slug),
+              mimeType: 'text/markdown',
+            },
+          },
+        },
+      ],
+    };
+  });
+
+  server.registerPrompt('granite_review_connections', {
+    title: 'Review Granite Connections',
+    description: 'Create a prompt for improving note links, tags, and next steps.',
+    argsSchema: {
+      slug: z.string().describe('Slug of the note to inspect.'),
+    },
+  }, async ({ slug }) => {
+    const note = runtime.getNote(slug);
+    const backlinks = runtime.getBacklinks(slug);
+    const recommendations = runtime.recommend(slug);
+
+    return {
+      description: `Review the connections around ${note.slug}.`,
+      messages: [
+        {
+          role: 'user',
+          content: {
+            type: 'text',
+            text: [
+              'Review this Granite note and propose better links, tags, and the most useful follow-up note.',
+              'Prefer concrete suggestions grounded in the vault context below.',
+            ].join(' '),
+          },
+        },
+        {
+          role: 'user',
+          content: {
+            type: 'resource',
+            resource: {
+              uri: note.resource_uri,
+              text: runtime.readNoteMarkdown(slug),
+              mimeType: 'text/markdown',
+            },
+          },
+        },
+        {
+          role: 'user',
+          content: {
+            type: 'text',
+            text: JSON.stringify({ backlinks, recommendations }, null, 2),
+          },
+        },
+      ],
+    };
+  });
+}
+
+function toolResult<T>(structuredContent: T, summary: string) {
+  return {
+    content: [{ type: 'text' as const, text: summary }],
+    structuredContent: asStructuredContent(structuredContent),
+  };
+}
+
+function createNoteResourceLink(name: string, uri: string) {
+  return {
+    type: 'resource_link' as const,
+    name,
+    uri,
+    mimeType: 'text/markdown',
+    description: 'Read the markdown resource for this note.',
+  };
+}
+
+function recommendationSummary(recommendations: NoteRecommendations): string {
+  return [
+    `${recommendations.links.length} link suggestion(s)`,
+    `${recommendations.tags.length} tag suggestion(s)`,
+    `${recommendations.next_steps.length} next-step suggestion(s)`,
+  ].join(', ');
+}
+
+function asStructuredContent<T>(value: T): Record<string, unknown> {
+  return JSON.parse(JSON.stringify(value)) as Record<string, unknown>;
+}
+
+function createGraniteMcpHttpApp(runtime: GraniteMcpRuntime, options: GraniteMcpHttpServerOptions): Hono {
+  const app = new Hono();
+  const allowedHosts = buildAllowedHosts(options.host, options.port);
+  const allowedOrigins = buildAllowedOrigins(options.host, options.port, options.allowedOrigins ?? []);
+
+  app.use('/mcp', async (c, next) => {
+    const requestHost = (c.req.header('host') ?? '').toLowerCase();
+    if (allowedHosts.size > 0 && !allowedHosts.has(requestHost)) {
+      return c.json({
+        jsonrpc: '2.0',
+        error: { code: -32000, message: 'Forbidden host header.' },
+        id: null,
+      }, 403);
+    }
+
+    const origin = c.req.header('origin');
+    if (origin && !allowedOrigins.has(origin)) {
+      return c.json({
+        jsonrpc: '2.0',
+        error: { code: -32000, message: 'Forbidden origin.' },
+        id: null,
+      }, 403);
+    }
+
+    if (c.req.method === 'OPTIONS') {
+      return new Response(null, {
+        status: 204,
+        headers: corsHeaders(origin, allowedOrigins),
+      });
+    }
+
+    await next();
+  });
+
+  app.get('/health', c => c.json({ status: 'ok', name: 'granite-mcp', version: GRANITE_VERSION }));
+
+  app.all('/mcp', async (c) => {
+    const origin = c.req.header('origin');
+    const transport = new WebStandardStreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+      enableJsonResponse: options.jsonResponse ?? false,
+    });
+    const server = createGraniteMcpServer(runtime);
+    await server.connect(transport);
+    const response = await transport.handleRequest(c.req.raw);
+    return withCors(response, origin, allowedOrigins);
+  });
+
+  return app;
+}
+
+function buildAllowedHosts(host: string, port: number): Set<string> {
+  const normalizedHost = host.toLowerCase();
+  if (normalizedHost === '0.0.0.0' || normalizedHost === '::' || normalizedHost === '[::]') {
+    return new Set<string>();
+  }
+
+  const allowed = new Set<string>([`${normalizedHost}:${port}`]);
+
+  if (normalizedHost === '127.0.0.1' || normalizedHost === 'localhost') {
+    allowed.add(`127.0.0.1:${port}`);
+    allowed.add(`localhost:${port}`);
+  }
+
+  if (normalizedHost === '::1' || normalizedHost === '[::1]') {
+    allowed.add(`[::1]:${port}`);
+  }
+
+  return allowed;
+}
+
+function buildAllowedOrigins(host: string, port: number, extraOrigins: string[]): Set<string> {
+  const allowed = new Set<string>(extraOrigins);
+  const normalizedHost = host.toLowerCase();
+
+  if (normalizedHost === '::1' || normalizedHost === '[::1]') {
+    allowed.add(`http://[::1]:${port}`);
+  } else if (normalizedHost !== '0.0.0.0' && normalizedHost !== '::' && normalizedHost !== '[::]') {
+    allowed.add(`http://${normalizedHost}:${port}`);
+  }
+
+  if (normalizedHost === '127.0.0.1' || normalizedHost === 'localhost') {
+    allowed.add(`http://127.0.0.1:${port}`);
+    allowed.add(`http://localhost:${port}`);
+  }
+
+  return allowed;
+}
+
+function withCors(response: Response, origin: string | undefined, allowedOrigins: Set<string>): Response {
+  const headers = new Headers(response.headers);
+
+  for (const [key, value] of corsHeaders(origin, allowedOrigins)) {
+    headers.set(key, value);
+  }
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+function corsHeaders(origin: string | undefined, allowedOrigins: Set<string>): Headers {
+  const headers = new Headers();
+  if (origin && allowedOrigins.has(origin)) {
+    headers.set('Access-Control-Allow-Origin', origin);
+    headers.set('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
+    headers.set('Access-Control-Allow-Headers', 'Content-Type, MCP-Protocol-Version, Last-Event-ID');
+    headers.set('Access-Control-Expose-Headers', 'MCP-Session-Id, MCP-Protocol-Version');
+    headers.set('Vary', 'Origin');
+  }
+  return headers;
+}

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,1 @@
+export const GRANITE_VERSION = '0.1.2';

--- a/test/commands/mcp.test.ts
+++ b/test/commands/mcp.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { parsePort, parseTransport } from '../../src/commands/mcp.js';
+
+const originalMcpPort = process.env.MCP_PORT;
+
+describe('mcp command helpers', () => {
+  afterEach(() => {
+    if (originalMcpPort === undefined) {
+      delete process.env.MCP_PORT;
+    } else {
+      process.env.MCP_PORT = originalMcpPort;
+    }
+  });
+
+  it('prefers the explicit port over MCP_PORT', () => {
+    process.env.MCP_PORT = '4444';
+    expect(parsePort('5555')).toBe(5555);
+  });
+
+  it('falls back to MCP_PORT and then the default port', () => {
+    process.env.MCP_PORT = '4444';
+    expect(parsePort()).toBe(4444);
+
+    delete process.env.MCP_PORT;
+    expect(parsePort()).toBe(3321);
+  });
+
+  it('rejects invalid transport values', () => {
+    expect(() => parseTransport('streamable-http' as 'stdio')).toThrow('Invalid MCP transport');
+  });
+});

--- a/test/mcp/runtime.test.ts
+++ b/test/mcp/runtime.test.ts
@@ -1,0 +1,42 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { writeDefaultConfig, loadConfig } from '../../src/core/config.js';
+import { createNote } from '../../src/core/note.js';
+import type { GraniteConfig } from '../../src/core/types.js';
+import { GraniteMcpRuntime } from '../../src/mcp/runtime.js';
+
+describe('GraniteMcpRuntime', () => {
+  let tmpDir: string;
+  let config: GraniteConfig;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'granite-runtime-'));
+    writeDefaultConfig(tmpDir);
+    config = loadConfig(tmpDir);
+
+    for (const typeConfig of Object.values(config.note_types)) {
+      fs.mkdirSync(path.join(tmpDir, typeConfig.folder), { recursive: true });
+    }
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('rebuilds a stale index on first refresh after a note deletion', () => {
+    createNote(tmpDir, config, 'permanent', 'Stable Note', 'Persistent note.\n');
+    const deleted = createNote(tmpDir, config, 'permanent', 'Deleted Note', 'Unique deleted content.\n');
+
+    let runtime = new GraniteMcpRuntime(tmpDir, { indexCheckIntervalMs: 0 });
+    expect(runtime.search('deleted')).toHaveLength(1);
+    runtime.close();
+
+    fs.unlinkSync(deleted.filepath);
+
+    runtime = new GraniteMcpRuntime(tmpDir, { indexCheckIntervalMs: 0 });
+    expect(runtime.search('deleted')).toHaveLength(0);
+    runtime.close();
+  });
+});

--- a/test/mcp/runtime.test.ts
+++ b/test/mcp/runtime.test.ts
@@ -39,4 +39,16 @@ describe('GraniteMcpRuntime', () => {
     expect(runtime.search('deleted')).toHaveLength(0);
     runtime.close();
   });
+
+  it('preserves created and modified timestamps when no metadata mutations are requested', () => {
+    const runtime = new GraniteMcpRuntime(tmpDir, { indexCheckIntervalMs: 0 });
+    const result = runtime.createNote({
+      title: 'Fresh Note',
+      type: 'permanent',
+      body: 'No extra metadata.\n',
+    });
+
+    expect(result.note.frontmatter.created).toBe(result.note.frontmatter.modified);
+    runtime.close();
+  });
 });

--- a/test/mcp/server.test.ts
+++ b/test/mcp/server.test.ts
@@ -1,0 +1,109 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { writeDefaultConfig, loadConfig } from '../../src/core/config.js';
+import { createNote } from '../../src/core/note.js';
+import type { GraniteConfig } from '../../src/core/types.js';
+import { GraniteMcpRuntime } from '../../src/mcp/runtime.js';
+import { createGraniteMcpServer } from '../../src/mcp/server.js';
+
+describe('granite MCP server', () => {
+  let tmpDir: string;
+  let config: GraniteConfig;
+  let runtime: GraniteMcpRuntime;
+  let server: ReturnType<typeof createGraniteMcpServer>;
+  let client: Client;
+
+  beforeEach(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'granite-mcp-'));
+    writeDefaultConfig(tmpDir);
+    config = loadConfig(tmpDir);
+
+    for (const typeConfig of Object.values(config.note_types)) {
+      fs.mkdirSync(path.join(tmpDir, typeConfig.folder), { recursive: true });
+    }
+
+    createNote(tmpDir, config, 'permanent', 'MCP Note', 'Granite MCP test note.\n');
+
+    runtime = new GraniteMcpRuntime(tmpDir, { indexCheckIntervalMs: 0 });
+    server = createGraniteMcpServer(runtime);
+    client = new Client({ name: 'granite-test-client', version: '1.0.0' });
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+  });
+
+  afterEach(async () => {
+    await client.close();
+    await server.close();
+    runtime.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('exposes tools, resources, prompts, and instructions', async () => {
+    const tools = await client.listTools();
+    const resources = await client.listResources();
+    const templates = await client.listResourceTemplates();
+    const prompts = await client.listPrompts();
+
+    expect(tools.tools.some(tool => tool.name === 'granite_create_note')).toBe(true);
+    expect(resources.resources.some(resource => resource.uri === 'granite://vault/config')).toBe(true);
+    expect(templates.resourceTemplates.some(template => template.uriTemplate === 'granite://notes/{slug}')).toBe(true);
+    expect(prompts.prompts.some(prompt => prompt.name === 'granite_refine_note')).toBe(true);
+    expect(client.getInstructions()).toContain('Granite exposes a local-first markdown vault.');
+  });
+
+  it('serves note resources and prompt templates', async () => {
+    const resource = await client.readResource({ uri: 'granite://notes/mcp-note' });
+    const prompt = await client.getPrompt({
+      name: 'granite_review_connections',
+      arguments: { slug: 'mcp-note' },
+    });
+
+    const noteText = resource.contents[0] && 'text' in resource.contents[0] ? resource.contents[0].text : '';
+
+    expect(noteText).toContain('title: MCP Note');
+    expect(prompt.messages).toHaveLength(3);
+  });
+
+  it('creates notes and updates backlinks through MCP tools', async () => {
+    const created = await client.callTool({
+      name: 'granite_create_note',
+      arguments: {
+        title: 'Linked Result',
+        type: 'permanent',
+        body: 'This note points to [[MCP Note]].\n',
+        source: 'agent',
+      },
+    });
+
+    const createdData = extractStructuredContent(created) as {
+      note: { slug: string; source: string };
+    };
+
+    expect(createdData.note.slug).toBe('linked-result');
+    expect(createdData.note.source).toBe('agent');
+
+    const backlinks = await client.callTool({
+      name: 'granite_get_backlinks',
+      arguments: { slug: 'mcp-note' },
+    });
+
+    const backlinkData = extractStructuredContent(backlinks) as {
+      backlinks: Array<{ source_slug: string }>;
+    };
+
+    expect(backlinkData.backlinks.some(link => link.source_slug === 'linked-result')).toBe(true);
+  });
+});
+
+function extractStructuredContent(result: Awaited<ReturnType<Client['callTool']>>) {
+  if (!('structuredContent' in result) || !result.structuredContent) {
+    throw new Error('Tool result did not include structuredContent.');
+  }
+  return result.structuredContent;
+}

--- a/test/mcp/server.test.ts
+++ b/test/mcp/server.test.ts
@@ -8,7 +8,7 @@ import { writeDefaultConfig, loadConfig } from '../../src/core/config.js';
 import { createNote } from '../../src/core/note.js';
 import type { GraniteConfig } from '../../src/core/types.js';
 import { GraniteMcpRuntime } from '../../src/mcp/runtime.js';
-import { createGraniteMcpServer } from '../../src/mcp/server.js';
+import { createGraniteMcpServer, withResponseCleanup } from '../../src/mcp/server.js';
 
 describe('granite MCP server', () => {
   let tmpDir: string;
@@ -98,6 +98,18 @@ describe('granite MCP server', () => {
     };
 
     expect(backlinkData.backlinks.some(link => link.source_slug === 'linked-result')).toBe(true);
+  });
+
+  it('closes cleanup hooks after an HTTP response body is consumed', async () => {
+    let cleanupCount = 0;
+    const response = new Response('granite');
+
+    const wrapped = await withResponseCleanup(response, async () => {
+      cleanupCount += 1;
+    });
+
+    expect(await wrapped.text()).toBe('granite');
+    expect(cleanupCount).toBe(1);
   });
 });
 


### PR DESCRIPTION
## Summary
- add a Granite MCP server with stdio and Streamable HTTP transports via the official TypeScript SDK
- expose Granite tools, resources, and prompts through a shared runtime that keeps the SQLite index fresh without needless rebuilds
- document `mem mcp`, add MCP smoke tests, and fix incremental index syncing for `status` and `source`

## Why
Granite was already agent-friendly from the CLI, but not directly controllable as an MCP server. This adds a first-class MCP surface so local and remote MCP clients can drive the vault with structured tools and resources.

## Validation
- `npm run lint`
- `npm run test`
- `npm run build`
- `node dist/index.js mcp --help`

## Notes
- PR is opened as draft while CI and external review feedback come in.
- HTTP mode includes host/origin checks for local-safe defaults.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a built-in MCP server for Granite with stdio and streamable HTTP transports, launched via `mem mcp`. Lets local or remote MCP clients use Granite tools, resources, and prompts while keeping the SQLite index fresh and safe by default.

- **New Features**
  - New `mem mcp` command with `--transport {stdio|http}`, `--host`, `--port` or `MCP_PORT`, `--allow-origin`, and `--json-response`.
  - Streamable HTTP mode with local-safe defaults and strict host/origin checks.
  - Shared MCP runtime exposing tools, resources, and prompts without needless SQLite rebuilds.
  - Docs updated; version now read from `GRANITE_VERSION` (0.1.2). Adds `@modelcontextprotocol/sdk` and `zod`. Basic MCP server/runtime tests included.

- **Bug Fixes**
  - Incremental index now syncs `status` and `source`.
  - Search accepts a capped `limit` for bounded results.
  - CLI validation tightened: invalid `--transport` rejected; explicit `--port` overrides `MCP_PORT`.
  - Exported `LinkSuggestion` for reuse.

<sup>Written for commit d9f1bd022c0a3c64b9d36c8ece4a1133c365cf2f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new long-running MCP server surface (stdio + HTTP) that can create/update notes on disk and exposes an HTTP endpoint with CORS/host checks, so misconfiguration could broaden access. Also changes SQLite indexing behavior to include new fields and variable search limits, which could affect query results and rebuild frequency.
> 
> **Overview**
> **Adds an MCP server surface to Granite.** Introduces `mem mcp` with stdio or Streamable HTTP transports, configurable vault selection, host/port/origin controls, and shared `GRANITE_VERSION` wiring for CLI versioning.
> 
> **Exposes vault operations via MCP.** Adds `GraniteMcpRuntime` and server registration for tools (list/get/search/create/update/backlinks/suggestions/recommendations/doctor), resources (config/overview/types and `granite://notes/{slug}`), and prompts for note refinement/review; HTTP mode includes host-header and Origin allowlisting plus optional JSON responses.
> 
> **Indexing/SDK plumbing updates.** SQLite upserts now persist `status`/`source`, full-text search accepts a capped `limit`, `LinkSuggestion` is exported for reuse, and new tests cover MCP command parsing, runtime index refresh behavior, and MCP server integration. Dependencies add `@modelcontextprotocol/sdk` and `zod` (lockfile updated accordingly), and README documents MCP usage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d9f1bd022c0a3c64b9d36c8ece4a1133c365cf2f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->