### PR TITLE
fix: align release workflow with companion

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,11 +16,12 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
   publish:
     needs: release-please
@@ -49,6 +50,9 @@ jobs:
 
       - name: Test with coverage
         run: npm run test:coverage
+
+      - name: Verify package contents
+        run: npm pack --dry-run
 
       - name: Publish to npm
         run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary
- force `release-please` to use `RELEASE_PLEASE_TOKEN`
- expose `tag_name` from the release job like in companion
- add `npm pack --dry-run` before publish to mirror companion's package verification

## Notes
- keeps the existing Granite Node/npm publish path
- does not add the companion-specific docker job

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only changes to the release/publish workflow; main risk is misconfiguration of `RELEASE_PLEASE_TOKEN` or an unexpectedly failing `npm pack --dry-run` blocking releases.
> 
> **Overview**
> Aligns the `Release` GitHub Actions workflow with the companion setup by **forcing `release-please` to use `secrets.RELEASE_PLEASE_TOKEN`** (removing the fallback to `GITHUB_TOKEN`) and **exposing `tag_name` as a job output**.
> 
> Adds a pre-publish safety check in the `publish` job by running `npm pack --dry-run` to verify the package contents before `npm publish`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70ee769d3e4b56487dd48114160399ebf607c805. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the release workflow with companion. Forces `release-please` to use `RELEASE_PLEASE_TOKEN`, exposes `tag_name`, and adds a `npm pack --dry-run` check.

- **Bug Fixes**
  - Force `release-please` to use `RELEASE_PLEASE_TOKEN` (no fallback to `GITHUB_TOKEN`).

- **New Features**
  - Expose `tag_name` from the release job for downstream steps.
  - Add `npm pack --dry-run` to verify package contents before publish.

<sup>Written for commit 70ee769d3e4b56487dd48114160399ebf607c805. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

