### PR TITLE
fix: harden CI and release-please workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,11 @@ jobs:
         with:
           node-version: 22
           cache: npm
-      - run: npm ci
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build
       - name: Typecheck
         run: npm run lint
-      - name: Test
-        run: npm test
+      - name: Run tests with coverage
+        run: npm run test:coverage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 permissions:
   contents: write
   pull-requests: write
@@ -17,7 +20,7 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
   publish:
     needs: release-please
@@ -35,10 +38,17 @@ jobs:
           cache: npm
           registry-url: https://registry.npmjs.org
 
-      - run: npm ci
+      - name: Install dependencies
+        run: npm ci
 
       - name: Build
         run: npm run build
+
+      - name: Typecheck
+        run: npm run lint
+
+      - name: Test with coverage
+        run: npm run test:coverage
 
       - name: Publish to npm
         run: npm publish --provenance --access public

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@types/js-yaml": "^4.0.0",
         "@types/node": "^22.0.0",
         "@types/uuid": "^10.0.0",
+        "@vitest/coverage-v8": "^3.2.4",
         "commitizen": "^4.3.1",
         "cz-conventional-changelog": "^3.3.0",
         "husky": "^9.1.7",
@@ -36,6 +37,20 @@
         "tsx": "^4.0.0",
         "typescript": "^5.7.0",
         "vitest": "^3.0.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -60,6 +75,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
@@ -68,6 +93,46 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@commitlint/cli": {
@@ -827,6 +892,119 @@
         "hono": "^4"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -904,6 +1082,17 @@
         "zod": {
           "optional": false
         }
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -1344,6 +1533,40 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
@@ -1586,6 +1809,25 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
@@ -2412,6 +2654,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -2883,6 +3132,36 @@
         "rollup": "^4.34.8"
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/foreground-child/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -3228,6 +3507,13 @@
       "engines": {
         "node": ">=16.9.0"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/http-errors": {
       "version": "2.0.1",
@@ -3615,6 +3901,99 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -3900,6 +4279,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -3908,6 +4294,34 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/math-intrinsics": {
@@ -4054,6 +4468,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/mkdirp-classic": {
@@ -4314,6 +4738,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -4382,6 +4813,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/path-to-regexp": {
@@ -5157,7 +5605,37 @@
         "node": ">=8"
       }
     },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -5283,6 +5761,115 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/test-exclude/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/test-exclude/node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/thenify": {
@@ -5860,6 +6447,61 @@
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/wrap-ansi/node_modules/ansi-styles": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "build": "tsup && rm -rf dist/public && cp -r src/web/public dist/public",
     "dev": "tsx src/index.ts",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
     "lint": "tsc --noEmit",
     "prepare": "husky"
@@ -49,6 +50,7 @@
     "@types/js-yaml": "^4.0.0",
     "@types/node": "^22.0.0",
     "@types/uuid": "^10.0.0",
+    "@vitest/coverage-v8": "^3.2.4",
     "commitizen": "^4.3.1",
     "cz-conventional-changelog": "^3.3.0",
     "husky": "^9.1.7",

--- a/test/core/doctor-edge-cases.test.ts
+++ b/test/core/doctor-edge-cases.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { loadConfig, writeDefaultConfig } from '../../src/core/config.js';
+import { createDatabase, rebuildIndex } from '../../src/core/index-db.js';
+import { createNote } from '../../src/core/note.js';
+import { parseFrontmatter, serializeFrontmatter } from '../../src/core/frontmatter.js';
+import { runDoctor } from '../../src/core/doctor.js';
+import type { GraniteConfig } from '../../src/core/types.js';
+
+describe('doctor edge cases', () => {
+  let tmpDir: string;
+  let config: GraniteConfig;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'granite-doctor-edges-'));
+    writeDefaultConfig(tmpDir);
+    config = loadConfig(tmpDir);
+    for (const typeConfig of Object.values(config.note_types)) {
+      fs.mkdirSync(path.join(tmpDir, typeConfig.folder), { recursive: true });
+    }
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function getDb(rebuild = true) {
+    const db = createDatabase(path.join(tmpDir, '.granite', 'index.db'));
+    if (rebuild) {
+      rebuildIndex(tmpDir, config, db);
+    }
+    return db;
+  }
+
+  it('reports missing note-type folders', () => {
+    fs.rmSync(path.join(tmpDir, config.note_types.reference.folder), { recursive: true, force: true });
+
+    const db = getDb(false);
+    const issues = runDoctor(tmpDir, config, db);
+    db.close();
+
+    expect(issues.some(issue => issue.message.includes('folder does not exist'))).toBe(true);
+  });
+
+  it('reports missing frontmatter fields, duplicate slugs, and duplicate ids', () => {
+    const first = createNote(tmpDir, config, 'permanent', 'Shared Title', 'Body.\n');
+    const second = createNote(tmpDir, config, 'reference', 'Another Title', 'Body.\n');
+
+    const firstContent = fs.readFileSync(first.filepath, 'utf-8');
+    const { frontmatter } = parseFrontmatter(firstContent);
+
+    const duplicateSlugPath = path.join(tmpDir, config.note_types.reference.folder, `${first.slug}.md`);
+    fs.writeFileSync(duplicateSlugPath, serializeFrontmatter(frontmatter, 'Duplicate slug.\n'), 'utf-8');
+
+    const secondContent = fs.readFileSync(second.filepath, 'utf-8');
+    const parsedSecond = parseFrontmatter(secondContent);
+    parsedSecond.frontmatter.id = frontmatter.id;
+    delete parsedSecond.frontmatter.title;
+    delete parsedSecond.frontmatter.type;
+    delete parsedSecond.frontmatter.created;
+    fs.writeFileSync(second.filepath, serializeFrontmatter(parsedSecond.frontmatter, parsedSecond.body), 'utf-8');
+
+    const db = getDb(false);
+    const issues = runDoctor(tmpDir, config, db);
+    db.close();
+
+    expect(issues.some(issue => issue.message.includes('Missing frontmatter field: title'))).toBe(true);
+    expect(issues.some(issue => issue.message.includes('Missing frontmatter field: type'))).toBe(true);
+    expect(issues.some(issue => issue.message.includes('Missing frontmatter field: created'))).toBe(true);
+    expect(issues.some(issue => issue.message.includes('Duplicate slug'))).toBe(true);
+    expect(issues.some(issue => issue.message.includes('Duplicate note ID'))).toBe(true);
+  });
+});

--- a/test/core/index-db-incremental.test.ts
+++ b/test/core/index-db-incremental.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { loadConfig, writeDefaultConfig } from '../../src/core/config.js';
+import { createDatabase, openDatabase, rebuildIndex, syncNoteInIndex } from '../../src/core/index-db.js';
+import { createNote, findNoteBySlug, readNote } from '../../src/core/note.js';
+import { parseFrontmatter, serializeFrontmatter } from '../../src/core/frontmatter.js';
+import type { GraniteConfig } from '../../src/core/types.js';
+
+describe('index-db incremental flows', () => {
+  let tmpDir: string;
+  let config: GraniteConfig;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'granite-idx-incremental-'));
+    writeDefaultConfig(tmpDir);
+    config = loadConfig(tmpDir);
+    for (const typeConfig of Object.values(config.note_types)) {
+      fs.mkdirSync(path.join(tmpDir, typeConfig.folder), { recursive: true });
+    }
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('recreates the index when the schema version is outdated', () => {
+    const dbPath = path.join(tmpDir, '.granite', 'index.db');
+    const firstDb = createDatabase(dbPath);
+    firstDb.prepare('UPDATE meta SET value = ? WHERE key = ?').run('1', 'schema_version');
+    firstDb.close();
+
+    const reopened = openDatabase(tmpDir);
+    const version = reopened.prepare('SELECT value FROM meta WHERE key = ?').get('schema_version') as { value: string };
+    expect(version.value).toBe('2');
+    reopened.close();
+  });
+
+  it('syncs a single note incrementally and resolves alias links', () => {
+    createNote(tmpDir, config, 'permanent', 'Target Note', 'Target.\n');
+
+    const targetPath = path.join(tmpDir, config.note_types.permanent.folder, 'target-note.md');
+    const targetContent = fs.readFileSync(targetPath, 'utf-8');
+    fs.writeFileSync(
+      targetPath,
+      targetContent.replace('aliases: []', 'aliases:\n  - TN'),
+      'utf-8',
+    );
+
+    const draft = createNote(tmpDir, config, 'permanent', 'Draft', 'Start.\n');
+
+    const db = createDatabase(path.join(tmpDir, '.granite', 'index.db'));
+    rebuildIndex(tmpDir, config, db);
+
+    const draftNote = findNoteBySlug(tmpDir, config, draft.slug);
+    expect(draftNote).not.toBeNull();
+
+    const updatedDraft = {
+      ...draftNote!,
+      body: 'Updated body with [[TN]].\n',
+    };
+
+    syncNoteInIndex(tmpDir, config, db, updatedDraft);
+
+    const stored = db.prepare('SELECT body FROM notes WHERE slug = ?').get('draft') as { body: string };
+    const link = db.prepare('SELECT target_slug FROM links WHERE source_slug = ?').get('draft') as { target_slug: string };
+
+    expect(stored.body).toContain('[[TN]]');
+    expect(link.target_slug).toBe('target-note');
+
+    db.close();
+  });
+
+  it('rebuilds the whole index when note counts drift from disk', () => {
+    const keep = createNote(tmpDir, config, 'permanent', 'Keep', 'Still here.\n');
+    const remove = createNote(tmpDir, config, 'permanent', 'Remove', 'Will be deleted.\n');
+
+    const db = createDatabase(path.join(tmpDir, '.granite', 'index.db'));
+    rebuildIndex(tmpDir, config, db);
+
+    fs.unlinkSync(remove.filepath);
+
+    syncNoteInIndex(tmpDir, config, db, readNote(keep.filepath));
+
+    const count = db.prepare('SELECT COUNT(*) as c FROM notes').get() as { c: number };
+    expect(count.c).toBe(1);
+    expect(
+      db.prepare('SELECT slug FROM notes').all() as Array<{ slug: string }>,
+    ).toEqual([{ slug: 'keep' }]);
+
+    db.close();
+  });
+
+  it('keeps malformed alias JSON from crashing link resolution', () => {
+    createNote(tmpDir, config, 'permanent', 'Target Note', 'Target.\n');
+
+    const targetPath = path.join(tmpDir, config.note_types.permanent.folder, 'target-note.md');
+    const targetContent = fs.readFileSync(targetPath, 'utf-8');
+    const parsed = parseFrontmatter(targetContent);
+    parsed.frontmatter.aliases = [] as string[];
+    fs.writeFileSync(
+      targetPath,
+      serializeFrontmatter(parsed.frontmatter, parsed.body),
+      'utf-8',
+    );
+
+    const db = createDatabase(path.join(tmpDir, '.granite', 'index.db'));
+    rebuildIndex(tmpDir, config, db);
+    db.prepare('UPDATE notes SET aliases = ? WHERE slug = ?').run('not-json', 'target-note');
+
+    const note = createNote(tmpDir, config, 'permanent', 'Draft', 'Link to [[Target Note]].\n');
+    syncNoteInIndex(tmpDir, config, db, readNote(note.filepath));
+
+    const link = db.prepare('SELECT target_slug FROM links WHERE source_slug = ?').get('draft') as { target_slug: string };
+    expect(link.target_slug).toBe('target-note');
+
+    db.close();
+  });
+});

--- a/test/core/querying.test.ts
+++ b/test/core/querying.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { loadConfig, writeDefaultConfig } from '../../src/core/config.js';
+import { getBacklinks } from '../../src/core/backlinks.js';
+import { createDatabase, rebuildIndex } from '../../src/core/index-db.js';
+import { createNote, findNoteBySlug } from '../../src/core/note.js';
+import { searchNotes } from '../../src/core/search.js';
+import { suggestLinks } from '../../src/core/suggest.js';
+import type { GraniteConfig } from '../../src/core/types.js';
+
+describe('querying helpers', () => {
+  let tmpDir: string;
+  let config: GraniteConfig;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'granite-querying-'));
+    writeDefaultConfig(tmpDir);
+    config = loadConfig(tmpDir);
+
+    for (const typeConfig of Object.values(config.note_types)) {
+      fs.mkdirSync(path.join(tmpDir, typeConfig.folder), { recursive: true });
+    }
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns normalized search results with snippet and score', () => {
+    createNote(tmpDir, config, 'permanent', 'Graph Memory', 'A graph memory stores linked ideas.\n');
+
+    const db = createDatabase(path.join(tmpDir, '.granite', 'index.db'));
+    rebuildIndex(tmpDir, config, db);
+
+    const results = searchNotes(db, 'linked ideas');
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      slug: 'graph-memory',
+      title: 'Graph Memory',
+    });
+    expect(results[0].snippet).toContain('>>>');
+    expect(typeof results[0].score).toBe('number');
+
+    db.close();
+  });
+
+  it('returns backlinks sorted by source title', () => {
+    createNote(tmpDir, config, 'permanent', 'Zulu Source', 'Points to [[Target Note]].\n');
+    createNote(tmpDir, config, 'permanent', 'Alpha Source', 'Also points to [[Target Note]].\n');
+    createNote(tmpDir, config, 'permanent', 'Target Note', 'Referenced note.\n');
+
+    const db = createDatabase(path.join(tmpDir, '.granite', 'index.db'));
+    rebuildIndex(tmpDir, config, db);
+
+    const backlinks = getBacklinks(db, 'target-note');
+    expect(backlinks.map(link => link.source_title)).toEqual(['Alpha Source', 'Zulu Source']);
+
+    db.close();
+  });
+
+  it('suggests notes mentioned in body and skips existing wikilinks', () => {
+    createNote(tmpDir, config, 'permanent', 'Machine Learning', 'Base concept.\n');
+    createNote(tmpDir, config, 'permanent', 'Large Language Model', 'Alias-heavy concept.\n');
+
+    const llmNotePath = path.join(tmpDir, config.note_types.permanent.folder, 'large-language-model.md');
+    const llmContent = fs.readFileSync(llmNotePath, 'utf-8');
+    fs.writeFileSync(
+      llmNotePath,
+      llmContent.replace('aliases: []', 'aliases:\n  - LLM\n  - foundation model'),
+      'utf-8',
+    );
+
+    const current = createNote(
+      tmpDir,
+      config,
+      'permanent',
+      'Draft Note',
+      [
+        'Machine learning appears twice.',
+        'Machine Learning enables modern systems.',
+        'An LLM can be a foundation model.',
+        'There is already a wikilink to [[Machine Learning]].',
+      ].join('\n'),
+    );
+
+    const db = createDatabase(path.join(tmpDir, '.granite', 'index.db'));
+    rebuildIndex(tmpDir, config, db);
+
+    const refreshedCurrent = findNoteBySlug(tmpDir, config, current.slug);
+    expect(refreshedCurrent).not.toBeNull();
+
+    const suggestions = suggestLinks(db, refreshedCurrent!).toSorted(
+      (a, b) => a.target_slug.localeCompare(b.target_slug),
+    );
+    expect(suggestions).toEqual([
+      {
+        target_slug: 'large-language-model',
+        target_title: 'Large Language Model',
+        mentions: 2,
+      },
+    ]);
+
+    db.close();
+  });
+});

--- a/test/core/recommendations.test.ts
+++ b/test/core/recommendations.test.ts
@@ -6,7 +6,7 @@ import { writeDefaultConfig, loadConfig } from '../../src/core/config.js';
 import { parseFrontmatter, serializeFrontmatter } from '../../src/core/frontmatter.js';
 import { createDatabase, rebuildIndex } from '../../src/core/index-db.js';
 import { createNote, readNote } from '../../src/core/note.js';
-import { getRecommendations } from '../../src/core/recommendations.js';
+import { formatRecommendations, getRecommendations, recommendNote } from '../../src/core/recommendations.js';
 import type { GraniteConfig } from '../../src/core/types.js';
 
 describe('recommendations', () => {
@@ -167,6 +167,106 @@ describe('recommendations', () => {
         'Link one project, company, or topic in the Links section.',
       ]),
     );
+  });
+
+  it('formats recommendation sections and returns nothing when empty', () => {
+    expect(formatRecommendations({
+      additions: [],
+      links: [],
+      tags: [],
+      next_steps: [],
+    })).toEqual([]);
+
+    expect(formatRecommendations({
+      additions: [{ text: 'Add context.' }],
+      links: [{ slug: 'granite', title: 'Granite', type: 'project', reason: 'mentioned 2 times', source: 'mention' }],
+      tags: [{ tag: 'search', weight: 3, source_slugs: ['granite', 'notes'] }],
+      next_steps: [{ type: 'decision', title_hint: 'Decision from Granite', reason: 'Capture the tradeoff.' }],
+    })).toEqual([
+      '  Add now:',
+      '    Add context.',
+      '  Link now:',
+      '    [[granite]] — mentioned 2 times',
+      '  Tag now:',
+      '    search — seen on 2 nearby notes',
+      '  Next note:',
+      '    decision — Capture the tradeoff. Title hint: Decision from Granite.',
+    ]);
+  });
+
+  it('covers next-step and add-now branches for remaining note types', () => {
+    const fleeting = createNote(tmpDir, config, 'fleeting', 'Quick capture', 'Tiny note.\n');
+    const meeting = createNote(tmpDir, config, 'meeting', 'Weekly sync');
+    const decision = createNote(tmpDir, config, 'decision', 'Choose SQLite');
+    const project = createNote(tmpDir, config, 'project', 'Granite');
+    const permanent = createNote(tmpDir, config, 'permanent', 'Memory Graph');
+
+    const db = createDatabase(path.join(tmpDir, '.granite', 'index.db'));
+    rebuildIndex(tmpDir, config, db);
+
+    const fleetingRecommendations = getRecommendations(db, readNote(fleeting.filepath), config);
+    expect(fleetingRecommendations.additions[0].text).toContain('Add one more sentence');
+    expect(fleetingRecommendations.next_steps[0]).toMatchObject({
+      type: 'permanent',
+      title_hint: 'Quick capture',
+    });
+
+    const meetingRecommendations = getRecommendations(db, readNote(meeting.filepath), config);
+    expect(meetingRecommendations.additions.map(item => item.text)).toEqual(
+      expect.arrayContaining([
+        'Link the attendees directly in the note.',
+        'Capture one decision or open question.',
+      ]),
+    );
+    expect(meetingRecommendations.next_steps[0].type).toBe('decision');
+
+    const decisionRecommendations = getRecommendations(db, readNote(decision.filepath), config);
+    expect(decisionRecommendations.additions.map(item => item.text)).toEqual(
+      expect.arrayContaining([
+        'Add the context that forced this decision.',
+        'State the decision in one sentence.',
+        'Link the project, meeting, or note affected by this decision.',
+      ]),
+    );
+    expect(decisionRecommendations.next_steps[0].type).toBe('project');
+
+    const projectRecommendations = getRecommendations(db, readNote(project.filepath), config);
+    expect(projectRecommendations.additions.map(item => item.text)).toEqual(
+      expect.arrayContaining([
+        'Add a one-line goal so the project has a clear anchor.',
+        'Link the people involved in the project.',
+        'Record one key decision or current status update.',
+      ]),
+    );
+    expect(projectRecommendations.next_steps[0].type).toBe('decision');
+
+    const permanentRecommendations = getRecommendations(db, readNote(permanent.filepath), config);
+    expect(permanentRecommendations.additions.map(item => item.text)).toEqual(
+      expect.arrayContaining([
+        'Write a one-line summary before expanding the idea.',
+        'Link one project, company, person, or adjacent idea.',
+      ]),
+    );
+    expect(permanentRecommendations.next_steps[0].type).toBe('project');
+
+    db.close();
+  });
+
+  it('supports incremental recommendation refreshes', () => {
+    createNote(tmpDir, config, 'project', 'Granite', 'Local-first system.\n');
+    const note = createNote(
+      tmpDir,
+      config,
+      'reference',
+      'Fresh note',
+      'Granite keeps markdown notes portable.\n',
+    );
+
+    const recommendations = recommendNote(tmpDir, config, readNote(note.filepath), {
+      strategy: 'incremental',
+    });
+
+    expect(recommendations.links.some(link => link.slug === 'granite')).toBe(true);
   });
 });
 

--- a/test/core/vault-and-json-output.test.ts
+++ b/test/core/vault-and-json-output.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  findVaultRoot,
+  getIndexDbPath,
+  requireVaultRoot,
+  resolveNotePath,
+} from '../../src/core/vault.js';
+import {
+  jsonError,
+  jsonSuccess,
+  validateSource,
+  validateStatus,
+} from '../../src/core/json-output.js';
+
+describe('vault helpers', () => {
+  let tmpDir: string;
+  let previousHome: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'granite-vault-'));
+    previousHome = process.env.HOME;
+    process.env.HOME = tmpDir;
+  });
+
+  afterEach(() => {
+    if (previousHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = previousHome;
+    }
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('finds the vault root from a nested directory', () => {
+    const nestedDir = path.join(tmpDir, 'notes', 'deep');
+    fs.mkdirSync(nestedDir, { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, 'granite.yml'), 'vault_name: test\n', 'utf-8');
+
+    expect(findVaultRoot(nestedDir)).toBe(tmpDir);
+    expect(requireVaultRoot(nestedDir)).toBe(tmpDir);
+  });
+
+  it('throws when no vault root is found', () => {
+    expect(findVaultRoot(tmpDir)).toBeNull();
+    expect(() => requireVaultRoot(tmpDir)).toThrow('No Granite vault found');
+  });
+
+  it('builds vault-relative file paths', () => {
+    expect(getIndexDbPath('/vault')).toBe(path.join('/vault', '.granite', 'index.db'));
+    expect(getIndexDbPath(path.join('/vault', '.granite'))).toBe(path.join('/vault', '.granite', 'index.db'));
+    expect(resolveNotePath('/vault', 'permanent', 'my-note')).toBe(path.join('/vault', 'permanent', 'my-note.md'));
+  });
+});
+
+describe('json output helpers', () => {
+  it('serializes success and error payloads', () => {
+    expect(JSON.parse(jsonSuccess({ slug: 'test' }))).toEqual({
+      success: true,
+      data: { slug: 'test' },
+    });
+
+    expect(JSON.parse(jsonError('boom'))).toEqual({
+      success: false,
+      error: 'boom',
+    });
+  });
+
+  it('accepts valid status and source values', () => {
+    expect(() => validateStatus('inbox')).not.toThrow();
+    expect(() => validateStatus('active')).not.toThrow();
+    expect(() => validateStatus('archived')).not.toThrow();
+
+    expect(() => validateSource('human')).not.toThrow();
+    expect(() => validateSource('agent')).not.toThrow();
+    expect(() => validateSource('extraction')).not.toThrow();
+  });
+
+  it('rejects invalid status and source values', () => {
+    expect(() => validateStatus('draft')).toThrow('Invalid status');
+    expect(() => validateSource('import')).toThrow('Invalid source');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,5 +3,17 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     globals: true,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html'],
+      include: ['src/core/**/*.ts'],
+      exclude: ['src/core/types.ts'],
+      thresholds: {
+        lines: 80,
+        functions: 80,
+        branches: 80,
+        statements: 80,
+      },
+    },
   },
 });


### PR DESCRIPTION
## Summary
- add Vitest coverage enforcement at 80% and run it in CI
- align the release workflow with the hardened validation path before npm publish
- make release-please prefer `RELEASE_PLEASE_TOKEN` over `GITHUB_TOKEN` to avoid the GitHub tree-write failure seen on the last run

## Validation
- npm run build
- npm run lint
- npm run test:coverage

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub workflows, test/coverage configuration, and expanded test coverage; runtime behavior should be unaffected aside from stricter CI/release gating.
> 
> **Overview**
> **CI/release validation is hardened** by running `npm run build` and `npm run test:coverage` (instead of plain `npm test`) on CI and before npm publish, and by adding named steps for clarity.
> 
> **Release automation is made more reliable** by preferring `RELEASE_PLEASE_TOKEN` over `GITHUB_TOKEN` for `release-please`, and by forcing GitHub JS actions onto Node 24 via `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`.
> 
> Adds Vitest coverage tooling/config (`@vitest/coverage-v8`, `vitest.config.ts` thresholds at 80% for `src/core/**`) and introduces several new core-focused tests covering doctor edge cases, incremental index DB sync/rebuild behaviors, querying helpers, vault/json-output helpers, and additional recommendation formatting/incremental-refresh scenarios.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5c16e797ddc0b971ee0ceb47a89add36fc3d1cfa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened CI and release: we now build, typecheck, and run tests with 80% coverage, and releases validate before publish. `release-please` prefers `RELEASE_PLEASE_TOKEN` (fallback `GITHUB_TOKEN`) and JS actions run on Node 24 to avoid tree-write failures.

- **Refactors**
  - CI runs `npm run build`, `npm run lint`, and `npm run test:coverage` with 80% thresholds via `@vitest/coverage-v8`.
  - Release job mirrors CI checks before `npm publish` and sets `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true`.
  - `release-please` uses `RELEASE_PLEASE_TOKEN` when set, falling back to `GITHUB_TOKEN`.

- **Dependencies**
  - Added `@vitest/coverage-v8`, a `test:coverage` script, and coverage thresholds in `vitest.config.ts`.

<sup>Written for commit 5c16e797ddc0b971ee0ceb47a89add36fc3d1cfa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

