### PR TITLE
feat: multi-device sync system + Granite Cloud worker

### DIFF
--- a/packages/worker/package-lock.json
+++ b/packages/worker/package-lock.json
@@ -1,0 +1,2795 @@
+{
+  "name": "granite-worker",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "granite-worker",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "gray-matter": "^4.0.3",
+        "hono": "^4.0.0",
+        "nanoid": "^5.0.0",
+        "uuid": "^11.0.0",
+        "zod": "^3.25.76"
+      },
+      "devDependencies": {
+        "@cloudflare/workers-types": "^4.20250313.0",
+        "typescript": "^5.8.0",
+        "wrangler": "^4.0.0"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.2.tgz",
+      "integrity": "sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.0.tgz",
+      "integrity": "sha512-8ovsRpwzPoEqPUzoErAYVv8l3FMZNeBVQfJTvtzP4AgLSRGZISRfuChFxHWUQd3n6cnrwkuTGxT+2cGo8EsyYg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260301.1 || ~1.20260302.1 || ~1.20260303.1 || ~1.20260304.1 || >1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260317.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260317.1.tgz",
+      "integrity": "sha512-8hjh3sPMwY8M/zedq3/sXoA2Q4BedlGufn3KOOleIG+5a4ReQKLlUah140D7J6zlKmYZAFMJ4tWC7hCuI/s79g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260317.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260317.1.tgz",
+      "integrity": "sha512-M/MnNyvO5HMgoIdr3QHjdCj2T1ki9gt0vIUnxYxBu9ISXS/jgtMl6chUVPJ7zHYBn9MyYr8ByeN6frjYxj0MGg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260317.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260317.1.tgz",
+      "integrity": "sha512-1ltuEjkRcS3fsVF7CxsKlWiRmzq2ZqMfqDN0qUOgbUwkpXsLVJsXmoblaLf5OP00ELlcgF0QsN0p2xPEua4Uug==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260317.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260317.1.tgz",
+      "integrity": "sha512-3QrNnPF1xlaNwkHpasvRvAMidOvQs2NhXQmALJrEfpIJ/IDL2la8g499yXp3eqhG3hVMCB07XVY149GTs42Xtw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260317.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260317.1.tgz",
+      "integrity": "sha512-MfZTz+7LfuIpMGTa3RLXHX8Z/pnycZLItn94WRdHr8LPVet+C5/1Nzei399w/jr3+kzT4pDKk26JF/tlI5elpQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20260331.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260331.1.tgz",
+      "integrity": "sha512-fsf+MWPQdQ8XPV0y3tQvqf035ETgEXfJgNTYqmiLcOHB32eH/5Kb75fyZIXS9nnBMq3x6c4+HJRTRxbovNLWiA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
+      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.12.tgz",
+      "integrity": "sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.15.tgz",
+      "integrity": "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.9",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
+      "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "4.20260317.3",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260317.3.tgz",
+      "integrity": "sha512-tK78D3X4q30/SXqVwMhWrUfH+ffRou9dJLC+jkhNy5zh1I7i7T4JH6xihOvYxdCSBavJ5fQXaaxDJz6orh09BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "^0.34.5",
+        "undici": "7.24.4",
+        "workerd": "1.20260317.1",
+        "ws": "8.18.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.7.tgz",
+      "integrity": "sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.1.tgz",
+      "integrity": "sha512-fvU78fIjZ+SBM9YwCknCvKOUKkLVqtWDVctl0s7xIqfmfb38t2TT4ZU2gHm+Z8xGwgW+QWEU3oQSAzIbo89Ggw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
+      "integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20260317.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260317.1.tgz",
+      "integrity": "sha512-ZuEq1OdrJBS+NV+L5HMYPCzVn49a2O60slQiiLpG44jqtlOo+S167fWC76kEXteXLLLydeuRrluRel7WdOUa4g==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260317.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260317.1",
+        "@cloudflare/workerd-linux-64": "1.20260317.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260317.1",
+        "@cloudflare/workerd-windows-64": "1.20260317.1"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.78.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.78.0.tgz",
+      "integrity": "sha512-He/vUhk4ih0D0eFmtNnlbT6Od8j+BEokaSR+oYjbVsH0SWIrIch+eHqfLRSBjBQaOoh6HCNxcafcIkBm2u0Hag==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.4.2",
+        "@cloudflare/unenv-preset": "2.16.0",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.27.3",
+        "miniflare": "4.20260317.3",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260317.1"
+      },
+      "bin": {
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=20.3.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20260317.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wrangler/node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    },
+    "node_modules/youch/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -12,6 +12,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "hono": "^4.0.0",
     "gray-matter": "^4.0.3",
+    "nanoid": "^5.0.0",
     "uuid": "^11.0.0",
     "zod": "^3.25.76"
   },

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "granite-worker",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "db:migrate": "wrangler d1 execute granite-index --file=schema.sql",
+    "db:migrate:local": "wrangler d1 execute granite-index --local --file=schema.sql"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "hono": "^4.0.0",
+    "gray-matter": "^4.0.3",
+    "uuid": "^11.0.0",
+    "zod": "^3.25.76"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20250313.0",
+    "wrangler": "^4.0.0",
+    "typescript": "^5.8.0"
+  }
+}

--- a/packages/worker/schema.sql
+++ b/packages/worker/schema.sql
@@ -126,11 +126,12 @@ CREATE TABLE IF NOT EXISTS sync_changelog (
 CREATE INDEX IF NOT EXISTS idx_changelog_vault_seq ON sync_changelog(vault_id, seq);
 
 CREATE TABLE IF NOT EXISTS devices (
-  device_id TEXT PRIMARY KEY,
+  device_id TEXT NOT NULL,
   vault_id TEXT NOT NULL,
   device_name TEXT NOT NULL,
   last_seen TEXT NOT NULL,
-  last_seq INTEGER NOT NULL DEFAULT 0
+  last_seq INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (vault_id, device_id)
 );
 
 -- === RATE LIMITING ===

--- a/packages/worker/schema.sql
+++ b/packages/worker/schema.sql
@@ -49,8 +49,8 @@ CREATE INDEX IF NOT EXISTS idx_vaults_user ON vaults(user_id);
 -- === NOTE INDEX (same as local SQLite) ===
 
 CREATE TABLE IF NOT EXISTS notes (
-  slug TEXT PRIMARY KEY,
-  id TEXT UNIQUE NOT NULL,
+  slug TEXT NOT NULL,
+  id TEXT NOT NULL,
   title TEXT NOT NULL,
   type TEXT NOT NULL,
   created TEXT NOT NULL,
@@ -61,10 +61,10 @@ CREATE TABLE IF NOT EXISTS notes (
   filepath TEXT NOT NULL,
   status TEXT NOT NULL DEFAULT 'active',
   source TEXT NOT NULL DEFAULT 'human',
-  vault_id TEXT NOT NULL REFERENCES vaults(vault_id) ON DELETE CASCADE
+  vault_id TEXT NOT NULL REFERENCES vaults(vault_id) ON DELETE CASCADE,
+  PRIMARY KEY (vault_id, slug),
+  UNIQUE (vault_id, id)
 );
-
-CREATE INDEX IF NOT EXISTS idx_notes_vault ON notes(vault_id);
 
 CREATE VIRTUAL TABLE IF NOT EXISTS notes_fts USING fts5(
   title,

--- a/packages/worker/schema.sql
+++ b/packages/worker/schema.sql
@@ -1,22 +1,70 @@
 -- Granite Cloud D1 Schema
--- Identical to src/core/index-db.ts SCHEMA_SQL + multi-tenant sync tables
+-- Users + Auth + Note Index + Sync
+
+-- === USERS & AUTH ===
+
+CREATE TABLE IF NOT EXISTS users (
+  id TEXT PRIMARY KEY,
+  github_id INTEGER UNIQUE,
+  email TEXT UNIQUE,
+  github_username TEXT,
+  tier TEXT NOT NULL DEFAULT 'free',
+  stripe_customer_id TEXT,
+  stripe_subscription_id TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS api_keys (
+  key_hash TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  key_prefix TEXT NOT NULL DEFAULT '',
+  name TEXT NOT NULL DEFAULT 'default',
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  last_used_at TEXT,
+  revoked_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_api_keys_user ON api_keys(user_id);
+
+CREATE TABLE IF NOT EXISTS auth_sessions (
+  session_id TEXT PRIMARY KEY,
+  api_key TEXT,
+  username TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  expires_at TEXT NOT NULL
+);
+
+-- === VAULTS (linked to users) ===
+
+CREATE TABLE IF NOT EXISTS vaults (
+  vault_id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  vault_name TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_vaults_user ON vaults(user_id);
 
 -- === NOTE INDEX (same as local SQLite) ===
 
 CREATE TABLE IF NOT EXISTS notes (
-  slug        TEXT PRIMARY KEY,
-  id          TEXT UNIQUE NOT NULL,
-  title       TEXT NOT NULL,
-  type        TEXT NOT NULL,
-  created     TEXT NOT NULL,
-  modified    TEXT NOT NULL,
-  tags        TEXT,
-  aliases     TEXT,
-  body        TEXT NOT NULL,
-  filepath    TEXT NOT NULL,
-  status      TEXT NOT NULL DEFAULT 'active',
-  source      TEXT NOT NULL DEFAULT 'human'
+  slug TEXT PRIMARY KEY,
+  id TEXT UNIQUE NOT NULL,
+  title TEXT NOT NULL,
+  type TEXT NOT NULL,
+  created TEXT NOT NULL,
+  modified TEXT NOT NULL,
+  tags TEXT,
+  aliases TEXT,
+  body TEXT NOT NULL,
+  filepath TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'active',
+  source TEXT NOT NULL DEFAULT 'human',
+  vault_id TEXT NOT NULL REFERENCES vaults(vault_id) ON DELETE CASCADE
 );
+
+CREATE INDEX IF NOT EXISTS idx_notes_vault ON notes(vault_id);
 
 CREATE VIRTUAL TABLE IF NOT EXISTS notes_fts USING fts5(
   title,
@@ -44,47 +92,55 @@ CREATE TRIGGER IF NOT EXISTS notes_au AFTER UPDATE ON notes BEGIN
 END;
 
 CREATE TABLE IF NOT EXISTS links (
-  source_slug   TEXT NOT NULL,
-  target_slug   TEXT,
-  target_raw    TEXT NOT NULL,
-  context       TEXT,
+  source_slug TEXT NOT NULL,
+  target_slug TEXT,
+  target_raw TEXT NOT NULL,
+  context TEXT,
+  vault_id TEXT NOT NULL REFERENCES vaults(vault_id) ON DELETE CASCADE,
   FOREIGN KEY (source_slug) REFERENCES notes(slug)
 );
 
-CREATE INDEX IF NOT EXISTS idx_links_target ON links(target_slug);
-CREATE INDEX IF NOT EXISTS idx_links_source ON links(source_slug);
+CREATE INDEX IF NOT EXISTS idx_links_target ON links(vault_id, target_slug);
+CREATE INDEX IF NOT EXISTS idx_links_source ON links(vault_id, source_slug);
 
 CREATE TABLE IF NOT EXISTS meta (
-  key   TEXT PRIMARY KEY,
-  value TEXT
+  key TEXT NOT NULL,
+  value TEXT,
+  vault_id TEXT NOT NULL,
+  PRIMARY KEY (vault_id, key)
 );
 
--- === MULTI-TENANT SYNC ===
-
-CREATE TABLE IF NOT EXISTS vaults (
-  vault_id      TEXT PRIMARY KEY,
-  api_key_hash  TEXT UNIQUE NOT NULL,
-  vault_name    TEXT NOT NULL,
-  created       TEXT NOT NULL
-);
+-- === SYNC ===
 
 CREATE TABLE IF NOT EXISTS sync_changelog (
-  seq         INTEGER PRIMARY KEY AUTOINCREMENT,
-  vault_id    TEXT NOT NULL,
-  note_id     TEXT NOT NULL,
-  operation   TEXT NOT NULL,
-  timestamp   TEXT NOT NULL,
-  device_id   TEXT NOT NULL,
-  checksum    TEXT NOT NULL,
-  slug        TEXT NOT NULL DEFAULT ''
+  seq INTEGER PRIMARY KEY AUTOINCREMENT,
+  vault_id TEXT NOT NULL,
+  note_id TEXT NOT NULL,
+  operation TEXT NOT NULL,
+  timestamp TEXT NOT NULL,
+  device_id TEXT NOT NULL,
+  checksum TEXT NOT NULL,
+  slug TEXT NOT NULL DEFAULT ''
 );
 
 CREATE INDEX IF NOT EXISTS idx_changelog_vault_seq ON sync_changelog(vault_id, seq);
 
 CREATE TABLE IF NOT EXISTS devices (
-  device_id   TEXT PRIMARY KEY,
-  vault_id    TEXT NOT NULL,
+  device_id TEXT PRIMARY KEY,
+  vault_id TEXT NOT NULL,
   device_name TEXT NOT NULL,
-  last_seen   TEXT NOT NULL,
-  last_seq    INTEGER NOT NULL DEFAULT 0
+  last_seen TEXT NOT NULL,
+  last_seq INTEGER NOT NULL DEFAULT 0
 );
+
+-- === RATE LIMITING ===
+
+CREATE TABLE IF NOT EXISTS rate_limits (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  identifier TEXT NOT NULL,
+  action TEXT NOT NULL DEFAULT 'sync',
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_rate_limits_lookup
+  ON rate_limits(identifier, action, created_at);

--- a/packages/worker/schema.sql
+++ b/packages/worker/schema.sql
@@ -41,6 +41,7 @@ CREATE TABLE IF NOT EXISTS vaults (
   vault_id TEXT PRIMARY KEY,
   user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
   vault_name TEXT NOT NULL,
+  storage_bytes INTEGER NOT NULL DEFAULT 0,
   created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
 );
 

--- a/packages/worker/schema.sql
+++ b/packages/worker/schema.sql
@@ -11,8 +11,8 @@ CREATE TABLE IF NOT EXISTS users (
   tier TEXT NOT NULL DEFAULT 'free',
   stripe_customer_id TEXT,
   stripe_subscription_id TEXT,
-  created_at TEXT NOT NULL DEFAULT (datetime('now')),
-  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
 );
 
 CREATE TABLE IF NOT EXISTS api_keys (
@@ -20,7 +20,7 @@ CREATE TABLE IF NOT EXISTS api_keys (
   user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
   key_prefix TEXT NOT NULL DEFAULT '',
   name TEXT NOT NULL DEFAULT 'default',
-  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
   last_used_at TEXT,
   revoked_at TEXT
 );
@@ -31,7 +31,7 @@ CREATE TABLE IF NOT EXISTS auth_sessions (
   session_id TEXT PRIMARY KEY,
   api_key TEXT,
   username TEXT,
-  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
   expires_at TEXT NOT NULL
 );
 
@@ -41,7 +41,7 @@ CREATE TABLE IF NOT EXISTS vaults (
   vault_id TEXT PRIMARY KEY,
   user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
   vault_name TEXT NOT NULL,
-  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
 );
 
 CREATE INDEX IF NOT EXISTS idx_vaults_user ON vaults(user_id);
@@ -140,7 +140,7 @@ CREATE TABLE IF NOT EXISTS rate_limits (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   identifier TEXT NOT NULL,
   action TEXT NOT NULL DEFAULT 'sync',
-  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
 );
 
 CREATE INDEX IF NOT EXISTS idx_rate_limits_lookup

--- a/packages/worker/schema.sql
+++ b/packages/worker/schema.sql
@@ -1,0 +1,90 @@
+-- Granite Cloud D1 Schema
+-- Identical to src/core/index-db.ts SCHEMA_SQL + multi-tenant sync tables
+
+-- === NOTE INDEX (same as local SQLite) ===
+
+CREATE TABLE IF NOT EXISTS notes (
+  slug        TEXT PRIMARY KEY,
+  id          TEXT UNIQUE NOT NULL,
+  title       TEXT NOT NULL,
+  type        TEXT NOT NULL,
+  created     TEXT NOT NULL,
+  modified    TEXT NOT NULL,
+  tags        TEXT,
+  aliases     TEXT,
+  body        TEXT NOT NULL,
+  filepath    TEXT NOT NULL,
+  status      TEXT NOT NULL DEFAULT 'active',
+  source      TEXT NOT NULL DEFAULT 'human'
+);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS notes_fts USING fts5(
+  title,
+  body,
+  tags,
+  content='notes',
+  content_rowid='rowid'
+);
+
+CREATE TRIGGER IF NOT EXISTS notes_ai AFTER INSERT ON notes BEGIN
+  INSERT INTO notes_fts(rowid, title, body, tags)
+    VALUES (new.rowid, new.title, new.body, new.tags);
+END;
+
+CREATE TRIGGER IF NOT EXISTS notes_ad AFTER DELETE ON notes BEGIN
+  INSERT INTO notes_fts(notes_fts, rowid, title, body, tags)
+    VALUES ('delete', old.rowid, old.title, old.body, old.tags);
+END;
+
+CREATE TRIGGER IF NOT EXISTS notes_au AFTER UPDATE ON notes BEGIN
+  INSERT INTO notes_fts(notes_fts, rowid, title, body, tags)
+    VALUES ('delete', old.rowid, old.title, old.body, old.tags);
+  INSERT INTO notes_fts(rowid, title, body, tags)
+    VALUES (new.rowid, new.title, new.body, new.tags);
+END;
+
+CREATE TABLE IF NOT EXISTS links (
+  source_slug   TEXT NOT NULL,
+  target_slug   TEXT,
+  target_raw    TEXT NOT NULL,
+  context       TEXT,
+  FOREIGN KEY (source_slug) REFERENCES notes(slug)
+);
+
+CREATE INDEX IF NOT EXISTS idx_links_target ON links(target_slug);
+CREATE INDEX IF NOT EXISTS idx_links_source ON links(source_slug);
+
+CREATE TABLE IF NOT EXISTS meta (
+  key   TEXT PRIMARY KEY,
+  value TEXT
+);
+
+-- === MULTI-TENANT SYNC ===
+
+CREATE TABLE IF NOT EXISTS vaults (
+  vault_id      TEXT PRIMARY KEY,
+  api_key_hash  TEXT UNIQUE NOT NULL,
+  vault_name    TEXT NOT NULL,
+  created       TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS sync_changelog (
+  seq         INTEGER PRIMARY KEY AUTOINCREMENT,
+  vault_id    TEXT NOT NULL,
+  note_id     TEXT NOT NULL,
+  operation   TEXT NOT NULL,
+  timestamp   TEXT NOT NULL,
+  device_id   TEXT NOT NULL,
+  checksum    TEXT NOT NULL,
+  slug        TEXT NOT NULL DEFAULT ''
+);
+
+CREATE INDEX IF NOT EXISTS idx_changelog_vault_seq ON sync_changelog(vault_id, seq);
+
+CREATE TABLE IF NOT EXISTS devices (
+  device_id   TEXT PRIMARY KEY,
+  vault_id    TEXT NOT NULL,
+  device_name TEXT NOT NULL,
+  last_seen   TEXT NOT NULL,
+  last_seq    INTEGER NOT NULL DEFAULT 0
+);

--- a/packages/worker/src/auth.ts
+++ b/packages/worker/src/auth.ts
@@ -1,0 +1,38 @@
+import type { Context, Next } from 'hono';
+import type { Env } from './env.js';
+
+async function hashApiKey(key: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(key);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  return hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
+}
+
+export async function authMiddleware(c: Context<{ Bindings: Env }>, next: Next) {
+  const authHeader = c.req.header('Authorization');
+  if (!authHeader?.startsWith('Bearer ')) {
+    return c.json({ error: 'Missing or invalid Authorization header' }, 401);
+  }
+
+  const apiKey = authHeader.slice(7);
+  if (!apiKey) {
+    return c.json({ error: 'Empty API key' }, 401);
+  }
+
+  const keyHash = await hashApiKey(apiKey);
+
+  const vault = await c.env.DB.prepare(
+    'SELECT vault_id, vault_name FROM vaults WHERE api_key_hash = ?'
+  ).bind(keyHash).first<{ vault_id: string; vault_name: string }>();
+
+  if (!vault) {
+    return c.json({ error: 'Invalid API key' }, 401);
+  }
+
+  c.set('vaultId', vault.vault_id);
+  c.set('vaultName', vault.vault_name);
+  await next();
+}
+
+export { hashApiKey };

--- a/packages/worker/src/auth.ts
+++ b/packages/worker/src/auth.ts
@@ -1,38 +1,54 @@
-import type { Context, Next } from 'hono';
-import type { Env } from './env.js';
+import { createMiddleware } from 'hono/factory';
+import type { Env, Tier, User } from './env.js';
+import { hashApiKey } from './lib/api-key.js';
 
-async function hashApiKey(key: string): Promise<string> {
-  const encoder = new TextEncoder();
-  const data = encoder.encode(key);
-  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
-  const hashArray = Array.from(new Uint8Array(hashBuffer));
-  return hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
+declare module 'hono' {
+  interface ContextVariableMap {
+    user: User | null;
+    tier: Tier;
+    vaultId: string;
+  }
 }
 
-export async function authMiddleware(c: Context<{ Bindings: Env }>, next: Next) {
+/**
+ * Auth middleware for protected routes.
+ * Extracts Bearer gsk_ token, looks up user via api_keys + users join.
+ * Rejects unauthenticated requests with 401.
+ */
+export const authMiddleware = createMiddleware<{ Bindings: Env }>(async (c, next) => {
   const authHeader = c.req.header('Authorization');
-  if (!authHeader?.startsWith('Bearer ')) {
-    return c.json({ error: 'Missing or invalid Authorization header' }, 401);
-  }
 
-  const apiKey = authHeader.slice(7);
-  if (!apiKey) {
-    return c.json({ error: 'Empty API key' }, 401);
+  // Also accept ?key= on billing routes (browser redirect flow)
+  const path = new URL(c.req.url).pathname;
+  const queryKey = path.startsWith('/billing/') ? c.req.query('key') : undefined;
+
+  const apiKey = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : (queryKey || '');
+
+  if (!apiKey || !apiKey.startsWith('gsk_')) {
+    return c.json({ error: 'Missing or invalid API key. Run: mem cloud login' }, 401);
   }
 
   const keyHash = await hashApiKey(apiKey);
 
-  const vault = await c.env.DB.prepare(
-    'SELECT vault_id, vault_name FROM vaults WHERE api_key_hash = ?'
-  ).bind(keyHash).first<{ vault_id: string; vault_name: string }>();
+  const result = await c.env.DB.prepare(`
+    SELECT u.id, u.github_id, u.email, u.github_username, u.tier,
+           u.stripe_customer_id, u.stripe_subscription_id, u.created_at, u.updated_at
+    FROM api_keys ak
+    JOIN users u ON ak.user_id = u.id
+    WHERE ak.key_hash = ? AND ak.revoked_at IS NULL
+  `).bind(keyHash).first<User>();
 
-  if (!vault) {
+  if (!result) {
     return c.json({ error: 'Invalid API key' }, 401);
   }
 
-  c.set('vaultId', vault.vault_id);
-  c.set('vaultName', vault.vault_name);
-  await next();
-}
+  // Update last_used_at fire-and-forget
+  c.executionCtx.waitUntil(
+    c.env.DB.prepare("UPDATE api_keys SET last_used_at = datetime('now') WHERE key_hash = ?")
+      .bind(keyHash).run(),
+  );
 
-export { hashApiKey };
+  c.set('user', result);
+  c.set('tier', result.tier as Tier);
+  await next();
+});

--- a/packages/worker/src/auth.ts
+++ b/packages/worker/src/auth.ts
@@ -44,7 +44,7 @@ export const authMiddleware = createMiddleware<{ Bindings: Env }>(async (c, next
 
   // Update last_used_at fire-and-forget
   c.executionCtx.waitUntil(
-    c.env.DB.prepare("UPDATE api_keys SET last_used_at = datetime('now') WHERE key_hash = ?")
+    c.env.DB.prepare("UPDATE api_keys SET last_used_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') WHERE key_hash = ?")
       .bind(keyHash).run(),
   );
 

--- a/packages/worker/src/cron/cleanup.ts
+++ b/packages/worker/src/cron/cleanup.ts
@@ -5,15 +5,15 @@ const CHANGELOG_RETENTION_DAYS = 30;
 
 export async function handleCleanup(env: Env): Promise<void> {
   await env.DB.prepare(`
-    DELETE FROM auth_sessions WHERE expires_at < datetime('now')
+    DELETE FROM auth_sessions WHERE expires_at < strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
   `).run();
 
   await env.DB.prepare(`
-    DELETE FROM rate_limits WHERE created_at < datetime('now', '-${RATE_LIMIT_RETENTION_HOURS} hours')
+    DELETE FROM rate_limits WHERE created_at < strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-${RATE_LIMIT_RETENTION_HOURS} hours')
   `).run();
 
   const result = await env.DB.prepare(`
-    DELETE FROM sync_changelog WHERE timestamp < datetime('now', '-${CHANGELOG_RETENTION_DAYS} days')
+    DELETE FROM sync_changelog WHERE timestamp < strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-${CHANGELOG_RETENTION_DAYS} days')
   `).run();
 
   console.log(`Cleanup: ${result.meta.changes} old changelog entries removed`);

--- a/packages/worker/src/cron/cleanup.ts
+++ b/packages/worker/src/cron/cleanup.ts
@@ -1,0 +1,24 @@
+import type { Env } from '../env.js';
+
+/**
+ * Cron handler: clean up expired sessions, old rate limit records, and old changelog entries.
+ * Runs every hour via Cloudflare Cron Triggers.
+ */
+export async function handleCleanup(env: Env): Promise<void> {
+  // Clean up expired auth sessions
+  await env.DB.prepare(`
+    DELETE FROM auth_sessions WHERE expires_at < datetime('now')
+  `).run();
+
+  // Clean up old rate limit records (2h retention, beyond the 1h window)
+  await env.DB.prepare(`
+    DELETE FROM rate_limits WHERE created_at < datetime('now', '-2 hours')
+  `).run();
+
+  // Clean up old sync changelog entries (keep last 30 days)
+  const result = await env.DB.prepare(`
+    DELETE FROM sync_changelog WHERE timestamp < datetime('now', '-30 days')
+  `).run();
+
+  console.log(`Cleanup complete: ${result.meta.changes} old changelog entries removed`);
+}

--- a/packages/worker/src/cron/cleanup.ts
+++ b/packages/worker/src/cron/cleanup.ts
@@ -1,24 +1,20 @@
 import type { Env } from '../env.js';
 
-/**
- * Cron handler: clean up expired sessions, old rate limit records, and old changelog entries.
- * Runs every hour via Cloudflare Cron Triggers.
- */
+const RATE_LIMIT_RETENTION_HOURS = 2;
+const CHANGELOG_RETENTION_DAYS = 30;
+
 export async function handleCleanup(env: Env): Promise<void> {
-  // Clean up expired auth sessions
   await env.DB.prepare(`
     DELETE FROM auth_sessions WHERE expires_at < datetime('now')
   `).run();
 
-  // Clean up old rate limit records (2h retention, beyond the 1h window)
   await env.DB.prepare(`
-    DELETE FROM rate_limits WHERE created_at < datetime('now', '-2 hours')
+    DELETE FROM rate_limits WHERE created_at < datetime('now', '-${RATE_LIMIT_RETENTION_HOURS} hours')
   `).run();
 
-  // Clean up old sync changelog entries (keep last 30 days)
   const result = await env.DB.prepare(`
-    DELETE FROM sync_changelog WHERE timestamp < datetime('now', '-30 days')
+    DELETE FROM sync_changelog WHERE timestamp < datetime('now', '-${CHANGELOG_RETENTION_DAYS} days')
   `).run();
 
-  console.log(`Cleanup complete: ${result.meta.changes} old changelog entries removed`);
+  console.log(`Cleanup: ${result.meta.changes} old changelog entries removed`);
 }

--- a/packages/worker/src/env.ts
+++ b/packages/worker/src/env.ts
@@ -1,0 +1,9 @@
+export interface Env {
+  DB: D1Database;
+  VAULT_BUCKET: R2Bucket;
+}
+
+export interface AuthedContext {
+  vaultId: string;
+  vaultName: string;
+}

--- a/packages/worker/src/env.ts
+++ b/packages/worker/src/env.ts
@@ -1,9 +1,37 @@
 export interface Env {
   DB: D1Database;
   VAULT_BUCKET: R2Bucket;
+  BASE_URL: string;
+  GITHUB_CLIENT_ID?: string;
+  GITHUB_CLIENT_SECRET?: string;
+  STRIPE_SECRET_KEY?: string;
+  STRIPE_WEBHOOK_SECRET?: string;
+  STRIPE_PRICE_ID?: string;
 }
 
-export interface AuthedContext {
-  vaultId: string;
-  vaultName: string;
+export type Tier = 'free' | 'pro';
+
+export interface User {
+  id: string;
+  github_id: number | null;
+  email: string | null;
+  github_username: string | null;
+  tier: Tier;
+  stripe_customer_id: string | null;
+  stripe_subscription_id: string | null;
+  created_at: string;
+  updated_at: string;
 }
+
+export const TIER_LIMITS = {
+  free: {
+    maxVaults: 1,
+    maxNotesPerVault: 100,
+    rateLimit: 30, // sync pushes per hour
+  },
+  pro: {
+    maxVaults: 10,
+    maxNotesPerVault: 10_000,
+    rateLimit: 300,
+  },
+} as const;

--- a/packages/worker/src/env.ts
+++ b/packages/worker/src/env.ts
@@ -26,12 +26,16 @@ export interface User {
 export const TIER_LIMITS = {
   free: {
     maxVaults: 1,
-    maxNotesPerVault: 100,
-    rateLimit: 30, // sync pushes per hour
+    maxNotesPerVault: 0, // no sync on free tier
+    maxStorageBytes: 0,
+    rateLimit: 0,
+    syncEnabled: false,
   },
   pro: {
     maxVaults: 10,
-    maxNotesPerVault: 10_000,
+    maxNotesPerVault: 50_000,
+    maxStorageBytes: 1_073_741_824, // 1 GB
     rateLimit: 300,
+    syncEnabled: true,
   },
 } as const;

--- a/packages/worker/src/handlers/mcp.ts
+++ b/packages/worker/src/handlers/mcp.ts
@@ -2,7 +2,8 @@ import type { Context } from 'hono';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js';
 import * as z from 'zod/v4';
-import type { Env } from '../env.js';
+import type { Env, Tier } from '../env.js';
+import { TIER_LIMITS } from '../env.js';
 import { R2NoteStorage } from '../storage/r2.js';
 import { D1IndexDatabase } from '../storage/d1.js';
 import { CloudMcpRuntime } from '../runtime.js';
@@ -13,9 +14,10 @@ function getVaultId(c: Context<{ Bindings: Env }>): string {
 
 function createRuntime(c: Context<{ Bindings: Env }>): CloudMcpRuntime {
   const vaultId = getVaultId(c);
+  const tier: Tier = c.get('tier');
   const storage = new R2NoteStorage(c.env.VAULT_BUCKET, vaultId);
   const db = new D1IndexDatabase(c.env.DB, vaultId);
-  return new CloudMcpRuntime(storage, db);
+  return new CloudMcpRuntime(storage, db, TIER_LIMITS[tier].maxNotesPerVault);
 }
 
 function createMcpServer(runtime: CloudMcpRuntime): McpServer {

--- a/packages/worker/src/handlers/mcp.ts
+++ b/packages/worker/src/handlers/mcp.ts
@@ -1,0 +1,213 @@
+import type { Context } from 'hono';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js';
+import * as z from 'zod/v4';
+import type { Env } from '../env.js';
+import { R2NoteStorage } from '../storage/r2.js';
+import { D1IndexDatabase } from '../storage/d1.js';
+import { CloudMcpRuntime } from '../runtime.js';
+
+function getVaultId(c: Context<{ Bindings: Env }>): string {
+  return c.get('vaultId') as string;
+}
+
+function createRuntime(c: Context<{ Bindings: Env }>): CloudMcpRuntime {
+  const vaultId = getVaultId(c);
+  const storage = new R2NoteStorage(c.env.VAULT_BUCKET, vaultId);
+  const db = new D1IndexDatabase(c.env.DB, vaultId);
+  return new CloudMcpRuntime(storage, db);
+}
+
+function createMcpServer(runtime: CloudMcpRuntime): McpServer {
+  const server = new McpServer({
+    name: 'granite-cloud',
+    version: '0.1.0',
+  });
+
+  // --- Read-only tools ---
+
+  server.tool(
+    'granite_get_vault_overview',
+    'Get a summary of the vault',
+    { recent_limit: z.number().optional() },
+    async ({ recent_limit }) => {
+      const overview = await runtime.getVaultOverview(recent_limit);
+      return { content: [{ type: 'text', text: JSON.stringify(overview, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'granite_list_note_types',
+    'List all configured note types',
+    {},
+    async () => {
+      const types = await runtime.listNoteTypes();
+      return { content: [{ type: 'text', text: JSON.stringify(types, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'granite_list_notes',
+    'List notes with optional filters',
+    {
+      type: z.string().optional(),
+      status: z.enum(['inbox', 'active', 'archived']).optional(),
+      source: z.enum(['human', 'agent', 'extraction']).optional(),
+      since: z.string().optional(),
+      limit: z.number().optional(),
+    },
+    async (input) => {
+      const notes = await runtime.listNotes(input);
+      return { content: [{ type: 'text', text: JSON.stringify(notes, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'granite_get_note',
+    'Get a note by slug with full details',
+    { slug: z.string() },
+    async ({ slug }) => {
+      const note = await runtime.getNote(slug);
+      return { content: [{ type: 'text', text: JSON.stringify(note, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'granite_search_notes',
+    'Full-text search across notes',
+    { query: z.string(), limit: z.number().optional() },
+    async ({ query, limit }) => {
+      const results = await runtime.search(query, limit);
+      return { content: [{ type: 'text', text: JSON.stringify(results, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'granite_get_backlinks',
+    'Get notes that link to a given note',
+    { slug: z.string() },
+    async ({ slug }) => {
+      const backlinks = await runtime.getBacklinks(slug);
+      return { content: [{ type: 'text', text: JSON.stringify(backlinks, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'granite_suggest_links',
+    'Suggest wikilinks based on unlinked mentions',
+    { slug: z.string() },
+    async ({ slug }) => {
+      const suggestions = await runtime.suggestLinks(slug);
+      return { content: [{ type: 'text', text: JSON.stringify(suggestions, null, 2) }] };
+    },
+  );
+
+  // --- Write tools ---
+
+  server.tool(
+    'granite_create_note',
+    'Create a new note',
+    {
+      title: z.string(),
+      type: z.string().optional(),
+      body: z.string().optional(),
+      tags: z.array(z.string()).optional(),
+      aliases: z.array(z.string()).optional(),
+      status: z.enum(['inbox', 'active', 'archived']).optional(),
+      source: z.enum(['human', 'agent', 'extraction']).optional(),
+    },
+    async (input) => {
+      const result = await runtime.createNote(input);
+      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'granite_capture_note',
+    'Quick-capture a note from free-form text',
+    {
+      text: z.string(),
+      type: z.string().optional(),
+      tags: z.array(z.string()).optional(),
+      status: z.enum(['inbox', 'active', 'archived']).optional(),
+      source: z.enum(['human', 'agent', 'extraction']).optional(),
+    },
+    async (input) => {
+      const result = await runtime.captureNote(input);
+      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'granite_update_note',
+    'Update an existing note',
+    {
+      slug: z.string(),
+      title: z.string().optional(),
+      body: z.string().optional(),
+      append: z.string().optional(),
+      tags: z.array(z.string()).optional(),
+      aliases: z.array(z.string()).optional(),
+      status: z.enum(['inbox', 'active', 'archived']).optional(),
+      source: z.enum(['human', 'agent', 'extraction']).optional(),
+    },
+    async ({ slug, ...input }) => {
+      const result = await runtime.updateNote(slug, input);
+      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  // --- Resources ---
+
+  server.resource(
+    'vault-config',
+    'granite://vault/config',
+    async (uri) => {
+      const config = await runtime.readVaultConfigRaw();
+      return { contents: [{ uri: uri.href, mimeType: 'text/yaml', text: config }] };
+    },
+  );
+
+  server.resource(
+    'vault-overview',
+    'granite://vault/overview',
+    async (uri) => {
+      const overview = await runtime.getVaultOverview();
+      return { contents: [{ uri: uri.href, mimeType: 'application/json', text: JSON.stringify(overview, null, 2) }] };
+    },
+  );
+
+  return server;
+}
+
+export async function handleMcp(c: Context<{ Bindings: Env }>) {
+  const runtime = createRuntime(c);
+  const server = createMcpServer(runtime);
+
+  const transport = new WebStandardStreamableHTTPServerTransport({
+    sessionIdGenerator: undefined,
+  });
+
+  await server.connect(transport);
+
+  const response = await transport.handleRequest(c.req.raw);
+
+  if (response) {
+    // Add CORS headers
+    const headers = new Headers(response.headers);
+    const origin = c.req.header('Origin');
+    if (origin) {
+      headers.set('Access-Control-Allow-Origin', origin);
+      headers.set('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
+      headers.set('Access-Control-Allow-Headers', 'Content-Type, Authorization, MCP-Protocol-Version, Last-Event-ID');
+      headers.set('Access-Control-Expose-Headers', 'MCP-Session-Id, MCP-Protocol-Version');
+    }
+
+    return new Response(response.body, {
+      status: response.status,
+      headers,
+    });
+  }
+
+  return c.json({ error: 'No response from MCP server' }, 500);
+}

--- a/packages/worker/src/handlers/mcp.ts
+++ b/packages/worker/src/handlers/mcp.ts
@@ -17,7 +17,7 @@ function createRuntime(c: Context<{ Bindings: Env }>): CloudMcpRuntime {
   const tier: Tier = c.get('tier');
   const storage = new R2NoteStorage(c.env.VAULT_BUCKET, vaultId);
   const db = new D1IndexDatabase(c.env.DB, vaultId);
-  return new CloudMcpRuntime(storage, db, TIER_LIMITS[tier].maxNotesPerVault);
+  return new CloudMcpRuntime(storage, db, TIER_LIMITS[tier].maxStorageBytes);
 }
 
 function createMcpServer(runtime: CloudMcpRuntime): McpServer {

--- a/packages/worker/src/handlers/sync.ts
+++ b/packages/worker/src/handlers/sync.ts
@@ -36,15 +36,13 @@ export async function handleSyncPush(c: Context<{ Bindings: Env }>) {
   const payload = await c.req.json<SyncPushPayload>();
   let accepted = 0;
 
-  // Enforce per-vault note limit (net creates = creates - deletes in batch)
+  // Enforce per-vault note limit (only count creates — deletes are untrusted)
   const tier: Tier = c.get('tier');
   const maxNotes = TIER_LIMITS[tier].maxNotesPerVault;
   const createCount = payload.changes.filter(ch => ch.operation === 'create').length;
-  const deleteCount = payload.changes.filter(ch => ch.operation === 'delete').length;
-  const netCreates = Math.max(createCount - deleteCount, 0);
-  if (netCreates > 0) {
+  if (createCount > 0) {
     const currentCount = await db.countNotes();
-    if (currentCount + netCreates > maxNotes) {
+    if (currentCount + createCount > maxNotes) {
       return c.json({
         error: `Vault note limit reached (${maxNotes}). Upgrade to pro for more.`,
         current: currentCount,
@@ -107,9 +105,12 @@ export async function handleSyncPush(c: Context<{ Bindings: Env }>) {
     accepted++;
   }
 
-  // Batch index wikilinks after all notes are upserted (single metadata fetch)
-  for (const { slug, body } of slugsToIndex) {
-    await indexLinks(db, slug, body);
+  // Batch index wikilinks — single metadata fetch shared across all notes
+  if (slugsToIndex.length > 0) {
+    const allNotes = await db.getAllNotesMeta();
+    for (const { slug, body } of slugsToIndex) {
+      await indexLinks(db, slug, body, undefined, allNotes);
+    }
   }
 
   await db.upsertDevice(payload.device_id, payload.device_id);

--- a/packages/worker/src/handlers/sync.ts
+++ b/packages/worker/src/handlers/sync.ts
@@ -36,20 +36,11 @@ export async function handleSyncPush(c: Context<{ Bindings: Env }>) {
   const payload = await c.req.json<SyncPushPayload>();
   let accepted = 0;
 
-  // Enforce per-vault note limit (only count creates — deletes are untrusted)
+  // Enforce per-vault storage limit
   const tier: Tier = c.get('tier');
-  const maxNotes = TIER_LIMITS[tier].maxNotesPerVault;
-  const createCount = payload.changes.filter(ch => ch.operation === 'create').length;
-  if (createCount > 0) {
-    const currentCount = await db.countNotes();
-    if (currentCount + createCount > maxNotes) {
-      return c.json({
-        error: `Vault note limit reached (${maxNotes}). Upgrade to pro for more.`,
-        current: currentCount,
-        limit: maxNotes,
-      }, 403);
-    }
-  }
+  const maxStorage = TIER_LIMITS[tier].maxStorageBytes;
+  const currentStorage = await db.getStorageBytes();
+  let storageDelta = 0;
 
   // Track slugs that need wikilink indexing (deferred to avoid N+1)
   const slugsToIndex: Array<{ slug: string; body: string }> = [];
@@ -68,6 +59,25 @@ export async function handleSyncPush(c: Context<{ Bindings: Env }>) {
       const typeFolder = getTypeFolder(change.frontmatter);
 
       const content = matter.stringify(change.body, change.frontmatter);
+      const contentBytes = new TextEncoder().encode(content).byteLength;
+
+      // Check storage limit before writing
+      const existing = await db.getNote(resolvedSlug);
+      const existingBytes = existing
+        ? new TextEncoder().encode(matter.stringify(existing.body, {})).byteLength
+        : 0;
+      const delta = contentBytes - existingBytes;
+
+      if (delta > 0 && currentStorage + storageDelta + delta > maxStorage) {
+        return c.json({
+          error: 'Vault storage limit reached (1 GB). Manage your notes to free up space.',
+          current_bytes: currentStorage + storageDelta,
+          limit_bytes: maxStorage,
+        }, 403);
+      }
+
+      storageDelta += delta;
+
       await storage.writeNote(typeFolder, resolvedSlug, content);
 
       await db.upsertNote({
@@ -91,6 +101,10 @@ export async function handleSyncPush(c: Context<{ Bindings: Env }>) {
       const indexed = await db.getNoteById(change.note_id);
       if (indexed) {
         const typeFolder = getTypeFolder({ type: indexed.type });
+        const oldContent = matter.stringify(indexed.body, {});
+        const oldBytes = new TextEncoder().encode(oldContent).byteLength;
+        storageDelta -= oldBytes;
+
         await storage.deleteNote(typeFolder, indexed.slug);
         await db.deleteNoteBySlug(indexed.slug);
         deletedSlugs.add(indexed.slug);
@@ -115,6 +129,11 @@ export async function handleSyncPush(c: Context<{ Bindings: Env }>) {
       if (deletedSlugs.has(slug)) continue;
       await indexLinks(db, slug, body, undefined, allNotes);
     }
+  }
+
+  // Update vault storage counter
+  if (storageDelta !== 0) {
+    await db.adjustStorageBytes(storageDelta);
   }
 
   await db.upsertDevice(payload.device_id, payload.device_id);

--- a/packages/worker/src/handlers/sync.ts
+++ b/packages/worker/src/handlers/sync.ts
@@ -53,6 +53,7 @@ export async function handleSyncPush(c: Context<{ Bindings: Env }>) {
 
   // Track slugs that need wikilink indexing (deferred to avoid N+1)
   const slugsToIndex: Array<{ slug: string; body: string }> = [];
+  const deletedSlugs = new Set<string>();
 
   for (const change of payload.changes) {
     // Resolve slug once — used for storage, DB, and changelog
@@ -91,6 +92,7 @@ export async function handleSyncPush(c: Context<{ Bindings: Env }>) {
         const typeFolder = getTypeFolder({ type: indexed.type });
         await storage.deleteNote(typeFolder, indexed.slug);
         await db.deleteNoteBySlug(indexed.slug);
+        deletedSlugs.add(indexed.slug);
       }
     }
 
@@ -109,6 +111,7 @@ export async function handleSyncPush(c: Context<{ Bindings: Env }>) {
   if (slugsToIndex.length > 0) {
     const allNotes = await db.getAllNotesMeta();
     for (const { slug, body } of slugsToIndex) {
+      if (deletedSlugs.has(slug)) continue;
       await indexLinks(db, slug, body, undefined, allNotes);
     }
   }

--- a/packages/worker/src/handlers/sync.ts
+++ b/packages/worker/src/handlers/sync.ts
@@ -34,7 +34,12 @@ export async function handleSyncPush(c: Context<{ Bindings: Env }>) {
   let accepted = 0;
 
   for (const change of payload.changes) {
-    if ((change.operation === 'create' || change.operation === 'update') && change.frontmatter && change.body !== undefined) {
+    if (change.operation === 'create' || change.operation === 'update') {
+      if (!change.frontmatter || change.body === undefined) {
+        // Skip unprocessable changes — don't record in changelog
+        continue;
+      }
+
       const typeFolder = getTypeFolder(change.frontmatter);
       const slug = change.slug || change.note_id;
 
@@ -58,7 +63,7 @@ export async function handleSyncPush(c: Context<{ Bindings: Env }>) {
     } else if (change.operation === 'delete') {
       const indexed = await db.getNoteById(change.note_id);
       if (indexed) {
-        const typeFolder = `notes/${indexed.type}`;
+        const typeFolder = getTypeFolder({ type: indexed.type });
         await storage.deleteNote(typeFolder, indexed.slug);
         await db.deleteNoteBySlug(indexed.slug);
       }

--- a/packages/worker/src/handlers/sync.ts
+++ b/packages/worker/src/handlers/sync.ts
@@ -86,6 +86,7 @@ export async function handleSyncPush(c: Context<{ Bindings: Env }>) {
       });
 
       slugsToIndex.push({ slug: resolvedSlug, body: change.body });
+      deletedSlugs.delete(resolvedSlug);
     } else if (change.operation === 'delete') {
       const indexed = await db.getNoteById(change.note_id);
       if (indexed) {

--- a/packages/worker/src/handlers/sync.ts
+++ b/packages/worker/src/handlers/sync.ts
@@ -63,9 +63,16 @@ export async function handleSyncPush(c: Context<{ Bindings: Env }>) {
 
       // Check storage limit before writing
       const existing = await db.getNote(resolvedSlug);
-      const existingBytes = existing
-        ? new TextEncoder().encode(matter.stringify(existing.body, {})).byteLength
-        : 0;
+      let existingBytes = 0;
+      if (existing) {
+        const existingFolder = getTypeFolder({ type: existing.type });
+        try {
+          const oldContent = await storage.readNote(existingFolder, existing.slug);
+          existingBytes = new TextEncoder().encode(oldContent).byteLength;
+        } catch {
+          // Note missing from R2 — treat as 0 bytes
+        }
+      }
       const delta = contentBytes - existingBytes;
 
       if (delta > 0 && currentStorage + storageDelta + delta > maxStorage) {
@@ -101,8 +108,13 @@ export async function handleSyncPush(c: Context<{ Bindings: Env }>) {
       const indexed = await db.getNoteById(change.note_id);
       if (indexed) {
         const typeFolder = getTypeFolder({ type: indexed.type });
-        const oldContent = matter.stringify(indexed.body, {});
-        const oldBytes = new TextEncoder().encode(oldContent).byteLength;
+        let oldBytes = 0;
+        try {
+          const oldContent = await storage.readNote(typeFolder, indexed.slug);
+          oldBytes = new TextEncoder().encode(oldContent).byteLength;
+        } catch {
+          // Note missing from R2 — treat as 0 bytes
+        }
         storageDelta -= oldBytes;
 
         await storage.deleteNote(typeFolder, indexed.slug);

--- a/packages/worker/src/handlers/sync.ts
+++ b/packages/worker/src/handlers/sync.ts
@@ -125,7 +125,11 @@ export async function handleSyncPull(c: Context<{ Bindings: Env }>) {
   const db = new D1IndexDatabase(c.env.DB, vaultId);
 
   const sinceSeq = Number(c.req.query('since_seq') ?? '0');
-  const deviceId = c.req.query('device_id') ?? '';
+  const deviceId = c.req.query('device_id');
+
+  if (!deviceId) {
+    return c.json({ error: 'Missing device_id parameter' }, 400);
+  }
 
   const changelog = await db.getChangesSince(sinceSeq, deviceId);
 

--- a/packages/worker/src/handlers/sync.ts
+++ b/packages/worker/src/handlers/sync.ts
@@ -4,6 +4,7 @@ import type { Env } from '../env.js';
 import { R2NoteStorage } from '../storage/r2.js';
 import { D1IndexDatabase } from '../storage/d1.js';
 import { parseJsonArray } from '../lib/json.js';
+import { resolveTypeFolder } from '../lib/config.js';
 
 interface SyncChange {
   note_id: string;
@@ -158,14 +159,5 @@ export async function handleSyncDevices(c: Context<{ Bindings: Env }>) {
 
 function getTypeFolder(frontmatter: Record<string, unknown>): string {
   const type = String(frontmatter.type ?? 'fleeting');
-  const folderMap: Record<string, string> = {
-    fleeting: 'notes/fleeting',
-    permanent: 'notes/permanent',
-    reference: 'notes/reference',
-    person: 'notes/people',
-    meeting: 'notes/meetings',
-    project: 'notes/projects',
-    decision: 'notes/decisions',
-  };
-  return folderMap[type] ?? `notes/${type}`;
+  return resolveTypeFolder(type);
 }

--- a/packages/worker/src/handlers/sync.ts
+++ b/packages/worker/src/handlers/sync.ts
@@ -1,0 +1,180 @@
+import type { Context } from 'hono';
+import type { Env } from '../env.js';
+import { R2NoteStorage } from '../storage/r2.js';
+import { D1IndexDatabase } from '../storage/d1.js';
+
+interface SyncChange {
+  note_id: string;
+  operation: string;
+  timestamp: string;
+  checksum: string;
+  slug: string;
+  frontmatter?: Record<string, unknown>;
+  body?: string;
+}
+
+interface SyncPushPayload {
+  device_id: string;
+  last_server_seq: number;
+  changes: SyncChange[];
+}
+
+function getVaultId(c: Context<{ Bindings: Env }>): string {
+  return c.get('vaultId') as string;
+}
+
+export async function handleSyncPush(c: Context<{ Bindings: Env }>) {
+  const vaultId = getVaultId(c);
+  const storage = new R2NoteStorage(c.env.VAULT_BUCKET, vaultId);
+  const db = new D1IndexDatabase(c.env.DB, vaultId);
+
+  const payload = await c.req.json<SyncPushPayload>();
+  let accepted = 0;
+
+  for (const change of payload.changes) {
+    // Write/delete note in R2
+    if ((change.operation === 'create' || change.operation === 'update') && change.frontmatter && change.body !== undefined) {
+      const typeFolder = getTypeFolder(change.frontmatter);
+      const slug = change.slug || change.note_id;
+
+      // Serialize and write to R2
+      const matter = await import('gray-matter');
+      const content = matter.default.stringify(change.body, change.frontmatter);
+      await storage.writeNote(typeFolder, slug, content);
+
+      // Upsert in D1 index
+      await db.upsertNote({
+        slug,
+        id: String(change.note_id),
+        title: String(change.frontmatter.title ?? ''),
+        type: String(change.frontmatter.type ?? 'fleeting'),
+        created: String(change.frontmatter.created ?? ''),
+        modified: String(change.frontmatter.modified ?? ''),
+        tags: JSON.stringify(change.frontmatter.tags ?? []),
+        aliases: JSON.stringify(change.frontmatter.aliases ?? []),
+        body: change.body,
+        filepath: `${typeFolder}/${slug}.md`,
+        status: String(change.frontmatter.status ?? 'active'),
+        source: String(change.frontmatter.source ?? 'human'),
+      });
+    } else if (change.operation === 'delete') {
+      const indexed = await db.getNoteById(change.note_id);
+      if (indexed) {
+        const typeFolder = `notes/${indexed.type}`;
+        await storage.deleteNote(typeFolder, indexed.slug);
+        await db.deleteNoteBySlug(indexed.slug);
+      }
+    }
+
+    // Record in sync changelog
+    await db.recordChange(
+      change.note_id,
+      change.operation,
+      payload.device_id,
+      change.checksum,
+      change.slug || '',
+    );
+
+    accepted++;
+  }
+
+  // Update device info
+  await db.upsertDevice(payload.device_id, payload.device_id);
+  const serverSeq = await db.getLatestSeq();
+  await db.updateDeviceSeq(payload.device_id, serverSeq);
+
+  return c.json({ server_seq: serverSeq, accepted });
+}
+
+export async function handleSyncPull(c: Context<{ Bindings: Env }>) {
+  const vaultId = getVaultId(c);
+  const storage = new R2NoteStorage(c.env.VAULT_BUCKET, vaultId);
+  const db = new D1IndexDatabase(c.env.DB, vaultId);
+
+  const sinceSeq = Number(c.req.query('since_seq') ?? '0');
+  const deviceId = c.req.query('device_id') ?? '';
+
+  const changelog = await db.getChangesSince(sinceSeq, deviceId);
+
+  // Build changes with note content
+  const changes: SyncChange[] = [];
+  for (const entry of changelog) {
+    if (entry.operation === 'delete') {
+      changes.push({
+        note_id: entry.note_id,
+        operation: entry.operation,
+        timestamp: entry.timestamp,
+        checksum: entry.checksum,
+        slug: entry.slug,
+      });
+      continue;
+    }
+
+    // Fetch note content from D1 index
+    const indexed = await db.getNoteById(entry.note_id);
+    if (!indexed) continue;
+
+    // Parse frontmatter from stored data
+    const frontmatter: Record<string, unknown> = {
+      id: indexed.id,
+      title: indexed.title,
+      type: indexed.type,
+      created: indexed.created,
+      modified: indexed.modified,
+      tags: parseJsonArray(indexed.tags),
+      aliases: parseJsonArray(indexed.aliases),
+      status: indexed.status,
+      source: indexed.source,
+    };
+
+    changes.push({
+      note_id: entry.note_id,
+      operation: entry.operation,
+      timestamp: entry.timestamp,
+      checksum: entry.checksum,
+      slug: indexed.slug,
+      frontmatter,
+      body: indexed.body,
+    });
+  }
+
+  const serverSeq = await db.getLatestSeq();
+
+  return c.json({ changes, server_seq: serverSeq });
+}
+
+export async function handleSyncDevices(c: Context<{ Bindings: Env }>) {
+  const vaultId = getVaultId(c);
+  const db = new D1IndexDatabase(c.env.DB, vaultId);
+  const devices = await db.getDevices();
+
+  return c.json(devices.map(d => ({
+    device_id: d.device_id,
+    device_name: d.device_name,
+    last_seen: d.last_seen,
+  })));
+}
+
+function getTypeFolder(frontmatter: Record<string, unknown>): string {
+  const type = String(frontmatter.type ?? 'fleeting');
+  const folderMap: Record<string, string> = {
+    fleeting: 'notes/fleeting',
+    permanent: 'notes/permanent',
+    reference: 'notes/reference',
+    person: 'notes/people',
+    meeting: 'notes/meetings',
+    project: 'notes/projects',
+    decision: 'notes/decisions',
+  };
+  return folderMap[type] ?? `notes/${type}`;
+}
+
+function parseJsonArray(raw: string | null | undefined): string[] {
+  if (!raw) return [];
+  try {
+    const value = JSON.parse(raw);
+    return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : [];
+  } catch {
+    return [];
+  }
+}

--- a/packages/worker/src/handlers/sync.ts
+++ b/packages/worker/src/handlers/sync.ts
@@ -1,6 +1,7 @@
 import type { Context } from 'hono';
 import matter from 'gray-matter';
-import type { Env } from '../env.js';
+import type { Env, Tier } from '../env.js';
+import { TIER_LIMITS } from '../env.js';
 import { R2NoteStorage } from '../storage/r2.js';
 import { D1IndexDatabase } from '../storage/d1.js';
 import { parseJsonArray } from '../lib/json.js';
@@ -34,7 +35,25 @@ export async function handleSyncPush(c: Context<{ Bindings: Env }>) {
   const payload = await c.req.json<SyncPushPayload>();
   let accepted = 0;
 
+  // Enforce per-vault note limit for creates
+  const tier: Tier = c.get('tier');
+  const maxNotes = TIER_LIMITS[tier].maxNotesPerVault;
+  const createCount = payload.changes.filter(ch => ch.operation === 'create').length;
+  if (createCount > 0) {
+    const currentCount = await db.countNotes();
+    if (currentCount + createCount > maxNotes) {
+      return c.json({
+        error: `Vault note limit reached (${maxNotes}). Upgrade to pro for more.`,
+        current: currentCount,
+        limit: maxNotes,
+      }, 403);
+    }
+  }
+
   for (const change of payload.changes) {
+    // Resolve slug once — used for storage, DB, and changelog
+    const resolvedSlug = change.slug || change.note_id;
+
     if (change.operation === 'create' || change.operation === 'update') {
       if (!change.frontmatter || change.body === undefined) {
         // Skip unprocessable changes — don't record in changelog
@@ -42,13 +61,12 @@ export async function handleSyncPush(c: Context<{ Bindings: Env }>) {
       }
 
       const typeFolder = getTypeFolder(change.frontmatter);
-      const slug = change.slug || change.note_id;
 
       const content = matter.stringify(change.body, change.frontmatter);
-      await storage.writeNote(typeFolder, slug, content);
+      await storage.writeNote(typeFolder, resolvedSlug, content);
 
       await db.upsertNote({
-        slug,
+        slug: resolvedSlug,
         id: String(change.note_id),
         title: String(change.frontmatter.title ?? ''),
         type: String(change.frontmatter.type ?? 'fleeting'),
@@ -57,10 +75,13 @@ export async function handleSyncPush(c: Context<{ Bindings: Env }>) {
         tags: JSON.stringify(change.frontmatter.tags ?? []),
         aliases: JSON.stringify(change.frontmatter.aliases ?? []),
         body: change.body,
-        filepath: `${typeFolder}/${slug}.md`,
+        filepath: `${typeFolder}/${resolvedSlug}.md`,
         status: String(change.frontmatter.status ?? 'active'),
         source: String(change.frontmatter.source ?? 'human'),
       });
+
+      // Index wikilinks for backlinks/suggest-links
+      await indexSyncedLinks(db, resolvedSlug, change.body);
     } else if (change.operation === 'delete') {
       const indexed = await db.getNoteById(change.note_id);
       if (indexed) {
@@ -75,7 +96,7 @@ export async function handleSyncPush(c: Context<{ Bindings: Env }>) {
       change.operation,
       payload.device_id,
       change.checksum,
-      change.slug || '',
+      resolvedSlug,
     );
 
     accepted++;
@@ -160,4 +181,43 @@ export async function handleSyncDevices(c: Context<{ Bindings: Env }>) {
 function getTypeFolder(frontmatter: Record<string, unknown>): string {
   const type = String(frontmatter.type ?? 'fleeting');
   return resolveTypeFolder(type);
+}
+
+/**
+ * Parse wikilinks from body and index them in D1 for backlinks/suggest-links.
+ */
+async function indexSyncedLinks(db: D1IndexDatabase, slug: string, body: string): Promise<void> {
+  const cleaned = body
+    .replace(/```[\s\S]*?```/g, '')
+    .replace(/`[^`]*`/g, '');
+
+  const regex = /\[\[([^\]]+)\]\]/g;
+  const allNotes = await db.getAllNotesMeta();
+  const bodyLines = body.split('\n');
+  const links: Array<{ target_slug: string | null; target_raw: string; context: string }> = [];
+  let match;
+
+  while ((match = regex.exec(cleaned)) !== null) {
+    const inner = match[1];
+    const pipeIdx = inner.indexOf('|');
+    const target = pipeIdx >= 0 ? inner.slice(0, pipeIdx).trim() : inner.trim();
+    const raw = match[0];
+
+    const targetSlug = target
+      .normalize('NFD').replace(/[\u0300-\u036f]/g, '')
+      .toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') || 'untitled';
+
+    const found = allNotes.find(n =>
+      n.slug === targetSlug || n.title.toLowerCase() === target.toLowerCase(),
+    );
+
+    const contextLine = bodyLines.find(l => l.includes(raw)) ?? '';
+    links.push({
+      target_slug: found?.slug ?? null,
+      target_raw: target,
+      context: contextLine.trim(),
+    });
+  }
+
+  await db.setLinks(slug, links);
 }

--- a/packages/worker/src/handlers/sync.ts
+++ b/packages/worker/src/handlers/sync.ts
@@ -6,6 +6,7 @@ import { R2NoteStorage } from '../storage/r2.js';
 import { D1IndexDatabase } from '../storage/d1.js';
 import { parseJsonArray } from '../lib/json.js';
 import { resolveTypeFolder } from '../lib/config.js';
+import { indexLinks } from '../lib/wikilinks.js';
 
 interface SyncChange {
   note_id: string;
@@ -35,13 +36,15 @@ export async function handleSyncPush(c: Context<{ Bindings: Env }>) {
   const payload = await c.req.json<SyncPushPayload>();
   let accepted = 0;
 
-  // Enforce per-vault note limit for creates
+  // Enforce per-vault note limit (net creates = creates - deletes in batch)
   const tier: Tier = c.get('tier');
   const maxNotes = TIER_LIMITS[tier].maxNotesPerVault;
   const createCount = payload.changes.filter(ch => ch.operation === 'create').length;
-  if (createCount > 0) {
+  const deleteCount = payload.changes.filter(ch => ch.operation === 'delete').length;
+  const netCreates = Math.max(createCount - deleteCount, 0);
+  if (netCreates > 0) {
     const currentCount = await db.countNotes();
-    if (currentCount + createCount > maxNotes) {
+    if (currentCount + netCreates > maxNotes) {
       return c.json({
         error: `Vault note limit reached (${maxNotes}). Upgrade to pro for more.`,
         current: currentCount,
@@ -49,6 +52,9 @@ export async function handleSyncPush(c: Context<{ Bindings: Env }>) {
       }, 403);
     }
   }
+
+  // Track slugs that need wikilink indexing (deferred to avoid N+1)
+  const slugsToIndex: Array<{ slug: string; body: string }> = [];
 
   for (const change of payload.changes) {
     // Resolve slug once — used for storage, DB, and changelog
@@ -80,8 +86,7 @@ export async function handleSyncPush(c: Context<{ Bindings: Env }>) {
         source: String(change.frontmatter.source ?? 'human'),
       });
 
-      // Index wikilinks for backlinks/suggest-links
-      await indexSyncedLinks(db, resolvedSlug, change.body);
+      slugsToIndex.push({ slug: resolvedSlug, body: change.body });
     } else if (change.operation === 'delete') {
       const indexed = await db.getNoteById(change.note_id);
       if (indexed) {
@@ -100,6 +105,11 @@ export async function handleSyncPush(c: Context<{ Bindings: Env }>) {
     );
 
     accepted++;
+  }
+
+  // Batch index wikilinks after all notes are upserted (single metadata fetch)
+  for (const { slug, body } of slugsToIndex) {
+    await indexLinks(db, slug, body);
   }
 
   await db.upsertDevice(payload.device_id, payload.device_id);
@@ -181,43 +191,4 @@ export async function handleSyncDevices(c: Context<{ Bindings: Env }>) {
 function getTypeFolder(frontmatter: Record<string, unknown>): string {
   const type = String(frontmatter.type ?? 'fleeting');
   return resolveTypeFolder(type);
-}
-
-/**
- * Parse wikilinks from body and index them in D1 for backlinks/suggest-links.
- */
-async function indexSyncedLinks(db: D1IndexDatabase, slug: string, body: string): Promise<void> {
-  const cleaned = body
-    .replace(/```[\s\S]*?```/g, '')
-    .replace(/`[^`]*`/g, '');
-
-  const regex = /\[\[([^\]]+)\]\]/g;
-  const allNotes = await db.getAllNotesMeta();
-  const bodyLines = body.split('\n');
-  const links: Array<{ target_slug: string | null; target_raw: string; context: string }> = [];
-  let match;
-
-  while ((match = regex.exec(cleaned)) !== null) {
-    const inner = match[1];
-    const pipeIdx = inner.indexOf('|');
-    const target = pipeIdx >= 0 ? inner.slice(0, pipeIdx).trim() : inner.trim();
-    const raw = match[0];
-
-    const targetSlug = target
-      .normalize('NFD').replace(/[\u0300-\u036f]/g, '')
-      .toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') || 'untitled';
-
-    const found = allNotes.find(n =>
-      n.slug === targetSlug || n.title.toLowerCase() === target.toLowerCase(),
-    );
-
-    const contextLine = bodyLines.find(l => l.includes(raw)) ?? '';
-    links.push({
-      target_slug: found?.slug ?? null,
-      target_raw: target,
-      context: contextLine.trim(),
-    });
-  }
-
-  await db.setLinks(slug, links);
 }

--- a/packages/worker/src/handlers/sync.ts
+++ b/packages/worker/src/handlers/sync.ts
@@ -1,7 +1,9 @@
 import type { Context } from 'hono';
+import matter from 'gray-matter';
 import type { Env } from '../env.js';
 import { R2NoteStorage } from '../storage/r2.js';
 import { D1IndexDatabase } from '../storage/d1.js';
+import { parseJsonArray } from '../lib/json.js';
 
 interface SyncChange {
   note_id: string;
@@ -36,8 +38,7 @@ export async function handleSyncPush(c: Context<{ Bindings: Env }>) {
       const typeFolder = getTypeFolder(change.frontmatter);
       const slug = change.slug || change.note_id;
 
-      const matter = await import('gray-matter');
-      const content = matter.default.stringify(change.body, change.frontmatter);
+      const content = matter.stringify(change.body, change.frontmatter);
       await storage.writeNote(typeFolder, slug, content);
 
       await db.upsertNote({
@@ -90,6 +91,12 @@ export async function handleSyncPull(c: Context<{ Bindings: Env }>) {
 
   const changelog = await db.getChangesSince(sinceSeq, deviceId);
 
+  // Batch-fetch all note IDs we need (avoid N+1 queries)
+  const noteIds = [...new Set(
+    changelog.filter(e => e.operation !== 'delete').map(e => e.note_id),
+  )];
+  const notesMap = await db.getNotesByIds(noteIds);
+
   const changes: SyncChange[] = [];
   for (const entry of changelog) {
     if (entry.operation === 'delete') {
@@ -103,20 +110,8 @@ export async function handleSyncPull(c: Context<{ Bindings: Env }>) {
       continue;
     }
 
-    const indexed = await db.getNoteById(entry.note_id);
+    const indexed = notesMap.get(entry.note_id);
     if (!indexed) continue;
-
-    const frontmatter: Record<string, unknown> = {
-      id: indexed.id,
-      title: indexed.title,
-      type: indexed.type,
-      created: indexed.created,
-      modified: indexed.modified,
-      tags: parseJsonArray(indexed.tags),
-      aliases: parseJsonArray(indexed.aliases),
-      status: indexed.status,
-      source: indexed.source,
-    };
 
     changes.push({
       note_id: entry.note_id,
@@ -124,7 +119,17 @@ export async function handleSyncPull(c: Context<{ Bindings: Env }>) {
       timestamp: entry.timestamp,
       checksum: entry.checksum,
       slug: indexed.slug,
-      frontmatter,
+      frontmatter: {
+        id: indexed.id,
+        title: indexed.title,
+        type: indexed.type,
+        created: indexed.created,
+        modified: indexed.modified,
+        tags: parseJsonArray(indexed.tags),
+        aliases: parseJsonArray(indexed.aliases),
+        status: indexed.status,
+        source: indexed.source,
+      },
       body: indexed.body,
     });
   }
@@ -158,14 +163,4 @@ function getTypeFolder(frontmatter: Record<string, unknown>): string {
     decision: 'notes/decisions',
   };
   return folderMap[type] ?? `notes/${type}`;
-}
-
-function parseJsonArray(raw: string | null | undefined): string[] {
-  if (!raw) return [];
-  try {
-    const value = JSON.parse(raw);
-    return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : [];
-  } catch {
-    return [];
-  }
 }

--- a/packages/worker/src/handlers/sync.ts
+++ b/packages/worker/src/handlers/sync.ts
@@ -32,17 +32,14 @@ export async function handleSyncPush(c: Context<{ Bindings: Env }>) {
   let accepted = 0;
 
   for (const change of payload.changes) {
-    // Write/delete note in R2
     if ((change.operation === 'create' || change.operation === 'update') && change.frontmatter && change.body !== undefined) {
       const typeFolder = getTypeFolder(change.frontmatter);
       const slug = change.slug || change.note_id;
 
-      // Serialize and write to R2
       const matter = await import('gray-matter');
       const content = matter.default.stringify(change.body, change.frontmatter);
       await storage.writeNote(typeFolder, slug, content);
 
-      // Upsert in D1 index
       await db.upsertNote({
         slug,
         id: String(change.note_id),
@@ -66,7 +63,6 @@ export async function handleSyncPush(c: Context<{ Bindings: Env }>) {
       }
     }
 
-    // Record in sync changelog
     await db.recordChange(
       change.note_id,
       change.operation,
@@ -78,7 +74,6 @@ export async function handleSyncPush(c: Context<{ Bindings: Env }>) {
     accepted++;
   }
 
-  // Update device info
   await db.upsertDevice(payload.device_id, payload.device_id);
   const serverSeq = await db.getLatestSeq();
   await db.updateDeviceSeq(payload.device_id, serverSeq);
@@ -88,7 +83,6 @@ export async function handleSyncPush(c: Context<{ Bindings: Env }>) {
 
 export async function handleSyncPull(c: Context<{ Bindings: Env }>) {
   const vaultId = getVaultId(c);
-  const storage = new R2NoteStorage(c.env.VAULT_BUCKET, vaultId);
   const db = new D1IndexDatabase(c.env.DB, vaultId);
 
   const sinceSeq = Number(c.req.query('since_seq') ?? '0');
@@ -96,7 +90,6 @@ export async function handleSyncPull(c: Context<{ Bindings: Env }>) {
 
   const changelog = await db.getChangesSince(sinceSeq, deviceId);
 
-  // Build changes with note content
   const changes: SyncChange[] = [];
   for (const entry of changelog) {
     if (entry.operation === 'delete') {
@@ -110,11 +103,9 @@ export async function handleSyncPull(c: Context<{ Bindings: Env }>) {
       continue;
     }
 
-    // Fetch note content from D1 index
     const indexed = await db.getNoteById(entry.note_id);
     if (!indexed) continue;
 
-    // Parse frontmatter from stored data
     const frontmatter: Record<string, unknown> = {
       id: indexed.id,
       title: indexed.title,

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -28,7 +28,11 @@ app.get('/health', (c) => c.json({ status: 'ok', service: 'granite-cloud' }));
 // Auth routes (no auth required — these handle OAuth flow)
 app.route('/', authRoutes);
 
-// Stripe webhook (no auth — verified via signature)
+// Billing checkout/portal (auth required — must register before route mount)
+app.use('/billing/checkout', authMiddleware);
+app.use('/billing/portal', authMiddleware);
+
+// Billing routes (webhook has no auth — verified via Stripe signature)
 app.route('/', billingRoutes);
 
 // --- Protected routes (require auth) ---
@@ -42,10 +46,6 @@ app.route('/', keysRoutes);
 app.use('/me', authMiddleware);
 app.use('/vaults', authMiddleware);
 app.route('/', userRoutes);
-
-// Billing checkout/portal (auth + browser key param)
-app.use('/billing/checkout', authMiddleware);
-app.use('/billing/portal', authMiddleware);
 
 // MCP endpoint (auth + vault resolution)
 app.use('/mcp', authMiddleware);

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -10,6 +10,7 @@ import authRoutes from './routes/auth.js';
 import keysRoutes from './routes/keys.js';
 import billingRoutes from './routes/billing.js';
 import userRoutes from './routes/user.js';
+import { requirePaidTier } from './middleware/tier-gate.js';
 import { handleCleanup } from './cron/cleanup.js';
 
 const app = new Hono<{ Bindings: Env }>();
@@ -47,13 +48,15 @@ app.use('/me', authMiddleware);
 app.use('/vaults', authMiddleware);
 app.route('/', userRoutes);
 
-// MCP endpoint (auth + vault resolution)
+// MCP endpoint (auth + paid tier + vault resolution)
 app.use('/mcp', authMiddleware);
+app.use('/mcp', requirePaidTier);
 app.use('/mcp', vaultMiddleware);
 app.post('/mcp', handleMcp);
 
-// Sync relay endpoints (auth + vault resolution + rate limit)
+// Sync relay endpoints (auth + paid tier + vault resolution + rate limit)
 app.use('/v1/sync/*', authMiddleware);
+app.use('/v1/sync/*', requirePaidTier);
 app.use('/v1/sync/*', vaultMiddleware);
 app.use('/v1/sync/push', rateLimitMiddleware);
 app.post('/v1/sync/push', handleSyncPush);

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -2,33 +2,78 @@ import { Hono } from 'hono';
 import { cors } from 'hono/cors';
 import type { Env } from './env.js';
 import { authMiddleware } from './auth.js';
+import { vaultMiddleware } from './middleware/vault.js';
+import { rateLimitMiddleware } from './middleware/rate-limit.js';
 import { handleMcp } from './handlers/mcp.js';
 import { handleSyncPush, handleSyncPull, handleSyncDevices } from './handlers/sync.js';
+import authRoutes from './routes/auth.js';
+import keysRoutes from './routes/keys.js';
+import billingRoutes from './routes/billing.js';
+import userRoutes from './routes/user.js';
+import { handleCleanup } from './cron/cleanup.js';
 
 const app = new Hono<{ Bindings: Env }>();
 
-// CORS for MCP clients (Claude Desktop, etc.)
-app.use('/mcp', cors({
+// CORS for all routes
+app.use('*', cors({
   origin: '*',
   allowMethods: ['GET', 'POST', 'DELETE', 'OPTIONS'],
-  allowHeaders: ['Content-Type', 'Authorization', 'MCP-Protocol-Version', 'Last-Event-ID'],
-  exposeHeaders: ['MCP-Session-Id', 'MCP-Protocol-Version'],
+  allowHeaders: ['Content-Type', 'Authorization', 'MCP-Protocol-Version', 'Last-Event-ID', 'X-Vault-Id'],
+  exposeHeaders: ['MCP-Session-Id', 'MCP-Protocol-Version', 'X-RateLimit-Limit', 'X-RateLimit-Remaining'],
 }));
 
-// Auth on protected routes
-app.use('/mcp', authMiddleware);
-app.use('/v1/sync/*', authMiddleware);
+// Health check (no auth)
+app.get('/health', (c) => c.json({ status: 'ok', service: 'granite-cloud' }));
 
-// MCP endpoint
+// Auth routes (no auth required — these handle OAuth flow)
+app.route('/', authRoutes);
+
+// Stripe webhook (no auth — verified via signature)
+app.route('/', billingRoutes);
+
+// --- Protected routes (require auth) ---
+
+// API key management
+app.use('/keys', authMiddleware);
+app.use('/keys/*', authMiddleware);
+app.route('/', keysRoutes);
+
+// User profile & vault management
+app.use('/me', authMiddleware);
+app.use('/vaults', authMiddleware);
+app.route('/', userRoutes);
+
+// Billing checkout/portal (auth + browser key param)
+app.use('/billing/checkout', authMiddleware);
+app.use('/billing/portal', authMiddleware);
+
+// MCP endpoint (auth + vault resolution)
+app.use('/mcp', authMiddleware);
+app.use('/mcp', vaultMiddleware);
 app.post('/mcp', handleMcp);
 
-// Sync relay endpoints
+// Sync relay endpoints (auth + vault resolution + rate limit)
+app.use('/v1/sync/*', authMiddleware);
+app.use('/v1/sync/*', vaultMiddleware);
+app.use('/v1/sync/push', rateLimitMiddleware);
 app.post('/v1/sync/push', handleSyncPush);
 app.get('/v1/sync/pull', handleSyncPull);
 app.get('/v1/sync/devices', handleSyncDevices);
 app.get('/v1/sync/ping', (c) => c.json({ ok: true }));
 
-// Health check (no auth)
-app.get('/health', (c) => c.json({ status: 'ok', service: 'granite-cloud' }));
+// 404 fallback
+app.notFound((c) => c.json({ error: 'Not found' }, 404));
 
-export default app;
+// Error handler
+app.onError((err, c) => {
+  console.error('Unhandled error:', err);
+  return c.json({ error: 'Internal server error' }, 500);
+});
+
+export default {
+  fetch: app.fetch,
+
+  async scheduled(event: ScheduledEvent, env: Env, ctx: ExecutionContext): Promise<void> {
+    ctx.waitUntil(handleCleanup(env));
+  },
+};

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -1,0 +1,34 @@
+import { Hono } from 'hono';
+import { cors } from 'hono/cors';
+import type { Env } from './env.js';
+import { authMiddleware } from './auth.js';
+import { handleMcp } from './handlers/mcp.js';
+import { handleSyncPush, handleSyncPull, handleSyncDevices } from './handlers/sync.js';
+
+const app = new Hono<{ Bindings: Env }>();
+
+// CORS for MCP clients (Claude Desktop, etc.)
+app.use('/mcp', cors({
+  origin: '*',
+  allowMethods: ['GET', 'POST', 'DELETE', 'OPTIONS'],
+  allowHeaders: ['Content-Type', 'Authorization', 'MCP-Protocol-Version', 'Last-Event-ID'],
+  exposeHeaders: ['MCP-Session-Id', 'MCP-Protocol-Version'],
+}));
+
+// Auth on protected routes
+app.use('/mcp', authMiddleware);
+app.use('/v1/sync/*', authMiddleware);
+
+// MCP endpoint
+app.post('/mcp', handleMcp);
+
+// Sync relay endpoints
+app.post('/v1/sync/push', handleSyncPush);
+app.get('/v1/sync/pull', handleSyncPull);
+app.get('/v1/sync/devices', handleSyncDevices);
+app.get('/v1/sync/ping', (c) => c.json({ ok: true }));
+
+// Health check (no auth)
+app.get('/health', (c) => c.json({ status: 'ok', service: 'granite-cloud' }));
+
+export default app;

--- a/packages/worker/src/lib/api-key.ts
+++ b/packages/worker/src/lib/api-key.ts
@@ -2,24 +2,15 @@ import { nanoid } from 'nanoid';
 
 const API_KEY_PREFIX = 'gsk_';
 
-/**
- * Generate a new API key: gsk_ + 43 random chars (~256 bits entropy).
- */
 export function generateApiKey(): string {
   return API_KEY_PREFIX + nanoid(43);
 }
 
-/**
- * Get the visible prefix of an API key (first 10 chars after gsk_)
- * for display in key listings without exposing the full key.
- */
+// Returns first 10 chars after prefix for safe display without exposing full key
 export function getKeyPrefix(apiKey: string): string {
   return apiKey.slice(0, API_KEY_PREFIX.length + 10);
 }
 
-/**
- * SHA-256 hash of an API key for storage.
- */
 export async function hashApiKey(key: string): Promise<string> {
   const encoder = new TextEncoder();
   const data = encoder.encode(key);

--- a/packages/worker/src/lib/api-key.ts
+++ b/packages/worker/src/lib/api-key.ts
@@ -1,0 +1,29 @@
+import { nanoid } from 'nanoid';
+
+const API_KEY_PREFIX = 'gsk_';
+
+/**
+ * Generate a new API key: gsk_ + 43 random chars (~256 bits entropy).
+ */
+export function generateApiKey(): string {
+  return API_KEY_PREFIX + nanoid(43);
+}
+
+/**
+ * Get the visible prefix of an API key (first 10 chars after gsk_)
+ * for display in key listings without exposing the full key.
+ */
+export function getKeyPrefix(apiKey: string): string {
+  return apiKey.slice(0, API_KEY_PREFIX.length + 10);
+}
+
+/**
+ * SHA-256 hash of an API key for storage.
+ */
+export async function hashApiKey(key: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(key);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  return hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
+}

--- a/packages/worker/src/lib/config.ts
+++ b/packages/worker/src/lib/config.ts
@@ -1,0 +1,21 @@
+/**
+ * Default note type → folder mapping shared between sync handlers and MCP runtime.
+ * These match the defaults in the main Granite CLI config (src/core/config.ts).
+ */
+export const DEFAULT_TYPE_FOLDERS: Record<string, string> = {
+  fleeting: 'notes/fleeting',
+  permanent: 'notes/permanent',
+  reference: 'notes/reference',
+  person: 'notes/people',
+  meeting: 'notes/meetings',
+  project: 'notes/projects',
+  decision: 'notes/decisions',
+};
+
+/**
+ * Resolve the folder for a given note type. Uses config-provided folder
+ * if available, then the default mapping, then falls back to `notes/${type}`.
+ */
+export function resolveTypeFolder(type: string, configFolder?: string): string {
+  return configFolder ?? DEFAULT_TYPE_FOLDERS[type] ?? `notes/${type}`;
+}

--- a/packages/worker/src/lib/json.ts
+++ b/packages/worker/src/lib/json.ts
@@ -1,0 +1,9 @@
+export function parseJsonArray(raw: string | null | undefined): string[] {
+  if (!raw) return [];
+  try {
+    const value = JSON.parse(raw);
+    return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : [];
+  } catch {
+    return [];
+  }
+}

--- a/packages/worker/src/lib/rate-limit.ts
+++ b/packages/worker/src/lib/rate-limit.ts
@@ -1,0 +1,15 @@
+import type { User } from '../env.js';
+
+/**
+ * Determine the rate limit identifier for a request.
+ * Authenticated users are identified by user_id, anonymous by IP.
+ */
+export function getRateLimitIdentifier(
+  user: User | null,
+  cfConnectingIp: string | null,
+  xForwardedFor: string | null,
+): string {
+  if (user) return user.id;
+  const ip = cfConnectingIp || xForwardedFor?.split(',')[0]?.trim() || 'unknown';
+  return `ip:${ip}`;
+}

--- a/packages/worker/src/lib/stripe.ts
+++ b/packages/worker/src/lib/stripe.ts
@@ -128,7 +128,7 @@ export async function verifyWebhookSignature(
   return signatures.some(sig => timingSafeEqual(sig, expectedSignature));
 }
 
-function timingSafeEqual(a: string, b: string): boolean {
+export function timingSafeEqual(a: string, b: string): boolean {
   if (a.length !== b.length) return false;
   let result = 0;
   for (let i = 0; i < a.length; i++) {

--- a/packages/worker/src/lib/stripe.ts
+++ b/packages/worker/src/lib/stripe.ts
@@ -1,0 +1,138 @@
+/**
+ * Minimal Stripe API client using fetch.
+ * No SDK needed — Cloudflare Workers calls the Stripe REST API directly.
+ */
+export class StripeClient {
+  private secretKey: string;
+  private baseUrl = 'https://api.stripe.com/v1';
+
+  constructor(secretKey: string) {
+    this.secretKey = secretKey;
+  }
+
+  private async request(
+    method: string,
+    path: string,
+    body?: Record<string, string>,
+  ): Promise<Record<string, unknown>> {
+    const headers: Record<string, string> = {
+      'Authorization': `Bearer ${this.secretKey}`,
+      'Content-Type': 'application/x-www-form-urlencoded',
+    };
+
+    const response = await fetch(`${this.baseUrl}${path}`, {
+      method,
+      headers,
+      body: body ? new URLSearchParams(body).toString() : undefined,
+    });
+
+    const data = (await response.json()) as Record<string, unknown>;
+    if (!response.ok) {
+      const error = data.error as { message?: string } | undefined;
+      throw new Error(error?.message || `Stripe API error: ${response.status}`);
+    }
+    return data;
+  }
+
+  async createCheckoutSession(params: {
+    priceId: string;
+    customerId?: string;
+    customerEmail?: string;
+    metadata: Record<string, string>;
+    successUrl: string;
+    cancelUrl: string;
+  }): Promise<{ id: string; url: string }> {
+    const body: Record<string, string> = {
+      'mode': 'subscription',
+      'line_items[0][price]': params.priceId,
+      'line_items[0][quantity]': '1',
+      'success_url': params.successUrl,
+      'cancel_url': params.cancelUrl,
+    };
+
+    if (params.customerId) {
+      body['customer'] = params.customerId;
+    } else if (params.customerEmail) {
+      body['customer_email'] = params.customerEmail;
+    }
+
+    for (const [key, value] of Object.entries(params.metadata)) {
+      body[`metadata[${key}]`] = value;
+    }
+
+    const data = await this.request('POST', '/checkout/sessions', body);
+    return { id: data.id as string, url: data.url as string };
+  }
+
+  async createPortalSession(params: {
+    customerId: string;
+    returnUrl: string;
+  }): Promise<{ url: string }> {
+    const data = await this.request('POST', '/billing_portal/sessions', {
+      'customer': params.customerId,
+      'return_url': params.returnUrl,
+    });
+    return { url: data.url as string };
+  }
+
+  async getSubscription(subscriptionId: string): Promise<{
+    id: string;
+    status: string;
+    customer: string;
+  }> {
+    const data = await this.request('GET', `/subscriptions/${subscriptionId}`);
+    return {
+      id: data.id as string,
+      status: data.status as string,
+      customer: data.customer as string,
+    };
+  }
+}
+
+/**
+ * Verify Stripe webhook signature (no SDK needed).
+ */
+export async function verifyWebhookSignature(
+  payload: string,
+  sigHeader: string,
+  secret: string,
+  toleranceSeconds = 300,
+): Promise<boolean> {
+  const parts = sigHeader.split(',');
+  const timestamp = parts.find(p => p.startsWith('t='))?.slice(2);
+  const signatures = parts.filter(p => p.startsWith('v1=')).map(p => p.slice(3));
+
+  if (!timestamp || signatures.length === 0) return false;
+
+  const ts = parseInt(timestamp, 10);
+  const now = Math.floor(Date.now() / 1000);
+  if (Math.abs(now - ts) > toleranceSeconds) return false;
+
+  const signedPayload = `${timestamp}.${payload}`;
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const signatureBuffer = await crypto.subtle.sign(
+    'HMAC',
+    key,
+    new TextEncoder().encode(signedPayload),
+  );
+  const expectedSignature = Array.from(new Uint8Array(signatureBuffer))
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('');
+
+  return signatures.some(sig => timingSafeEqual(sig, expectedSignature));
+}
+
+function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let result = 0;
+  for (let i = 0; i < a.length; i++) {
+    result |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return result === 0;
+}

--- a/packages/worker/src/lib/wikilinks.ts
+++ b/packages/worker/src/lib/wikilinks.ts
@@ -1,0 +1,99 @@
+import type { D1IndexDatabase } from '../storage/d1.js';
+
+interface WikiLink {
+  raw: string;
+  target: string;
+  display: string;
+  resolved: boolean;
+  resolved_slug?: string;
+}
+
+interface NoteMeta {
+  slug: string;
+  title: string;
+}
+
+function slugify(title: string): string {
+  return title
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    || 'untitled';
+}
+
+/**
+ * Parse [[wikilinks]] from a note body, stripping code blocks and inline code.
+ */
+export function parseWikilinks(body: string): WikiLink[] {
+  const cleaned = body
+    .replace(/```[\s\S]*?```/g, '')
+    .replace(/`[^`]*`/g, '');
+
+  const links: WikiLink[] = [];
+  const regex = /\[\[([^\]]+)\]\]/g;
+  let match;
+
+  while ((match = regex.exec(cleaned)) !== null) {
+    const inner = match[1];
+    const pipeIndex = inner.indexOf('|');
+    const target = pipeIndex >= 0 ? inner.slice(0, pipeIndex).trim() : inner.trim();
+    const display = pipeIndex >= 0 ? inner.slice(pipeIndex + 1).trim() : inner.trim();
+
+    links.push({
+      raw: match[0],
+      target,
+      display,
+      resolved: false,
+    });
+  }
+
+  return links;
+}
+
+/**
+ * Resolve wikilinks against a list of known notes and return resolved links.
+ */
+export function resolveWikilinks(
+  links: WikiLink[],
+  allNotes: NoteMeta[],
+): WikiLink[] {
+  return links.map(link => {
+    const targetSlug = slugify(link.target);
+    const found = allNotes.find(n =>
+      n.slug === targetSlug ||
+      n.title.toLowerCase() === link.target.toLowerCase(),
+    );
+    return { ...link, resolved: !!found, resolved_slug: found?.slug };
+  });
+}
+
+/**
+ * Parse wikilinks from body, resolve against all notes, and persist to D1 links table.
+ */
+export async function indexLinks(
+  db: D1IndexDatabase,
+  slug: string,
+  body: string,
+  preParsedLinks?: WikiLink[],
+): Promise<void> {
+  const wikilinks = preParsedLinks ?? parseWikilinks(body);
+  const allNotes = await db.getAllNotesMeta();
+  const bodyLines = body.split('\n');
+
+  const indexedLinks = wikilinks.map(link => {
+    const targetSlug = slugify(link.target);
+    const found = allNotes.find(n =>
+      n.slug === targetSlug || n.title.toLowerCase() === link.target.toLowerCase(),
+    );
+    const contextLine = bodyLines.find(l => l.includes(link.raw)) ?? '';
+    return {
+      target_slug: found?.slug ?? null,
+      target_raw: link.target,
+      context: contextLine.trim(),
+    };
+  });
+
+  await db.setLinks(slug, indexedLinks);
+}

--- a/packages/worker/src/lib/wikilinks.ts
+++ b/packages/worker/src/lib/wikilinks.ts
@@ -77,9 +77,10 @@ export async function indexLinks(
   slug: string,
   body: string,
   preParsedLinks?: WikiLink[],
+  preloadedNotes?: NoteMeta[],
 ): Promise<void> {
   const wikilinks = preParsedLinks ?? parseWikilinks(body);
-  const allNotes = await db.getAllNotesMeta();
+  const allNotes = preloadedNotes ?? await db.getAllNotesMeta();
   const bodyLines = body.split('\n');
 
   const indexedLinks = wikilinks.map(link => {

--- a/packages/worker/src/lib/wikilinks.ts
+++ b/packages/worker/src/lib/wikilinks.ts
@@ -13,7 +13,7 @@ interface NoteMeta {
   title: string;
 }
 
-function slugify(title: string): string {
+export function slugify(title: string): string {
   return title
     .normalize('NFD')
     .replace(/[\u0300-\u036f]/g, '')

--- a/packages/worker/src/middleware/rate-limit.ts
+++ b/packages/worker/src/middleware/rate-limit.ts
@@ -1,0 +1,44 @@
+import { createMiddleware } from 'hono/factory';
+import type { Env, Tier } from '../env.js';
+import { TIER_LIMITS } from '../env.js';
+import { getRateLimitIdentifier } from '../lib/rate-limit.js';
+
+export const rateLimitMiddleware = createMiddleware<{ Bindings: Env }>(async (c, next) => {
+  const tier: Tier = c.get('tier');
+  const user = c.get('user');
+  const limits = TIER_LIMITS[tier];
+
+  const identifier = getRateLimitIdentifier(
+    user,
+    c.req.header('CF-Connecting-IP') || null,
+    c.req.header('X-Forwarded-For') || null,
+  );
+
+  const action = 'sync';
+
+  const result = await c.env.DB.prepare(`
+    SELECT COUNT(*) as count FROM rate_limits
+    WHERE identifier = ? AND action = ? AND created_at > datetime('now', '-1 hour')
+  `).bind(identifier, action).first<{ count: number }>();
+
+  const count = result?.count ?? 0;
+
+  if (count >= limits.rateLimit) {
+    return c.json({
+      error: 'Rate limit exceeded',
+      limit: limits.rateLimit,
+      window: '1 hour',
+      tier,
+    }, 429);
+  }
+
+  // Insert before next() to prevent race conditions
+  await c.env.DB.prepare(`
+    INSERT INTO rate_limits (identifier, action) VALUES (?, ?)
+  `).bind(identifier, action).run();
+
+  c.header('X-RateLimit-Limit', String(limits.rateLimit));
+  c.header('X-RateLimit-Remaining', String(limits.rateLimit - count - 1));
+
+  return next();
+});

--- a/packages/worker/src/middleware/rate-limit.ts
+++ b/packages/worker/src/middleware/rate-limit.ts
@@ -18,7 +18,7 @@ export const rateLimitMiddleware = createMiddleware<{ Bindings: Env }>(async (c,
 
   const result = await c.env.DB.prepare(`
     SELECT COUNT(*) as count FROM rate_limits
-    WHERE identifier = ? AND action = ? AND created_at > datetime('now', '-1 hour')
+    WHERE identifier = ? AND action = ? AND created_at > strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-1 hour')
   `).bind(identifier, action).first<{ count: number }>();
 
   const count = result?.count ?? 0;

--- a/packages/worker/src/middleware/tier-gate.ts
+++ b/packages/worker/src/middleware/tier-gate.ts
@@ -1,0 +1,21 @@
+import { createMiddleware } from 'hono/factory';
+import type { Env, Tier } from '../env.js';
+import { TIER_LIMITS } from '../env.js';
+
+/**
+ * Middleware that blocks free-tier users from sync/MCP endpoints.
+ * Must be registered after authMiddleware (which sets `tier`).
+ */
+export const requirePaidTier = createMiddleware<{ Bindings: Env }>(async (c, next) => {
+  const tier: Tier = c.get('tier');
+
+  if (!TIER_LIMITS[tier].syncEnabled) {
+    return c.json({
+      error: 'Sync requires a Pro subscription. Run: mem cloud upgrade',
+      tier,
+      upgrade_url: `${c.env.BASE_URL}/billing/checkout`,
+    }, 403);
+  }
+
+  return next();
+});

--- a/packages/worker/src/middleware/vault.ts
+++ b/packages/worker/src/middleware/vault.ts
@@ -1,0 +1,39 @@
+import { createMiddleware } from 'hono/factory';
+import type { Env } from '../env.js';
+
+/**
+ * Vault resolution middleware.
+ * Resolves the vault_id from query param or the user's default (first) vault.
+ * Must run after auth middleware.
+ */
+export const vaultMiddleware = createMiddleware<{ Bindings: Env }>(async (c, next) => {
+  const user = c.get('user');
+  if (!user) return c.json({ error: 'Authentication required' }, 401);
+
+  // Allow explicit vault_id via query param or header
+  let vaultId = c.req.query('vault_id') || c.req.header('X-Vault-Id') || '';
+
+  if (vaultId) {
+    // Verify user owns this vault
+    const vault = await c.env.DB.prepare(
+      'SELECT vault_id FROM vaults WHERE vault_id = ? AND user_id = ?',
+    ).bind(vaultId, user.id).first<{ vault_id: string }>();
+
+    if (!vault) {
+      return c.json({ error: 'Vault not found or access denied' }, 404);
+    }
+  } else {
+    // Default to user's first vault
+    const vault = await c.env.DB.prepare(
+      'SELECT vault_id FROM vaults WHERE user_id = ? ORDER BY created_at LIMIT 1',
+    ).bind(user.id).first<{ vault_id: string }>();
+
+    if (!vault) {
+      return c.json({ error: 'No vaults found. Create one first.' }, 404);
+    }
+    vaultId = vault.vault_id;
+  }
+
+  c.set('vaultId', vaultId);
+  await next();
+});

--- a/packages/worker/src/middleware/vault.ts
+++ b/packages/worker/src/middleware/vault.ts
@@ -1,11 +1,7 @@
 import { createMiddleware } from 'hono/factory';
 import type { Env } from '../env.js';
 
-/**
- * Vault resolution middleware.
- * Resolves the vault_id from query param or the user's default (first) vault.
- * Must run after auth middleware.
- */
+// Must run after auth middleware
 export const vaultMiddleware = createMiddleware<{ Bindings: Env }>(async (c, next) => {
   const user = c.get('user');
   if (!user) return c.json({ error: 'Authentication required' }, 401);

--- a/packages/worker/src/routes/auth.ts
+++ b/packages/worker/src/routes/auth.ts
@@ -24,6 +24,24 @@ function escapeHtml(str: string): string {
     .replace(/'/g, '&#39;');
 }
 
+async function signState(payload: string, secret: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    'raw', new TextEncoder().encode(secret), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign'],
+  );
+  const sig = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(payload));
+  const sigHex = Array.from(new Uint8Array(sig)).map(b => b.toString(16).padStart(2, '0')).join('');
+  return `${payload}.${sigHex}`;
+}
+
+async function verifyState(signed: string, secret: string): Promise<string | null> {
+  const dotIdx = signed.lastIndexOf('.');
+  if (dotIdx < 0) return null;
+  const payload = signed.slice(0, dotIdx);
+  const expected = await signState(payload, secret);
+  if (expected !== signed) return null;
+  return payload;
+}
+
 const auth = new Hono<{ Bindings: Env }>();
 
 /**
@@ -41,7 +59,8 @@ auth.get('/auth/github', async (c) => {
   const session = c.req.query('session') || '';
   const redirect = c.req.query('redirect') || '';
 
-  const state = btoa(JSON.stringify({ session, redirect }));
+  const payload = btoa(JSON.stringify({ session, redirect }));
+  const state = await signState(payload, c.env.GITHUB_CLIENT_SECRET);
 
   const githubAuthUrl = new URL('https://github.com/login/oauth/authorize');
   githubAuthUrl.searchParams.set('client_id', clientId);
@@ -66,12 +85,18 @@ auth.get('/auth/callback', async (c) => {
 
   let session = '';
   let redirect = '';
+
+  const verifiedPayload = await verifyState(stateParam, c.env.GITHUB_CLIENT_SECRET);
+  if (!verifiedPayload) {
+    return c.json({ error: 'Invalid or tampered state parameter' }, 400);
+  }
+
   try {
-    const parsed = JSON.parse(atob(stateParam));
+    const parsed = JSON.parse(atob(verifiedPayload));
     session = parsed.session || '';
     redirect = parsed.redirect || '';
   } catch {
-    // Invalid state, continue without session/redirect
+    // Invalid state payload, continue without session/redirect
   }
 
   // Exchange code for access token

--- a/packages/worker/src/routes/auth.ts
+++ b/packages/worker/src/routes/auth.ts
@@ -87,10 +87,15 @@ auth.get('/auth/callback', async (c) => {
     return c.json({ error: 'Missing authorization code' }, 400);
   }
 
+  const clientSecret = c.env.GITHUB_CLIENT_SECRET;
+  if (!clientSecret) {
+    return c.json({ error: 'GitHub OAuth not configured' }, 503);
+  }
+
   let session = '';
   let redirect = '';
 
-  const verifiedPayload = await verifyState(stateParam, c.env.GITHUB_CLIENT_SECRET);
+  const verifiedPayload = await verifyState(stateParam, clientSecret);
   if (!verifiedPayload) {
     return c.json({ error: 'Invalid or tampered state parameter' }, 400);
   }

--- a/packages/worker/src/routes/auth.ts
+++ b/packages/worker/src/routes/auth.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import { nanoid } from 'nanoid';
 import type { Env } from '../env.js';
 import { generateApiKey, getKeyPrefix, hashApiKey } from '../lib/api-key.js';
+import { timingSafeEqual } from '../lib/stripe.js';
 
 interface GitHubUser {
   id: number;
@@ -37,8 +38,10 @@ async function verifyState(signed: string, secret: string): Promise<string | nul
   const dotIdx = signed.lastIndexOf('.');
   if (dotIdx < 0) return null;
   const payload = signed.slice(0, dotIdx);
+  const sig = signed.slice(dotIdx + 1);
   const expected = await signState(payload, secret);
-  if (expected !== signed) return null;
+  const expectedSig = expected.slice(expected.lastIndexOf('.') + 1);
+  if (!timingSafeEqual(sig, expectedSig)) return null;
   return payload;
 }
 

--- a/packages/worker/src/routes/auth.ts
+++ b/packages/worker/src/routes/auth.ts
@@ -186,24 +186,38 @@ auth.get('/auth/callback', async (c) => {
 
   // Default: show success page with API key
   const html = `<!DOCTYPE html>
-<html><head><title>Granite Cloud - Logged in</title>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Granite Cloud - Logged in</title>
 <style>
-  body { font-family: -apple-system, system-ui, sans-serif; max-width: 600px; margin: 80px auto; padding: 0 20px; }
-  .key { background: #f0f0f0; padding: 12px 16px; border-radius: 8px; font-family: monospace; font-size: 14px; word-break: break-all; }
-  .copy-btn { margin-top: 12px; padding: 8px 16px; background: #000; color: #fff; border: none; border-radius: 6px; cursor: pointer; }
-  .warning { color: #666; font-size: 13px; margin-top: 8px; }
+  body { font-family: -apple-system, system-ui, sans-serif; max-width: 600px; margin: 80px auto; padding: 0 20px; color: #1a1a1a; }
+  .key { background: #f5f5f5; padding: 12px 16px; border-radius: 8px; font-family: monospace; font-size: 14px; word-break: break-all; }
+  .copy-btn { margin-top: 12px; padding: 8px 16px; background: #1a1a1a; color: #fff; border: none; border-radius: 6px; cursor: pointer; font-size: 14px; }
+  .copy-btn:hover { background: #333; }
+  .copy-btn:focus-visible { outline: 2px solid #005fcc; outline-offset: 2px; }
+  .warning { color: #555; font-size: 13px; margin-top: 8px; }
+  pre { background: #f5f5f5; padding: 12px; border-radius: 8px; font-size: 13px; overflow-x: auto; }
+  @media (prefers-color-scheme: dark) {
+    body { background: #1a1a1a; color: #e5e5e5; }
+    .key, pre { background: #2a2a2a; }
+    .copy-btn { background: #e5e5e5; color: #1a1a1a; }
+    .copy-btn:hover { background: #ccc; }
+    .warning { color: #999; }
+    code { color: #e5e5e5; }
+  }
 </style></head>
 <body>
-  <h1>Welcome, @${ghUser.login}!</h1>
-  <p>Your Granite Cloud account is set up (${tier} tier). Here's your API key:</p>
-  <div class="key" id="key">${apiKey}</div>
-  <button class="copy-btn" onclick="navigator.clipboard.writeText('${apiKey}');this.textContent='Copied!'">Copy to clipboard</button>
-  <p class="warning">This key is shown only once. Save it now.</p>
-  <p>If you used <code>mem cloud login</code>, the CLI has already picked it up. You can close this tab.</p>
-  <p>Add to your <code>granite.yml</code>:</p>
-  <pre style="background:#f0f0f0;padding:12px;border-radius:8px;font-size:13px;">sync:
+  <main>
+    <h1>Welcome, @${ghUser.login}!</h1>
+    <p>Your Granite Cloud account is set up (${tier} tier). Here's your API key:</p>
+    <div class="key" id="key" role="status">${apiKey}</div>
+    <button class="copy-btn" onclick="navigator.clipboard.writeText('${apiKey}');this.textContent='Copied!'">Copy to clipboard</button>
+    <p class="warning">This key is shown only once. Save it now.</p>
+    <p>If you used <code>mem cloud login</code>, the CLI has already picked it up. You can close this tab.</p>
+    <p>Add to your <code>granite.yml</code>:</p>
+    <pre>sync:
   server: ${c.env.BASE_URL}
   api_key: ${apiKey}</pre>
+  </main>
 </body></html>`;
 
   return c.html(html);

--- a/packages/worker/src/routes/auth.ts
+++ b/packages/worker/src/routes/auth.ts
@@ -272,7 +272,7 @@ auth.get('/auth/poll', async (c) => {
   }
 
   const result = await c.env.DB.prepare(
-    "SELECT api_key, username FROM auth_sessions WHERE session_id = ? AND expires_at > datetime('now')",
+    "SELECT api_key, username FROM auth_sessions WHERE session_id = ? AND expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', 'now')",
   ).bind(session).first<{ api_key: string; username: string }>();
 
   if (!result || !result.api_key) {

--- a/packages/worker/src/routes/auth.ts
+++ b/packages/worker/src/routes/auth.ts
@@ -202,8 +202,11 @@ auth.get('/auth/callback', async (c) => {
   if (keyCount && keyCount.cnt >= 10) {
     await c.env.DB.prepare(`
       UPDATE api_keys SET revoked_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
-      WHERE user_id = ? AND revoked_at IS NULL
-      ORDER BY created_at ASC LIMIT 1
+      WHERE key_hash = (
+        SELECT key_hash FROM api_keys
+        WHERE user_id = ? AND revoked_at IS NULL
+        ORDER BY created_at ASC LIMIT 1
+      )
     `).bind(userId).run();
   }
 

--- a/packages/worker/src/routes/auth.ts
+++ b/packages/worker/src/routes/auth.ts
@@ -55,7 +55,8 @@ const auth = new Hono<{ Bindings: Env }>();
  */
 auth.get('/auth/github', async (c) => {
   const clientId = c.env.GITHUB_CLIENT_ID;
-  if (!clientId) {
+  const clientSecret = c.env.GITHUB_CLIENT_SECRET;
+  if (!clientId || !clientSecret) {
     return c.json({ error: 'GitHub OAuth not configured' }, 503);
   }
 
@@ -63,7 +64,7 @@ auth.get('/auth/github', async (c) => {
   const redirect = c.req.query('redirect') || '';
 
   const payload = btoa(JSON.stringify({ session, redirect }));
-  const state = await signState(payload, c.env.GITHUB_CLIENT_SECRET);
+  const state = await signState(payload, clientSecret);
 
   const githubAuthUrl = new URL('https://github.com/login/oauth/authorize');
   githubAuthUrl.searchParams.set('client_id', clientId);
@@ -188,6 +189,19 @@ auth.get('/auth/callback', async (c) => {
     `).bind(vaultId, userId, `${ghUser.login}'s vault`).run();
   }
 
+  // Enforce 10-key limit: revoke oldest if at cap
+  const keyCount = await c.env.DB.prepare(
+    'SELECT COUNT(*) as cnt FROM api_keys WHERE user_id = ? AND revoked_at IS NULL',
+  ).bind(userId).first<{ cnt: number }>();
+
+  if (keyCount && keyCount.cnt >= 10) {
+    await c.env.DB.prepare(`
+      UPDATE api_keys SET revoked_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+      WHERE user_id = ? AND revoked_at IS NULL
+      ORDER BY created_at ASC LIMIT 1
+    `).bind(userId).run();
+  }
+
   // Generate API key
   const apiKey = generateApiKey();
   const keyHash = await hashApiKey(apiKey);
@@ -195,7 +209,7 @@ auth.get('/auth/callback', async (c) => {
 
   await c.env.DB.prepare(`
     INSERT INTO api_keys (key_hash, user_id, key_prefix, name)
-    VALUES (?, ?, ?, 'default')
+    VALUES (?, ?, ?, 'oauth-login')
   `).bind(keyHash, userId, keyPrefix).run();
 
   // If CLI session, store API key for polling

--- a/packages/worker/src/routes/auth.ts
+++ b/packages/worker/src/routes/auth.ts
@@ -170,7 +170,7 @@ auth.get('/auth/callback', async (c) => {
     userId = existingUser.id;
     tier = existingUser.tier;
     await c.env.DB.prepare(`
-      UPDATE users SET github_username = ?, email = COALESCE(?, email), updated_at = datetime('now')
+      UPDATE users SET github_username = ?, email = COALESCE(?, email), updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
       WHERE id = ?
     `).bind(ghUser.login, email, userId).run();
   } else {

--- a/packages/worker/src/routes/auth.ts
+++ b/packages/worker/src/routes/auth.ts
@@ -15,6 +15,15 @@ interface GitHubTokenResponse {
   scope: string;
 }
 
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 const auth = new Hono<{ Bindings: Env }>();
 
 /**
@@ -170,7 +179,7 @@ auth.get('/auth/callback', async (c) => {
     `).bind(session, apiKey, ghUser.login, expiresAt).run();
   }
 
-  // If web redirect
+  // If web redirect (only allow same-origin redirects)
   if (redirect) {
     try {
       const url = new URL(redirect, c.env.BASE_URL);
@@ -179,12 +188,16 @@ auth.get('/auth/callback', async (c) => {
         return c.redirect(url.pathname + url.search);
       }
     } catch {
-      // Invalid URL, fall through
+      // Invalid URL, fall through to success page
     }
-    return c.redirect(`${redirect}?success=true`);
   }
 
   // Default: show success page with API key
+  const safeLogin = escapeHtml(ghUser.login);
+  const safeKey = escapeHtml(apiKey);
+  const safeTier = escapeHtml(tier);
+  const safeBaseUrl = escapeHtml(c.env.BASE_URL);
+
   const html = `<!DOCTYPE html>
 <html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Granite Cloud - Logged in</title>
@@ -207,16 +220,17 @@ auth.get('/auth/callback', async (c) => {
 </style></head>
 <body>
   <main>
-    <h1>Welcome, @${ghUser.login}!</h1>
-    <p>Your Granite Cloud account is set up (${tier} tier). Here's your API key:</p>
-    <div class="key" id="key" role="status">${apiKey}</div>
-    <button class="copy-btn" onclick="navigator.clipboard.writeText('${apiKey}');this.textContent='Copied!'">Copy to clipboard</button>
+    <h1>Welcome, @${safeLogin}!</h1>
+    <p>Your Granite Cloud account is set up (${safeTier} tier). Here's your API key:</p>
+    <div class="key" id="key" role="status">${safeKey}</div>
+    <button class="copy-btn" id="copy-btn">Copy to clipboard</button>
+    <script>document.getElementById('copy-btn').addEventListener('click',function(){navigator.clipboard.writeText(document.getElementById('key').textContent);this.textContent='Copied!'});</script>
     <p class="warning">This key is shown only once. Save it now.</p>
     <p>If you used <code>mem cloud login</code>, the CLI has already picked it up. You can close this tab.</p>
     <p>Add to your <code>granite.yml</code>:</p>
     <pre>sync:
-  server: ${c.env.BASE_URL}
-  api_key: ${apiKey}</pre>
+  server: ${safeBaseUrl}
+  api_key: ${safeKey}</pre>
   </main>
 </body></html>`;
 

--- a/packages/worker/src/routes/auth.ts
+++ b/packages/worker/src/routes/auth.ts
@@ -1,0 +1,241 @@
+import { Hono } from 'hono';
+import { nanoid } from 'nanoid';
+import type { Env } from '../env.js';
+import { generateApiKey, getKeyPrefix, hashApiKey } from '../lib/api-key.js';
+
+interface GitHubUser {
+  id: number;
+  login: string;
+  email: string | null;
+}
+
+interface GitHubTokenResponse {
+  access_token: string;
+  token_type: string;
+  scope: string;
+}
+
+const auth = new Hono<{ Bindings: Env }>();
+
+/**
+ * GET /auth/github — Start GitHub OAuth flow.
+ * Query params:
+ *   - session: CLI session ID for polling (optional, for CLI flow)
+ *   - redirect: URL to redirect to after auth (optional, for web flow)
+ */
+auth.get('/auth/github', async (c) => {
+  const clientId = c.env.GITHUB_CLIENT_ID;
+  if (!clientId) {
+    return c.json({ error: 'GitHub OAuth not configured' }, 503);
+  }
+
+  const session = c.req.query('session') || '';
+  const redirect = c.req.query('redirect') || '';
+
+  const state = btoa(JSON.stringify({ session, redirect }));
+
+  const githubAuthUrl = new URL('https://github.com/login/oauth/authorize');
+  githubAuthUrl.searchParams.set('client_id', clientId);
+  githubAuthUrl.searchParams.set('scope', 'read:user user:email');
+  githubAuthUrl.searchParams.set('state', state);
+  githubAuthUrl.searchParams.set('redirect_uri', `${c.env.BASE_URL}/auth/callback`);
+
+  return c.redirect(githubAuthUrl.toString());
+});
+
+/**
+ * GET /auth/callback — GitHub OAuth callback.
+ * Exchanges code for token, creates/updates user, generates API key.
+ */
+auth.get('/auth/callback', async (c) => {
+  const code = c.req.query('code');
+  const stateParam = c.req.query('state') || '';
+
+  if (!code) {
+    return c.json({ error: 'Missing authorization code' }, 400);
+  }
+
+  let session = '';
+  let redirect = '';
+  try {
+    const parsed = JSON.parse(atob(stateParam));
+    session = parsed.session || '';
+    redirect = parsed.redirect || '';
+  } catch {
+    // Invalid state, continue without session/redirect
+  }
+
+  // Exchange code for access token
+  const tokenResponse = await fetch('https://github.com/login/oauth/access_token', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Accept': 'application/json',
+    },
+    body: JSON.stringify({
+      client_id: c.env.GITHUB_CLIENT_ID,
+      client_secret: c.env.GITHUB_CLIENT_SECRET,
+      code,
+    }),
+  });
+
+  const tokenData = (await tokenResponse.json()) as GitHubTokenResponse;
+  if (!tokenData.access_token) {
+    return c.json({ error: 'Failed to exchange code for token' }, 400);
+  }
+
+  // Fetch GitHub user info
+  const userResponse = await fetch('https://api.github.com/user', {
+    headers: {
+      'Authorization': `Bearer ${tokenData.access_token}`,
+      'User-Agent': 'granite-cloud',
+      'Accept': 'application/vnd.github+json',
+    },
+  });
+
+  if (!userResponse.ok) {
+    return c.json({ error: 'Failed to fetch GitHub user info' }, 500);
+  }
+
+  const ghUser = (await userResponse.json()) as GitHubUser;
+
+  // If no public email, fetch from emails endpoint
+  let email = ghUser.email;
+  if (!email) {
+    try {
+      const emailsResponse = await fetch('https://api.github.com/user/emails', {
+        headers: {
+          'Authorization': `Bearer ${tokenData.access_token}`,
+          'User-Agent': 'granite-cloud',
+          'Accept': 'application/vnd.github+json',
+        },
+      });
+      if (emailsResponse.ok) {
+        const emails = (await emailsResponse.json()) as Array<{ email: string; primary: boolean }>;
+        const primary = emails.find(e => e.primary);
+        email = primary?.email || emails[0]?.email || null;
+      }
+    } catch {
+      // Non-critical, continue without email
+    }
+  }
+
+  // Upsert user
+  const existingUser = await c.env.DB.prepare(
+    'SELECT id, tier FROM users WHERE github_id = ?',
+  ).bind(ghUser.id).first<{ id: string; tier: string }>();
+
+  let userId: string;
+  let tier: string;
+
+  if (existingUser) {
+    userId = existingUser.id;
+    tier = existingUser.tier;
+    await c.env.DB.prepare(`
+      UPDATE users SET github_username = ?, email = COALESCE(?, email), updated_at = datetime('now')
+      WHERE id = ?
+    `).bind(ghUser.login, email, userId).run();
+  } else {
+    userId = nanoid(16);
+    tier = 'free';
+    await c.env.DB.prepare(`
+      INSERT INTO users (id, github_id, github_username, email, tier)
+      VALUES (?, ?, ?, ?, ?)
+    `).bind(userId, ghUser.id, ghUser.login, email, tier).run();
+
+    // Create a default vault for new users
+    const vaultId = `v_${nanoid(12)}`;
+    await c.env.DB.prepare(`
+      INSERT INTO vaults (vault_id, user_id, vault_name)
+      VALUES (?, ?, ?)
+    `).bind(vaultId, userId, `${ghUser.login}'s vault`).run();
+  }
+
+  // Generate API key
+  const apiKey = generateApiKey();
+  const keyHash = await hashApiKey(apiKey);
+  const keyPrefix = getKeyPrefix(apiKey);
+
+  await c.env.DB.prepare(`
+    INSERT INTO api_keys (key_hash, user_id, key_prefix, name)
+    VALUES (?, ?, ?, 'default')
+  `).bind(keyHash, userId, keyPrefix).run();
+
+  // If CLI session, store API key for polling
+  if (session) {
+    const expiresAt = new Date(Date.now() + 5 * 60 * 1000).toISOString();
+    await c.env.DB.prepare(`
+      INSERT OR REPLACE INTO auth_sessions (session_id, api_key, username, expires_at)
+      VALUES (?, ?, ?, ?)
+    `).bind(session, apiKey, ghUser.login, expiresAt).run();
+  }
+
+  // If web redirect
+  if (redirect) {
+    try {
+      const url = new URL(redirect, c.env.BASE_URL);
+      if (url.origin === new URL(c.env.BASE_URL).origin) {
+        url.searchParams.set('key', apiKey);
+        return c.redirect(url.pathname + url.search);
+      }
+    } catch {
+      // Invalid URL, fall through
+    }
+    return c.redirect(`${redirect}?success=true`);
+  }
+
+  // Default: show success page with API key
+  const html = `<!DOCTYPE html>
+<html><head><title>Granite Cloud - Logged in</title>
+<style>
+  body { font-family: -apple-system, system-ui, sans-serif; max-width: 600px; margin: 80px auto; padding: 0 20px; }
+  .key { background: #f0f0f0; padding: 12px 16px; border-radius: 8px; font-family: monospace; font-size: 14px; word-break: break-all; }
+  .copy-btn { margin-top: 12px; padding: 8px 16px; background: #000; color: #fff; border: none; border-radius: 6px; cursor: pointer; }
+  .warning { color: #666; font-size: 13px; margin-top: 8px; }
+</style></head>
+<body>
+  <h1>Welcome, @${ghUser.login}!</h1>
+  <p>Your Granite Cloud account is set up (${tier} tier). Here's your API key:</p>
+  <div class="key" id="key">${apiKey}</div>
+  <button class="copy-btn" onclick="navigator.clipboard.writeText('${apiKey}');this.textContent='Copied!'">Copy to clipboard</button>
+  <p class="warning">This key is shown only once. Save it now.</p>
+  <p>If you used <code>mem cloud login</code>, the CLI has already picked it up. You can close this tab.</p>
+  <p>Add to your <code>granite.yml</code>:</p>
+  <pre style="background:#f0f0f0;padding:12px;border-radius:8px;font-size:13px;">sync:
+  server: ${c.env.BASE_URL}
+  api_key: ${apiKey}</pre>
+</body></html>`;
+
+  return c.html(html);
+});
+
+/**
+ * GET /auth/poll — CLI polls this to retrieve the API key after OAuth.
+ */
+auth.get('/auth/poll', async (c) => {
+  const session = c.req.query('session');
+  if (!session) {
+    return c.json({ error: 'Missing session parameter' }, 400);
+  }
+
+  const result = await c.env.DB.prepare(
+    "SELECT api_key, username FROM auth_sessions WHERE session_id = ? AND expires_at > datetime('now')",
+  ).bind(session).first<{ api_key: string; username: string }>();
+
+  if (!result || !result.api_key) {
+    return c.json({ status: 'waiting' }, 202);
+  }
+
+  // Delete session after retrieval
+  c.executionCtx.waitUntil(
+    c.env.DB.prepare('DELETE FROM auth_sessions WHERE session_id = ?')
+      .bind(session).run(),
+  );
+
+  return c.json({
+    api_key: result.api_key,
+    username: result.username,
+  }, 200);
+});
+
+export default auth;

--- a/packages/worker/src/routes/billing.ts
+++ b/packages/worker/src/routes/billing.ts
@@ -137,7 +137,7 @@ billing.post('/webhooks/stripe', async (c) => {
 
       await c.env.DB.prepare(`
         UPDATE users
-        SET stripe_customer_id = ?, stripe_subscription_id = ?, tier = 'pro', updated_at = datetime('now')
+        SET stripe_customer_id = ?, stripe_subscription_id = ?, tier = 'pro', updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
         WHERE id = ?
       `).bind(customerId, subscriptionId, userId).run();
 
@@ -151,7 +151,7 @@ billing.post('/webhooks/stripe', async (c) => {
 
       await c.env.DB.prepare(`
         UPDATE users
-        SET tier = 'free', stripe_subscription_id = NULL, updated_at = datetime('now')
+        SET tier = 'free', stripe_subscription_id = NULL, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
         WHERE stripe_subscription_id = ?
       `).bind(subscriptionId).run();
 
@@ -166,13 +166,13 @@ billing.post('/webhooks/stripe', async (c) => {
 
       if (['past_due', 'unpaid', 'canceled', 'incomplete_expired'].includes(status)) {
         await c.env.DB.prepare(`
-          UPDATE users SET tier = 'free', updated_at = datetime('now')
+          UPDATE users SET tier = 'free', updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
           WHERE stripe_subscription_id = ?
         `).bind(subscriptionId).run();
         console.log(`Subscription ${subscriptionId} status ${status} — downgraded to free`);
       } else if (status === 'active') {
         await c.env.DB.prepare(`
-          UPDATE users SET tier = 'pro', updated_at = datetime('now')
+          UPDATE users SET tier = 'pro', updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
           WHERE stripe_subscription_id = ?
         `).bind(subscriptionId).run();
         console.log(`Subscription ${subscriptionId} active — upgraded to pro`);

--- a/packages/worker/src/routes/billing.ts
+++ b/packages/worker/src/routes/billing.ts
@@ -58,47 +58,44 @@ billing.get('/billing/portal', async (c) => {
   return c.redirect(session.url);
 });
 
-billing.get('/billing/success', (c) => {
-  return c.html(`<!DOCTYPE html>
-<html><head><title>Granite Cloud - Upgrade successful</title>
+function billingPage(title: string, body: string): string {
+  return `<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Granite Cloud - ${title}</title>
 <style>
-  body { font-family: -apple-system, system-ui, sans-serif; max-width: 600px; margin: 80px auto; padding: 0 20px; text-align: center; }
+  body { font-family: -apple-system, system-ui, sans-serif; max-width: 600px; margin: 80px auto; padding: 0 20px; text-align: center; color: #1a1a1a; }
+  code { background: #f5f5f5; padding: 2px 6px; border-radius: 4px; }
+  @media (prefers-color-scheme: dark) {
+    body { background: #1a1a1a; color: #e5e5e5; }
+    code { background: #2a2a2a; color: #e5e5e5; }
+  }
 </style></head>
-<body>
-  <h1>Welcome to Pro!</h1>
-  <p>Your Granite Cloud account has been upgraded. You now have:</p>
-  <ul style="text-align:left;display:inline-block;">
-    <li>Up to 10 vaults</li>
-    <li>10,000 notes per vault</li>
-    <li>300 sync operations/hour</li>
-    <li>Priority support</li>
-  </ul>
-  <p>You can close this tab and continue using <code>mem</code>.</p>
-</body></html>`);
+<body><main>${body}</main></body></html>`;
+}
+
+billing.get('/billing/success', (c) => {
+  return c.html(billingPage('Upgrade successful', `
+    <h1>Welcome to Pro!</h1>
+    <p>Your Granite Cloud account has been upgraded. You now have:</p>
+    <ul style="text-align:left;display:inline-block;">
+      <li>Up to 10 vaults</li>
+      <li>10,000 notes per vault</li>
+      <li>300 sync operations/hour</li>
+      <li>Priority support</li>
+    </ul>
+    <p>You can close this tab and continue using <code>mem</code>.</p>`));
 });
 
 billing.get('/billing/cancel', (c) => {
-  return c.html(`<!DOCTYPE html>
-<html><head><title>Granite Cloud - Checkout cancelled</title>
-<style>
-  body { font-family: -apple-system, system-ui, sans-serif; max-width: 600px; margin: 80px auto; padding: 0 20px; text-align: center; }
-</style></head>
-<body>
-  <h1>Checkout cancelled</h1>
-  <p>No worries! You can upgrade anytime by running <code>mem cloud upgrade</code>.</p>
-</body></html>`);
+  return c.html(billingPage('Checkout cancelled', `
+    <h1>Checkout cancelled</h1>
+    <p>No worries! You can upgrade anytime by running <code>mem cloud upgrade</code>.</p>`));
 });
 
 billing.get('/billing/portal-return', (c) => {
-  return c.html(`<!DOCTYPE html>
-<html><head><title>Granite Cloud - Billing</title>
-<style>
-  body { font-family: -apple-system, system-ui, sans-serif; max-width: 600px; margin: 80px auto; padding: 0 20px; text-align: center; }
-</style></head>
-<body>
-  <h1>Billing updated</h1>
-  <p>Your billing changes have been saved. You can close this tab.</p>
-</body></html>`);
+  return c.html(billingPage('Billing', `
+    <h1>Billing updated</h1>
+    <p>Your billing changes have been saved. You can close this tab.</p>`));
 });
 
 /**

--- a/packages/worker/src/routes/billing.ts
+++ b/packages/worker/src/routes/billing.ts
@@ -78,10 +78,10 @@ billing.get('/billing/success', (c) => {
     <h1>Welcome to Pro!</h1>
     <p>Your Granite Cloud account has been upgraded. You now have:</p>
     <ul style="text-align:left;display:inline-block;">
+      <li>Multi-device sync</li>
+      <li>1 GB of cloud storage</li>
       <li>Up to 10 vaults</li>
-      <li>10,000 notes per vault</li>
-      <li>300 sync operations/hour</li>
-      <li>Priority support</li>
+      <li>Remote MCP access</li>
     </ul>
     <p>You can close this tab and continue using <code>mem</code>.</p>`));
 });

--- a/packages/worker/src/routes/billing.ts
+++ b/packages/worker/src/routes/billing.ts
@@ -1,0 +1,193 @@
+import { Hono } from 'hono';
+import type { Env } from '../env.js';
+import { StripeClient, verifyWebhookSignature } from '../lib/stripe.js';
+
+const billing = new Hono<{ Bindings: Env }>();
+
+/**
+ * GET /billing/checkout — Create a Stripe Checkout session and redirect.
+ */
+billing.get('/billing/checkout', async (c) => {
+  const user = c.get('user');
+  if (!user) return c.json({ error: 'Authentication required. Run: mem cloud login' }, 401);
+
+  if (user.tier === 'pro') {
+    return c.json({ error: 'Already on Pro tier', tier: 'pro' }, 400);
+  }
+
+  if (!c.env.STRIPE_SECRET_KEY || !c.env.STRIPE_PRICE_ID) {
+    return c.json({ error: 'Stripe not configured' }, 503);
+  }
+
+  const stripe = new StripeClient(c.env.STRIPE_SECRET_KEY);
+
+  const session = await stripe.createCheckoutSession({
+    priceId: c.env.STRIPE_PRICE_ID,
+    customerId: user.stripe_customer_id || undefined,
+    customerEmail: !user.stripe_customer_id ? (user.email || undefined) : undefined,
+    metadata: { granite_user_id: user.id },
+    successUrl: `${c.env.BASE_URL}/billing/success`,
+    cancelUrl: `${c.env.BASE_URL}/billing/cancel`,
+  });
+
+  return c.redirect(session.url);
+});
+
+/**
+ * GET /billing/portal — Redirect to Stripe Customer Portal.
+ */
+billing.get('/billing/portal', async (c) => {
+  const user = c.get('user');
+  if (!user) return c.json({ error: 'Authentication required' }, 401);
+
+  if (!user.stripe_customer_id) {
+    return c.json({ error: 'No billing account found. Upgrade first: mem cloud upgrade' }, 400);
+  }
+
+  if (!c.env.STRIPE_SECRET_KEY) {
+    return c.json({ error: 'Stripe not configured' }, 503);
+  }
+
+  const stripe = new StripeClient(c.env.STRIPE_SECRET_KEY);
+
+  const session = await stripe.createPortalSession({
+    customerId: user.stripe_customer_id,
+    returnUrl: c.env.BASE_URL + '/billing/portal-return',
+  });
+
+  return c.redirect(session.url);
+});
+
+billing.get('/billing/success', (c) => {
+  return c.html(`<!DOCTYPE html>
+<html><head><title>Granite Cloud - Upgrade successful</title>
+<style>
+  body { font-family: -apple-system, system-ui, sans-serif; max-width: 600px; margin: 80px auto; padding: 0 20px; text-align: center; }
+</style></head>
+<body>
+  <h1>Welcome to Pro!</h1>
+  <p>Your Granite Cloud account has been upgraded. You now have:</p>
+  <ul style="text-align:left;display:inline-block;">
+    <li>Up to 10 vaults</li>
+    <li>10,000 notes per vault</li>
+    <li>300 sync operations/hour</li>
+    <li>Priority support</li>
+  </ul>
+  <p>You can close this tab and continue using <code>mem</code>.</p>
+</body></html>`);
+});
+
+billing.get('/billing/cancel', (c) => {
+  return c.html(`<!DOCTYPE html>
+<html><head><title>Granite Cloud - Checkout cancelled</title>
+<style>
+  body { font-family: -apple-system, system-ui, sans-serif; max-width: 600px; margin: 80px auto; padding: 0 20px; text-align: center; }
+</style></head>
+<body>
+  <h1>Checkout cancelled</h1>
+  <p>No worries! You can upgrade anytime by running <code>mem cloud upgrade</code>.</p>
+</body></html>`);
+});
+
+billing.get('/billing/portal-return', (c) => {
+  return c.html(`<!DOCTYPE html>
+<html><head><title>Granite Cloud - Billing</title>
+<style>
+  body { font-family: -apple-system, system-ui, sans-serif; max-width: 600px; margin: 80px auto; padding: 0 20px; text-align: center; }
+</style></head>
+<body>
+  <h1>Billing updated</h1>
+  <p>Your billing changes have been saved. You can close this tab.</p>
+</body></html>`);
+});
+
+/**
+ * POST /webhooks/stripe — Handle Stripe webhook events.
+ */
+billing.post('/webhooks/stripe', async (c) => {
+  if (!c.env.STRIPE_WEBHOOK_SECRET) {
+    return c.json({ error: 'Webhook secret not configured' }, 503);
+  }
+
+  const sigHeader = c.req.header('Stripe-Signature');
+  if (!sigHeader) {
+    return c.json({ error: 'Missing Stripe-Signature header' }, 400);
+  }
+
+  const body = await c.req.text();
+
+  const isValid = await verifyWebhookSignature(body, sigHeader, c.env.STRIPE_WEBHOOK_SECRET);
+  if (!isValid) {
+    return c.json({ error: 'Invalid signature' }, 400);
+  }
+
+  const event = JSON.parse(body) as {
+    type: string;
+    data: { object: Record<string, unknown> };
+  };
+
+  switch (event.type) {
+    case 'checkout.session.completed': {
+      const session = event.data.object;
+      const userId = (session.metadata as Record<string, string>)?.granite_user_id;
+      const customerId = session.customer as string;
+      const subscriptionId = session.subscription as string;
+
+      if (!userId) {
+        console.error('Webhook: checkout.session.completed without granite_user_id');
+        break;
+      }
+
+      await c.env.DB.prepare(`
+        UPDATE users
+        SET stripe_customer_id = ?, stripe_subscription_id = ?, tier = 'pro', updated_at = datetime('now')
+        WHERE id = ?
+      `).bind(customerId, subscriptionId, userId).run();
+
+      console.log(`User ${userId} upgraded to Pro (customer: ${customerId})`);
+      break;
+    }
+
+    case 'customer.subscription.deleted': {
+      const subscription = event.data.object;
+      const subscriptionId = subscription.id as string;
+
+      await c.env.DB.prepare(`
+        UPDATE users
+        SET tier = 'free', stripe_subscription_id = NULL, updated_at = datetime('now')
+        WHERE stripe_subscription_id = ?
+      `).bind(subscriptionId).run();
+
+      console.log(`Subscription ${subscriptionId} cancelled — user downgraded to free`);
+      break;
+    }
+
+    case 'customer.subscription.updated': {
+      const subscription = event.data.object;
+      const subscriptionId = subscription.id as string;
+      const status = subscription.status as string;
+
+      if (['past_due', 'unpaid', 'canceled', 'incomplete_expired'].includes(status)) {
+        await c.env.DB.prepare(`
+          UPDATE users SET tier = 'free', updated_at = datetime('now')
+          WHERE stripe_subscription_id = ?
+        `).bind(subscriptionId).run();
+        console.log(`Subscription ${subscriptionId} status ${status} — downgraded to free`);
+      } else if (status === 'active') {
+        await c.env.DB.prepare(`
+          UPDATE users SET tier = 'pro', updated_at = datetime('now')
+          WHERE stripe_subscription_id = ?
+        `).bind(subscriptionId).run();
+        console.log(`Subscription ${subscriptionId} active — upgraded to pro`);
+      }
+      break;
+    }
+
+    default:
+      break;
+  }
+
+  return c.json({ received: true });
+});
+
+export default billing;

--- a/packages/worker/src/routes/keys.ts
+++ b/packages/worker/src/routes/keys.ts
@@ -1,0 +1,98 @@
+import { Hono } from 'hono';
+import type { Env } from '../env.js';
+import { generateApiKey, getKeyPrefix, hashApiKey } from '../lib/api-key.js';
+
+interface ApiKeyRow {
+  key_prefix: string;
+  name: string;
+  created_at: string;
+  last_used_at: string | null;
+  revoked_at: string | null;
+}
+
+const keys = new Hono<{ Bindings: Env }>();
+
+/**
+ * GET /keys — List all API keys for the authenticated user.
+ */
+keys.get('/keys', async (c) => {
+  const user = c.get('user');
+  if (!user) return c.json({ error: 'Authentication required' }, 401);
+
+  const result = await c.env.DB.prepare(`
+    SELECT key_prefix, name, created_at, last_used_at, revoked_at
+    FROM api_keys WHERE user_id = ? ORDER BY created_at DESC
+  `).bind(user.id).all<ApiKeyRow>();
+
+  const apiKeys = (result.results || []).map(k => ({
+    prefix: k.key_prefix,
+    name: k.name,
+    created_at: k.created_at,
+    last_used_at: k.last_used_at,
+    revoked: k.revoked_at !== null,
+  }));
+
+  return c.json({ keys: apiKeys });
+});
+
+/**
+ * POST /keys — Create a new API key.
+ */
+keys.post('/keys', async (c) => {
+  const user = c.get('user');
+  if (!user) return c.json({ error: 'Authentication required' }, 401);
+
+  let name = 'default';
+  try {
+    const body = await c.req.json<{ name?: string }>();
+    if (body.name) name = body.name.slice(0, 64);
+  } catch {
+    // No body or invalid JSON
+  }
+
+  const count = await c.env.DB.prepare(
+    'SELECT COUNT(*) as cnt FROM api_keys WHERE user_id = ? AND revoked_at IS NULL',
+  ).bind(user.id).first<{ cnt: number }>();
+
+  if (count && count.cnt >= 10) {
+    return c.json({ error: 'Maximum 10 active API keys. Revoke one first.' }, 400);
+  }
+
+  const apiKey = generateApiKey();
+  const keyHash = await hashApiKey(apiKey);
+  const keyPrefix = getKeyPrefix(apiKey);
+
+  await c.env.DB.prepare(`
+    INSERT INTO api_keys (key_hash, user_id, key_prefix, name) VALUES (?, ?, ?, ?)
+  `).bind(keyHash, user.id, keyPrefix, name).run();
+
+  return c.json({
+    api_key: apiKey,
+    prefix: keyPrefix,
+    name,
+    message: 'Save this key — it will not be shown again.',
+  }, 201);
+});
+
+/**
+ * DELETE /keys/:prefix — Revoke an API key by its prefix.
+ */
+keys.delete('/keys/:prefix', async (c) => {
+  const user = c.get('user');
+  if (!user) return c.json({ error: 'Authentication required' }, 401);
+
+  const prefix = c.req.param('prefix');
+
+  const result = await c.env.DB.prepare(`
+    UPDATE api_keys SET revoked_at = datetime('now')
+    WHERE user_id = ? AND key_prefix = ? AND revoked_at IS NULL
+  `).bind(user.id, prefix).run();
+
+  if (result.meta.changes === 0) {
+    return c.json({ error: 'Key not found or already revoked' }, 404);
+  }
+
+  return c.json({ ok: true });
+});
+
+export default keys;

--- a/packages/worker/src/routes/keys.ts
+++ b/packages/worker/src/routes/keys.ts
@@ -84,7 +84,7 @@ keys.delete('/keys/:prefix', async (c) => {
   const prefix = c.req.param('prefix');
 
   const result = await c.env.DB.prepare(`
-    UPDATE api_keys SET revoked_at = datetime('now')
+    UPDATE api_keys SET revoked_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
     WHERE user_id = ? AND key_prefix = ? AND revoked_at IS NULL
   `).bind(user.id, prefix).run();
 

--- a/packages/worker/src/routes/user.ts
+++ b/packages/worker/src/routes/user.ts
@@ -15,21 +15,23 @@ user.get('/me', async (c) => {
   const limits = TIER_LIMITS[tier];
 
   const vaults = await c.env.DB.prepare(`
-    SELECT v.vault_id, v.vault_name, v.created_at, COUNT(n.slug) as note_count
+    SELECT v.vault_id, v.vault_name, v.created_at, v.storage_bytes, COUNT(n.slug) as note_count
     FROM vaults v
     LEFT JOIN notes n ON n.vault_id = v.vault_id
     WHERE v.user_id = ?
     GROUP BY v.vault_id
     ORDER BY v.created_at
-  `).bind(u.id).all<{ vault_id: string; vault_name: string; created_at: string; note_count: number }>();
+  `).bind(u.id).all<{ vault_id: string; vault_name: string; created_at: string; storage_bytes: number; note_count: number }>();
 
   const vaultStats = (vaults.results || []).map(v => ({
     vault_id: v.vault_id,
     vault_name: v.vault_name,
     note_count: v.note_count,
+    storage_bytes: v.storage_bytes,
     created_at: v.created_at,
   }));
   const totalNotes = vaultStats.reduce((sum, v) => sum + v.note_count, 0);
+  const totalStorage = vaultStats.reduce((sum, v) => sum + v.storage_bytes, 0);
 
   return c.json({
     user: {
@@ -43,10 +45,12 @@ user.get('/me', async (c) => {
     totals: {
       vaults: vaultStats.length,
       notes: totalNotes,
+      storage_bytes: totalStorage,
     },
     limits: {
       max_vaults: limits.maxVaults,
-      max_notes_per_vault: limits.maxNotesPerVault,
+      max_storage_bytes: limits.maxStorageBytes,
+      sync_enabled: limits.syncEnabled,
       rate_limit_per_hour: limits.rateLimit,
     },
   });

--- a/packages/worker/src/routes/user.ts
+++ b/packages/worker/src/routes/user.ts
@@ -1,0 +1,111 @@
+import { Hono } from 'hono';
+import type { Env } from '../env.js';
+import { TIER_LIMITS } from '../env.js';
+
+const user = new Hono<{ Bindings: Env }>();
+
+/**
+ * GET /me — Return current user profile with vault stats.
+ */
+user.get('/me', async (c) => {
+  const u = c.get('user');
+  if (!u) return c.json({ error: 'Authentication required' }, 401);
+
+  const tier = c.get('tier');
+  const limits = TIER_LIMITS[tier];
+
+  // Get vault count and note count
+  const vaults = await c.env.DB.prepare(
+    'SELECT vault_id, vault_name, created_at FROM vaults WHERE user_id = ?',
+  ).bind(u.id).all<{ vault_id: string; vault_name: string; created_at: string }>();
+
+  let totalNotes = 0;
+  const vaultStats = [];
+  for (const v of vaults.results || []) {
+    const noteCount = await c.env.DB.prepare(
+      'SELECT COUNT(*) as cnt FROM notes WHERE vault_id = ?',
+    ).bind(v.vault_id).first<{ cnt: number }>();
+    const cnt = noteCount?.cnt ?? 0;
+    totalNotes += cnt;
+    vaultStats.push({
+      vault_id: v.vault_id,
+      vault_name: v.vault_name,
+      note_count: cnt,
+      created_at: v.created_at,
+    });
+  }
+
+  return c.json({
+    user: {
+      id: u.id,
+      github_username: u.github_username,
+      email: u.email,
+      tier,
+      created_at: u.created_at,
+    },
+    vaults: vaultStats,
+    totals: {
+      vaults: vaultStats.length,
+      notes: totalNotes,
+    },
+    limits: {
+      max_vaults: limits.maxVaults,
+      max_notes_per_vault: limits.maxNotesPerVault,
+      rate_limit_per_hour: limits.rateLimit,
+    },
+  });
+});
+
+/**
+ * GET /vaults — List user's vaults.
+ */
+user.get('/vaults', async (c) => {
+  const u = c.get('user');
+  if (!u) return c.json({ error: 'Authentication required' }, 401);
+
+  const result = await c.env.DB.prepare(
+    'SELECT vault_id, vault_name, created_at FROM vaults WHERE user_id = ? ORDER BY created_at',
+  ).bind(u.id).all<{ vault_id: string; vault_name: string; created_at: string }>();
+
+  return c.json({ vaults: result.results || [] });
+});
+
+/**
+ * POST /vaults — Create a new vault.
+ */
+user.post('/vaults', async (c) => {
+  const u = c.get('user');
+  if (!u) return c.json({ error: 'Authentication required' }, 401);
+
+  const tier = c.get('tier');
+  const limits = TIER_LIMITS[tier];
+
+  const vaultCount = await c.env.DB.prepare(
+    'SELECT COUNT(*) as cnt FROM vaults WHERE user_id = ?',
+  ).bind(u.id).first<{ cnt: number }>();
+
+  if (vaultCount && vaultCount.cnt >= limits.maxVaults) {
+    return c.json({
+      error: `Maximum ${limits.maxVaults} vault(s) on ${tier} tier. Upgrade to create more.`,
+    }, 400);
+  }
+
+  let name = 'My Vault';
+  try {
+    const body = await c.req.json<{ name?: string }>();
+    if (body.name) name = body.name.slice(0, 100);
+  } catch {
+    // No body
+  }
+
+  const { nanoid } = await import('nanoid');
+  const vaultId = `v_${nanoid(12)}`;
+
+  await c.env.DB.prepare(`
+    INSERT INTO vaults (vault_id, user_id, vault_name) VALUES (?, ?, ?)
+  `).bind(vaultId, u.id, name).run();
+
+  return c.json({ vault_id: vaultId, vault_name: name }, 201);
+});
+
+export default user;

--- a/packages/worker/src/routes/user.ts
+++ b/packages/worker/src/routes/user.ts
@@ -14,26 +14,22 @@ user.get('/me', async (c) => {
   const tier = c.get('tier');
   const limits = TIER_LIMITS[tier];
 
-  // Get vault count and note count
-  const vaults = await c.env.DB.prepare(
-    'SELECT vault_id, vault_name, created_at FROM vaults WHERE user_id = ?',
-  ).bind(u.id).all<{ vault_id: string; vault_name: string; created_at: string }>();
+  const vaults = await c.env.DB.prepare(`
+    SELECT v.vault_id, v.vault_name, v.created_at, COUNT(n.slug) as note_count
+    FROM vaults v
+    LEFT JOIN notes n ON n.vault_id = v.vault_id
+    WHERE v.user_id = ?
+    GROUP BY v.vault_id
+    ORDER BY v.created_at
+  `).bind(u.id).all<{ vault_id: string; vault_name: string; created_at: string; note_count: number }>();
 
-  let totalNotes = 0;
-  const vaultStats = [];
-  for (const v of vaults.results || []) {
-    const noteCount = await c.env.DB.prepare(
-      'SELECT COUNT(*) as cnt FROM notes WHERE vault_id = ?',
-    ).bind(v.vault_id).first<{ cnt: number }>();
-    const cnt = noteCount?.cnt ?? 0;
-    totalNotes += cnt;
-    vaultStats.push({
-      vault_id: v.vault_id,
-      vault_name: v.vault_name,
-      note_count: cnt,
-      created_at: v.created_at,
-    });
-  }
+  const vaultStats = (vaults.results || []).map(v => ({
+    vault_id: v.vault_id,
+    vault_name: v.vault_name,
+    note_count: v.note_count,
+    created_at: v.created_at,
+  }));
+  const totalNotes = vaultStats.reduce((sum, v) => sum + v.note_count, 0);
 
   return c.json({
     user: {

--- a/packages/worker/src/runtime.ts
+++ b/packages/worker/src/runtime.ts
@@ -3,19 +3,7 @@ import type { R2NoteStorage } from './storage/r2.js';
 import type { D1IndexDatabase } from './storage/d1.js';
 import { parseJsonArray } from './lib/json.js';
 import { DEFAULT_TYPE_FOLDERS, resolveTypeFolder } from './lib/config.js';
-import { parseWikilinks, resolveWikilinks, indexLinks } from './lib/wikilinks.js';
-
-// --- Pure function imports (same logic as src/core/) ---
-
-function slugify(title: string): string {
-  return title
-    .normalize('NFD')
-    .replace(/[\u0300-\u036f]/g, '')
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-    || 'untitled';
-}
+import { slugify, parseWikilinks, resolveWikilinks, indexLinks } from './lib/wikilinks.js';
 
 // WikiLink type re-exported from shared module
 type WikiLink = ReturnType<typeof parseWikilinks>[number];

--- a/packages/worker/src/runtime.ts
+++ b/packages/worker/src/runtime.ts
@@ -58,8 +58,8 @@ function parseFrontmatter(content: string): { frontmatter: Record<string, unknow
       type: String(data.type ?? ''),
       created: data.created instanceof Date ? data.created.toISOString() : String(data.created ?? ''),
       modified: data.modified instanceof Date ? data.modified.toISOString() : String(data.modified ?? ''),
-      tags: data.tags ?? [],
-      aliases: data.aliases ?? [],
+      tags: Array.isArray(data.tags) ? data.tags : data.tags ? [data.tags] : [],
+      aliases: Array.isArray(data.aliases) ? data.aliases : data.aliases ? [data.aliases] : [],
       status: data.status ?? 'active',
       source: data.source ?? 'human',
       ...Object.fromEntries(
@@ -236,7 +236,7 @@ export class CloudMcpRuntime {
   }
 
   async listNotes(input: ListNotesInput = {}): Promise<NoteSummary[]> {
-    let notes = await this.db.getAllNotes();
+    let notes = await this.db.getAllNotesMeta();
 
     if (input.type) notes = notes.filter(n => n.type === input.type);
     if (input.status) notes = notes.filter(n => n.status === input.status);
@@ -299,6 +299,7 @@ export class CloudMcpRuntime {
     for (const other of allNotes) {
       if (other.slug === slug) continue;
       const titleLower = other.title.toLowerCase();
+      if (!titleLower) continue;
       if (existingLinks.has(titleLower) || existingLinks.has(other.slug)) continue;
 
       let mentions = 0;

--- a/packages/worker/src/runtime.ts
+++ b/packages/worker/src/runtime.ts
@@ -1,0 +1,546 @@
+import matter from 'gray-matter';
+import type { R2NoteStorage } from './storage/r2.js';
+import type { D1IndexDatabase } from './storage/d1.js';
+
+// --- Pure function imports (same logic as src/core/) ---
+
+function slugify(title: string): string {
+  return title
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    || 'untitled';
+}
+
+interface WikiLink {
+  raw: string;
+  target: string;
+  display: string;
+  resolved: boolean;
+  resolved_slug?: string;
+}
+
+function parseWikilinks(body: string): WikiLink[] {
+  const cleaned = body
+    .replace(/```[\s\S]*?```/g, '')
+    .replace(/`[^`]*`/g, '');
+
+  const links: WikiLink[] = [];
+  const regex = /\[\[([^\]]+)\]\]/g;
+  let match;
+
+  while ((match = regex.exec(cleaned)) !== null) {
+    const inner = match[1];
+    const pipeIndex = inner.indexOf('|');
+    const target = pipeIndex >= 0 ? inner.slice(0, pipeIndex).trim() : inner.trim();
+    const display = pipeIndex >= 0 ? inner.slice(pipeIndex + 1).trim() : inner.trim();
+
+    links.push({
+      raw: match[0],
+      target,
+      display,
+      resolved: false,
+    });
+  }
+
+  return links;
+}
+
+function parseFrontmatter(content: string): { frontmatter: Record<string, unknown>; body: string } {
+  const { data, content: body } = matter(content);
+  return {
+    frontmatter: {
+      id: String(data.id ?? ''),
+      title: String(data.title ?? ''),
+      type: String(data.type ?? ''),
+      created: data.created instanceof Date ? data.created.toISOString() : String(data.created ?? ''),
+      modified: data.modified instanceof Date ? data.modified.toISOString() : String(data.modified ?? ''),
+      tags: data.tags ?? [],
+      aliases: data.aliases ?? [],
+      status: data.status ?? 'active',
+      source: data.source ?? 'human',
+      ...Object.fromEntries(
+        Object.entries(data).filter(([k]) => !['id', 'title', 'type', 'created', 'modified', 'tags', 'aliases', 'status', 'source'].includes(k))
+      ),
+    },
+    body,
+  };
+}
+
+function serializeFrontmatter(fm: Record<string, unknown>, body: string): string {
+  return matter.stringify(body, fm);
+}
+
+// --- Types ---
+
+interface GraniteConfig {
+  vault_name: string;
+  version: number;
+  note_types: Record<string, NoteTypeConfig>;
+  defaults: { note_type: string; editor: string };
+  index: { auto_rebuild: boolean };
+}
+
+interface NoteTypeConfig {
+  folder: string;
+  description: string;
+  template: string;
+  line_limit: number;
+  warn_only: boolean;
+  slug_format?: 'title' | 'date';
+  instructions?: string;
+  fields?: Record<string, unknown>;
+}
+
+export interface NoteSummary {
+  slug: string;
+  title: string;
+  type: string;
+  created: string;
+  modified: string;
+  tags: string[];
+  aliases: string[];
+  status: string;
+  source: string;
+  filepath: string;
+  resource_uri: string;
+}
+
+export interface NoteDetails extends NoteSummary {
+  body: string;
+  frontmatter: Record<string, unknown>;
+  outgoing_links: WikiLink[];
+}
+
+export interface SearchResult {
+  slug: string;
+  title: string;
+  snippet: string;
+  score: number;
+}
+
+export interface BacklinkEntry {
+  source_slug: string;
+  source_title: string;
+  context: string;
+}
+
+export interface LinkSuggestion {
+  target_slug: string;
+  target_title: string;
+  mentions: number;
+}
+
+export interface NoteRecommendations {
+  additions: Array<{ text: string }>;
+  links: Array<{ slug: string; title: string; type: string; reason: string; source: 'mention' | 'search' }>;
+  tags: Array<{ tag: string; weight: number; source_slugs: string[] }>;
+  next_steps: Array<{ type: string; title_hint?: string; reason: string }>;
+}
+
+interface NoteMutationResult {
+  note: NoteDetails;
+  recommendations: NoteRecommendations;
+}
+
+export interface ListNotesInput {
+  type?: string;
+  status?: string;
+  source?: string;
+  since?: string;
+  limit?: number;
+}
+
+export interface CreateNoteInput {
+  title: string;
+  type?: string;
+  body?: string;
+  tags?: string[];
+  aliases?: string[];
+  status?: string;
+  source?: string;
+}
+
+export interface UpdateNoteInput {
+  title?: string;
+  body?: string;
+  append?: string;
+  tags?: string[];
+  aliases?: string[];
+  status?: string;
+  source?: string;
+}
+
+// --- Runtime ---
+
+export class CloudMcpRuntime {
+  private config: GraniteConfig | null = null;
+
+  constructor(
+    private storage: R2NoteStorage,
+    private db: D1IndexDatabase,
+  ) {}
+
+  private async getConfig(): Promise<GraniteConfig> {
+    if (this.config) return this.config;
+    try {
+      const raw = await this.storage.readConfig();
+      const yaml = await import('js-yaml');
+      this.config = yaml.load(raw) as GraniteConfig;
+    } catch {
+      // Return default config if not found in R2
+      this.config = getDefaultConfig();
+    }
+    return this.config!;
+  }
+
+  async getVaultOverview(recentLimit = 10): Promise<{
+    vault_name: string;
+    default_type: string;
+    note_count: number;
+    notes_by_type: Record<string, number>;
+    recent_notes: NoteSummary[];
+  }> {
+    const config = await this.getConfig();
+    const allNotes = await this.db.getAllNotes();
+
+    const byType: Record<string, number> = {};
+    for (const n of allNotes) {
+      byType[n.type] = (byType[n.type] ?? 0) + 1;
+    }
+
+    const limit = Math.max(1, Math.min(recentLimit, 20));
+    const recent = allNotes.slice(0, limit).map(n => this.toNoteSummary(n));
+
+    return {
+      vault_name: config.vault_name,
+      default_type: config.defaults.note_type,
+      note_count: allNotes.length,
+      notes_by_type: byType,
+      recent_notes: recent,
+    };
+  }
+
+  async listNoteTypes(): Promise<Array<{ name: string; description: string; folder: string; slug_format: string; instructions?: string }>> {
+    const config = await this.getConfig();
+    return Object.entries(config.note_types).map(([name, tc]) => ({
+      name,
+      description: tc.description,
+      folder: tc.folder,
+      slug_format: tc.slug_format ?? 'title',
+      instructions: tc.instructions,
+    }));
+  }
+
+  async listNotes(input: ListNotesInput = {}): Promise<NoteSummary[]> {
+    let notes = await this.db.getAllNotes();
+
+    if (input.type) notes = notes.filter(n => n.type === input.type);
+    if (input.status) notes = notes.filter(n => n.status === input.status);
+    if (input.source) notes = notes.filter(n => n.source === input.source);
+    if (input.since) {
+      const since = input.since;
+      notes = notes.filter(n => n.modified >= since);
+    }
+
+    const limit = Math.max(1, Math.min(input.limit ?? 25, 200));
+    return notes.slice(0, limit).map(n => this.toNoteSummary(n));
+  }
+
+  async getNote(slug: string): Promise<NoteDetails> {
+    const config = await this.getConfig();
+    const indexed = await this.db.getNote(slug);
+    if (!indexed) throw new Error(`Note not found: ${slug}`);
+
+    // Read full content from R2
+    const typeConfig = config.note_types[indexed.type];
+    const folder = typeConfig?.folder ?? `notes/${indexed.type}`;
+    const content = await this.storage.readNote(folder, slug);
+    const { frontmatter, body } = parseFrontmatter(content);
+
+    // Resolve outgoing links
+    const allNotes = await this.db.getAllNotes();
+    const links = parseWikilinks(body);
+    const resolvedLinks = links.map(link => {
+      const targetSlug = slugify(link.target);
+      const found = allNotes.find(n =>
+        n.slug === targetSlug ||
+        n.title.toLowerCase() === link.target.toLowerCase()
+      );
+      return { ...link, resolved: !!found, resolved_slug: found?.slug };
+    });
+
+    return {
+      ...this.toNoteSummary(indexed),
+      body,
+      frontmatter,
+      outgoing_links: resolvedLinks,
+    };
+  }
+
+  async search(query: string, limit = 10): Promise<SearchResult[]> {
+    return this.db.searchNotes(query, limit);
+  }
+
+  async getBacklinks(slug: string): Promise<BacklinkEntry[]> {
+    return this.db.getBacklinks(slug);
+  }
+
+  async suggestLinks(slug: string): Promise<LinkSuggestion[]> {
+    const indexed = await this.db.getNote(slug);
+    if (!indexed) throw new Error(`Note not found: ${slug}`);
+
+    const existingLinks = new Set(parseWikilinks(indexed.body).map(l => l.target.toLowerCase()));
+    const allNotes = await this.db.getAllNotes();
+    const bodyLower = indexed.body.toLowerCase();
+    const suggestions: LinkSuggestion[] = [];
+
+    for (const other of allNotes) {
+      if (other.slug === slug) continue;
+      const titleLower = other.title.toLowerCase();
+      if (existingLinks.has(titleLower) || existingLinks.has(other.slug)) continue;
+
+      let mentions = 0;
+      let idx = 0;
+      while ((idx = bodyLower.indexOf(titleLower, idx)) !== -1) {
+        mentions++;
+        idx += titleLower.length;
+      }
+
+      if (mentions > 0) {
+        suggestions.push({ target_slug: other.slug, target_title: other.title, mentions });
+      }
+    }
+
+    return suggestions.sort((a, b) => b.mentions - a.mentions);
+  }
+
+  async createNote(input: CreateNoteInput): Promise<NoteMutationResult> {
+    const config = await this.getConfig();
+    const typeName = input.type ?? config.defaults.note_type;
+    const typeConfig = config.note_types[typeName];
+    if (!typeConfig) throw new Error(`Unknown note type: "${typeName}"`);
+
+    // Generate slug
+    let finalSlug: string;
+    if (typeConfig.slug_format === 'date') {
+      const date = new Date().toISOString().slice(0, 10);
+      const rand = Math.random().toString(36).slice(2, 6);
+      finalSlug = `${date}-${rand}`;
+    } else {
+      finalSlug = slugify(input.title) || 'untitled';
+      if (await this.storage.noteExists(typeConfig.folder, finalSlug)) {
+        let counter = 2;
+        while (await this.storage.noteExists(typeConfig.folder, `${finalSlug}-${counter}`)) {
+          counter++;
+        }
+        finalSlug = `${finalSlug}-${counter}`;
+      }
+    }
+
+    const now = new Date().toISOString();
+    const id = crypto.randomUUID();
+
+    const frontmatter: Record<string, unknown> = {
+      id,
+      title: input.title,
+      type: typeName,
+      created: now,
+      modified: now,
+      tags: input.tags ?? [],
+      aliases: input.aliases ?? [],
+      status: input.status ?? 'active',
+      source: input.source ?? 'human',
+    };
+
+    const body = input.body !== undefined
+      ? (input.body.endsWith('\n') ? input.body : input.body + '\n')
+      : typeConfig.slug_format === 'date'
+        ? input.title + '\n'
+        : typeConfig.template;
+
+    const content = serializeFrontmatter(frontmatter, body);
+
+    // Write to R2
+    await this.storage.writeNote(typeConfig.folder, finalSlug, content);
+
+    // Index in D1
+    const links = parseWikilinks(body);
+    await this.db.upsertNote({
+      slug: finalSlug,
+      id,
+      title: input.title,
+      type: typeName,
+      created: now,
+      modified: now,
+      tags: JSON.stringify(input.tags ?? []),
+      aliases: JSON.stringify(input.aliases ?? []),
+      body,
+      filepath: `${typeConfig.folder}/${finalSlug}.md`,
+      status: input.status ?? 'active',
+      source: input.source ?? 'human',
+    });
+
+    // Index links
+    const allNotes = await this.db.getAllNotes();
+    const indexedLinks = links.map(link => {
+      const targetSlug = slugify(link.target);
+      const found = allNotes.find(n =>
+        n.slug === targetSlug || n.title.toLowerCase() === link.target.toLowerCase()
+      );
+      const bodyLines = body.split('\n');
+      const contextLine = bodyLines.find(l => l.includes(link.raw)) ?? '';
+      return {
+        target_slug: found?.slug ?? null,
+        target_raw: link.target,
+        context: contextLine.trim(),
+      };
+    });
+    await this.db.setLinks(finalSlug, indexedLinks);
+
+    const note = await this.getNote(finalSlug);
+    return { note, recommendations: emptyRecommendations() };
+  }
+
+  async captureNote(input: { text: string; type?: string; tags?: string[]; status?: string; source?: string }): Promise<NoteMutationResult> {
+    const text = input.text.trim();
+    if (!text) throw new Error('Capture text cannot be empty.');
+    const firstLine = text.split('\n')[0] ?? 'Untitled';
+    const title = firstLine.length > 60 ? firstLine.slice(0, 60).trim() + '...' : firstLine;
+    return this.createNote({
+      title,
+      type: input.type,
+      body: text + '\n',
+      tags: input.tags,
+      status: input.status,
+      source: input.source,
+    });
+  }
+
+  async updateNote(slug: string, input: UpdateNoteInput): Promise<NoteMutationResult> {
+    const config = await this.getConfig();
+    const indexed = await this.db.getNote(slug);
+    if (!indexed) throw new Error(`Note not found: ${slug}`);
+
+    const typeConfig = config.note_types[indexed.type];
+    const folder = typeConfig?.folder ?? `notes/${indexed.type}`;
+
+    // Read current content from R2
+    const content = await this.storage.readNote(folder, slug);
+    const { frontmatter, body: existingBody } = parseFrontmatter(content);
+    let body = existingBody;
+
+    if (input.title !== undefined) frontmatter.title = input.title;
+    if (input.tags && input.tags.length > 0) {
+      const existing = new Set(frontmatter.tags as string[] ?? []);
+      for (const t of input.tags) existing.add(t.trim());
+      frontmatter.tags = [...existing];
+    }
+    if (input.aliases && input.aliases.length > 0) {
+      const existing = new Set(frontmatter.aliases as string[] ?? []);
+      for (const a of input.aliases) existing.add(a.trim());
+      frontmatter.aliases = [...existing];
+    }
+    if (input.status !== undefined) frontmatter.status = input.status;
+    if (input.source !== undefined) frontmatter.source = input.source;
+    if (input.body !== undefined) body = input.body.endsWith('\n') ? input.body : input.body + '\n';
+    if (input.append !== undefined) body = body.trimEnd() + '\n' + input.append + '\n';
+
+    frontmatter.modified = new Date().toISOString();
+
+    const newContent = serializeFrontmatter(frontmatter, body);
+    await this.storage.writeNote(folder, slug, newContent);
+
+    // Re-index
+    await this.db.upsertNote({
+      slug,
+      id: String(frontmatter.id),
+      title: String(frontmatter.title),
+      type: indexed.type,
+      created: String(frontmatter.created),
+      modified: String(frontmatter.modified),
+      tags: JSON.stringify(frontmatter.tags),
+      aliases: JSON.stringify(frontmatter.aliases),
+      body,
+      filepath: `${folder}/${slug}.md`,
+      status: String(frontmatter.status),
+      source: String(frontmatter.source),
+    });
+
+    // Re-index links
+    const links = parseWikilinks(body);
+    const allNotes = await this.db.getAllNotes();
+    const indexedLinks = links.map(link => {
+      const targetSlug = slugify(link.target);
+      const found = allNotes.find(n =>
+        n.slug === targetSlug || n.title.toLowerCase() === link.target.toLowerCase()
+      );
+      const bodyLines = body.split('\n');
+      const contextLine = bodyLines.find(l => l.includes(link.raw)) ?? '';
+      return { target_slug: found?.slug ?? null, target_raw: link.target, context: contextLine.trim() };
+    });
+    await this.db.setLinks(slug, indexedLinks);
+
+    const note = await this.getNote(slug);
+    return { note, recommendations: emptyRecommendations() };
+  }
+
+  async readVaultConfigRaw(): Promise<string> {
+    return this.storage.readConfig();
+  }
+
+  async readNoteMarkdown(slug: string): Promise<string> {
+    const config = await this.getConfig();
+    const indexed = await this.db.getNote(slug);
+    if (!indexed) throw new Error(`Note not found: ${slug}`);
+    const typeConfig = config.note_types[indexed.type];
+    const folder = typeConfig?.folder ?? `notes/${indexed.type}`;
+    return this.storage.readNote(folder, slug);
+  }
+
+  private toNoteSummary(n: { slug: string; title: string; type: string; created: string; modified: string; tags: string; aliases: string; status: string; source: string; filepath: string }): NoteSummary {
+    return {
+      slug: n.slug,
+      title: n.title,
+      type: n.type,
+      created: n.created,
+      modified: n.modified,
+      tags: parseJsonArray(n.tags),
+      aliases: parseJsonArray(n.aliases),
+      status: n.status,
+      source: n.source,
+      filepath: n.filepath,
+      resource_uri: `granite://notes/${encodeURIComponent(n.slug)}`,
+    };
+  }
+}
+
+function parseJsonArray(raw: string | null | undefined): string[] {
+  if (!raw) return [];
+  try {
+    const value = JSON.parse(raw);
+    return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
+function emptyRecommendations(): NoteRecommendations {
+  return { additions: [], links: [], tags: [], next_steps: [] };
+}
+
+function getDefaultConfig(): GraniteConfig {
+  return {
+    vault_name: 'My Vault',
+    version: 1,
+    note_types: {
+      fleeting: { folder: 'notes/fleeting', description: 'Quick captures', template: '', line_limit: 50, warn_only: true, slug_format: 'date' },
+      permanent: { folder: 'notes/permanent', description: 'Refined notes', template: '', line_limit: 200, warn_only: false },
+      reference: { folder: 'notes/reference', description: 'External sources', template: '', line_limit: 300, warn_only: true },
+    },
+    defaults: { note_type: 'fleeting', editor: '$EDITOR' },
+    index: { auto_rebuild: true },
+  };
+}

--- a/packages/worker/src/runtime.ts
+++ b/packages/worker/src/runtime.ts
@@ -183,6 +183,7 @@ export class CloudMcpRuntime {
   constructor(
     private storage: R2NoteStorage,
     private db: D1IndexDatabase,
+    private maxNotesPerVault = Infinity,
   ) {}
 
   private async getConfig(): Promise<GraniteConfig> {
@@ -319,6 +320,14 @@ export class CloudMcpRuntime {
   }
 
   async createNote(input: CreateNoteInput): Promise<NoteMutationResult> {
+    // Enforce per-vault note limit
+    if (this.maxNotesPerVault < Infinity) {
+      const count = await this.db.countNotes();
+      if (count >= this.maxNotesPerVault) {
+        throw new Error(`Vault note limit reached (${this.maxNotesPerVault}). Upgrade to pro for more.`);
+      }
+    }
+
     const config = await this.getConfig();
     const typeName = input.type ?? config.defaults.note_type;
     const typeConfig = config.note_types[typeName];

--- a/packages/worker/src/runtime.ts
+++ b/packages/worker/src/runtime.ts
@@ -141,7 +141,7 @@ export class CloudMcpRuntime {
   constructor(
     private storage: R2NoteStorage,
     private db: D1IndexDatabase,
-    private maxNotesPerVault = Infinity,
+    private maxStorageBytes = Infinity,
   ) {}
 
   private async getConfig(): Promise<GraniteConfig> {
@@ -271,14 +271,6 @@ export class CloudMcpRuntime {
   }
 
   async createNote(input: CreateNoteInput): Promise<NoteMutationResult> {
-    // Enforce per-vault note limit
-    if (this.maxNotesPerVault < Infinity) {
-      const count = await this.db.countNotes();
-      if (count >= this.maxNotesPerVault) {
-        throw new Error(`Vault note limit reached (${this.maxNotesPerVault}). Upgrade to pro for more.`);
-      }
-    }
-
     const config = await this.getConfig();
     const typeName = input.type ?? config.defaults.note_type;
     const typeConfig = config.note_types[typeName];
@@ -322,8 +314,18 @@ export class CloudMcpRuntime {
         : typeConfig.template;
 
     const content = serializeFrontmatter(frontmatter, body);
+    const contentBytes = new TextEncoder().encode(content).byteLength;
+
+    // Check storage limit before writing
+    if (this.maxStorageBytes < Infinity) {
+      const used = await this.db.getStorageBytes();
+      if (used + contentBytes > this.maxStorageBytes) {
+        throw new Error('Vault storage limit reached (1 GB). Manage your notes to free up space.');
+      }
+    }
 
     await this.storage.writeNote(typeConfig.folder, finalSlug, content);
+    await this.db.adjustStorageBytes(contentBytes);
 
     const links = parseWikilinks(body);
     await this.db.upsertNote({
@@ -393,7 +395,22 @@ export class CloudMcpRuntime {
     frontmatter.modified = new Date().toISOString();
 
     const newContent = serializeFrontmatter(frontmatter, body);
+    const oldBytes = new TextEncoder().encode(content).byteLength;
+    const newBytes = new TextEncoder().encode(newContent).byteLength;
+    const delta = newBytes - oldBytes;
+
+    // Check storage limit if content grew
+    if (delta > 0 && this.maxStorageBytes < Infinity) {
+      const used = await this.db.getStorageBytes();
+      if (used + delta > this.maxStorageBytes) {
+        throw new Error('Vault storage limit reached (1 GB). Manage your notes to free up space.');
+      }
+    }
+
     await this.storage.writeNote(folder, slug, newContent);
+    if (delta !== 0) {
+      await this.db.adjustStorageBytes(delta);
+    }
 
     await this.db.upsertNote({
       slug,

--- a/packages/worker/src/runtime.ts
+++ b/packages/worker/src/runtime.ts
@@ -1,6 +1,7 @@
 import matter from 'gray-matter';
 import type { R2NoteStorage } from './storage/r2.js';
 import type { D1IndexDatabase } from './storage/d1.js';
+import { parseJsonArray } from './lib/json.js';
 
 // --- Pure function imports (same logic as src/core/) ---
 
@@ -204,7 +205,7 @@ export class CloudMcpRuntime {
     recent_notes: NoteSummary[];
   }> {
     const config = await this.getConfig();
-    const allNotes = await this.db.getAllNotes();
+    const allNotes = await this.db.getAllNotesMeta();
 
     const byType: Record<string, number> = {};
     for (const n of allNotes) {
@@ -254,14 +255,12 @@ export class CloudMcpRuntime {
     const indexed = await this.db.getNote(slug);
     if (!indexed) throw new Error(`Note not found: ${slug}`);
 
-    // Read full content from R2
     const typeConfig = config.note_types[indexed.type];
     const folder = typeConfig?.folder ?? `notes/${indexed.type}`;
     const content = await this.storage.readNote(folder, slug);
     const { frontmatter, body } = parseFrontmatter(content);
 
-    // Resolve outgoing links
-    const allNotes = await this.db.getAllNotes();
+    const allNotes = await this.db.getAllNotesMeta();
     const links = parseWikilinks(body);
     const resolvedLinks = links.map(link => {
       const targetSlug = slugify(link.target);
@@ -293,7 +292,7 @@ export class CloudMcpRuntime {
     if (!indexed) throw new Error(`Note not found: ${slug}`);
 
     const existingLinks = new Set(parseWikilinks(indexed.body).map(l => l.target.toLowerCase()));
-    const allNotes = await this.db.getAllNotes();
+    const allNotes = await this.db.getAllNotesMeta();
     const bodyLower = indexed.body.toLowerCase();
     const suggestions: LinkSuggestion[] = [];
 
@@ -323,7 +322,6 @@ export class CloudMcpRuntime {
     const typeConfig = config.note_types[typeName];
     if (!typeConfig) throw new Error(`Unknown note type: "${typeName}"`);
 
-    // Generate slug
     let finalSlug: string;
     if (typeConfig.slug_format === 'date') {
       const date = new Date().toISOString().slice(0, 10);
@@ -363,10 +361,8 @@ export class CloudMcpRuntime {
 
     const content = serializeFrontmatter(frontmatter, body);
 
-    // Write to R2
     await this.storage.writeNote(typeConfig.folder, finalSlug, content);
 
-    // Index in D1
     const links = parseWikilinks(body);
     await this.db.upsertNote({
       slug: finalSlug,
@@ -383,22 +379,7 @@ export class CloudMcpRuntime {
       source: input.source ?? 'human',
     });
 
-    // Index links
-    const allNotes = await this.db.getAllNotes();
-    const indexedLinks = links.map(link => {
-      const targetSlug = slugify(link.target);
-      const found = allNotes.find(n =>
-        n.slug === targetSlug || n.title.toLowerCase() === link.target.toLowerCase()
-      );
-      const bodyLines = body.split('\n');
-      const contextLine = bodyLines.find(l => l.includes(link.raw)) ?? '';
-      return {
-        target_slug: found?.slug ?? null,
-        target_raw: link.target,
-        context: contextLine.trim(),
-      };
-    });
-    await this.db.setLinks(finalSlug, indexedLinks);
+    await this.indexLinks(finalSlug, body, links);
 
     const note = await this.getNote(finalSlug);
     return { note, recommendations: emptyRecommendations() };
@@ -427,7 +408,6 @@ export class CloudMcpRuntime {
     const typeConfig = config.note_types[indexed.type];
     const folder = typeConfig?.folder ?? `notes/${indexed.type}`;
 
-    // Read current content from R2
     const content = await this.storage.readNote(folder, slug);
     const { frontmatter, body: existingBody } = parseFrontmatter(content);
     let body = existingBody;
@@ -453,7 +433,6 @@ export class CloudMcpRuntime {
     const newContent = serializeFrontmatter(frontmatter, body);
     await this.storage.writeNote(folder, slug, newContent);
 
-    // Re-index
     await this.db.upsertNote({
       slug,
       id: String(frontmatter.id),
@@ -469,19 +448,7 @@ export class CloudMcpRuntime {
       source: String(frontmatter.source),
     });
 
-    // Re-index links
-    const links = parseWikilinks(body);
-    const allNotes = await this.db.getAllNotes();
-    const indexedLinks = links.map(link => {
-      const targetSlug = slugify(link.target);
-      const found = allNotes.find(n =>
-        n.slug === targetSlug || n.title.toLowerCase() === link.target.toLowerCase()
-      );
-      const bodyLines = body.split('\n');
-      const contextLine = bodyLines.find(l => l.includes(link.raw)) ?? '';
-      return { target_slug: found?.slug ?? null, target_raw: link.target, context: contextLine.trim() };
-    });
-    await this.db.setLinks(slug, indexedLinks);
+    await this.indexLinks(slug, body);
 
     const note = await this.getNote(slug);
     return { note, recommendations: emptyRecommendations() };
@@ -500,6 +467,25 @@ export class CloudMcpRuntime {
     return this.storage.readNote(folder, slug);
   }
 
+  private async indexLinks(slug: string, body: string, links?: WikiLink[]): Promise<void> {
+    const wikilinks = links ?? parseWikilinks(body);
+    const allNotes = await this.db.getAllNotesMeta();
+    const bodyLines = body.split('\n');
+    const indexedLinks = wikilinks.map(link => {
+      const targetSlug = slugify(link.target);
+      const found = allNotes.find(n =>
+        n.slug === targetSlug || n.title.toLowerCase() === link.target.toLowerCase(),
+      );
+      const contextLine = bodyLines.find(l => l.includes(link.raw)) ?? '';
+      return {
+        target_slug: found?.slug ?? null,
+        target_raw: link.target,
+        context: contextLine.trim(),
+      };
+    });
+    await this.db.setLinks(slug, indexedLinks);
+  }
+
   private toNoteSummary(n: { slug: string; title: string; type: string; created: string; modified: string; tags: string; aliases: string; status: string; source: string; filepath: string }): NoteSummary {
     return {
       slug: n.slug,
@@ -514,16 +500,6 @@ export class CloudMcpRuntime {
       filepath: n.filepath,
       resource_uri: `granite://notes/${encodeURIComponent(n.slug)}`,
     };
-  }
-}
-
-function parseJsonArray(raw: string | null | undefined): string[] {
-  if (!raw) return [];
-  try {
-    const value = JSON.parse(raw);
-    return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : [];
-  } catch {
-    return [];
   }
 }
 

--- a/packages/worker/src/runtime.ts
+++ b/packages/worker/src/runtime.ts
@@ -2,6 +2,7 @@ import matter from 'gray-matter';
 import type { R2NoteStorage } from './storage/r2.js';
 import type { D1IndexDatabase } from './storage/d1.js';
 import { parseJsonArray } from './lib/json.js';
+import { DEFAULT_TYPE_FOLDERS, resolveTypeFolder } from './lib/config.js';
 
 // --- Pure function imports (same logic as src/core/) ---
 
@@ -256,7 +257,7 @@ export class CloudMcpRuntime {
     if (!indexed) throw new Error(`Note not found: ${slug}`);
 
     const typeConfig = config.note_types[indexed.type];
-    const folder = typeConfig?.folder ?? `notes/${indexed.type}`;
+    const folder = resolveTypeFolder(indexed.type, typeConfig?.folder);
     const content = await this.storage.readNote(folder, slug);
     const { frontmatter, body } = parseFrontmatter(content);
 
@@ -407,7 +408,7 @@ export class CloudMcpRuntime {
     if (!indexed) throw new Error(`Note not found: ${slug}`);
 
     const typeConfig = config.note_types[indexed.type];
-    const folder = typeConfig?.folder ?? `notes/${indexed.type}`;
+    const folder = resolveTypeFolder(indexed.type, typeConfig?.folder);
 
     const content = await this.storage.readNote(folder, slug);
     const { frontmatter, body: existingBody } = parseFrontmatter(content);
@@ -464,7 +465,7 @@ export class CloudMcpRuntime {
     const indexed = await this.db.getNote(slug);
     if (!indexed) throw new Error(`Note not found: ${slug}`);
     const typeConfig = config.note_types[indexed.type];
-    const folder = typeConfig?.folder ?? `notes/${indexed.type}`;
+    const folder = resolveTypeFolder(indexed.type, typeConfig?.folder);
     return this.storage.readNote(folder, slug);
   }
 
@@ -509,14 +510,25 @@ function emptyRecommendations(): NoteRecommendations {
 }
 
 function getDefaultConfig(): GraniteConfig {
+  const defaultType = (folder: string, desc: string, opts: Partial<NoteTypeConfig> = {}): NoteTypeConfig => ({
+    folder, description: desc, template: '', line_limit: 200, warn_only: false, ...opts,
+  });
+
   return {
     vault_name: 'My Vault',
     version: 1,
-    note_types: {
-      fleeting: { folder: 'notes/fleeting', description: 'Quick captures', template: '', line_limit: 50, warn_only: true, slug_format: 'date' },
-      permanent: { folder: 'notes/permanent', description: 'Refined notes', template: '', line_limit: 200, warn_only: false },
-      reference: { folder: 'notes/reference', description: 'External sources', template: '', line_limit: 300, warn_only: true },
-    },
+    note_types: Object.fromEntries(
+      Object.entries(DEFAULT_TYPE_FOLDERS).map(([type, folder]) => {
+        const descriptions: Record<string, string> = {
+          fleeting: 'Quick captures', permanent: 'Refined notes', reference: 'External sources',
+          person: 'People', meeting: 'Meetings', project: 'Projects', decision: 'Decisions',
+        };
+        const extra: Partial<NoteTypeConfig> = {};
+        if (type === 'fleeting') { extra.slug_format = 'date'; extra.line_limit = 50; extra.warn_only = true; }
+        if (type === 'reference') { extra.line_limit = 300; extra.warn_only = true; }
+        return [type, defaultType(folder, descriptions[type] ?? type, extra)];
+      }),
+    ),
     defaults: { note_type: 'fleeting', editor: '$EDITOR' },
     index: { auto_rebuild: true },
   };

--- a/packages/worker/src/runtime.ts
+++ b/packages/worker/src/runtime.ts
@@ -3,6 +3,7 @@ import type { R2NoteStorage } from './storage/r2.js';
 import type { D1IndexDatabase } from './storage/d1.js';
 import { parseJsonArray } from './lib/json.js';
 import { DEFAULT_TYPE_FOLDERS, resolveTypeFolder } from './lib/config.js';
+import { parseWikilinks, resolveWikilinks, indexLinks } from './lib/wikilinks.js';
 
 // --- Pure function imports (same logic as src/core/) ---
 
@@ -16,39 +17,8 @@ function slugify(title: string): string {
     || 'untitled';
 }
 
-interface WikiLink {
-  raw: string;
-  target: string;
-  display: string;
-  resolved: boolean;
-  resolved_slug?: string;
-}
-
-function parseWikilinks(body: string): WikiLink[] {
-  const cleaned = body
-    .replace(/```[\s\S]*?```/g, '')
-    .replace(/`[^`]*`/g, '');
-
-  const links: WikiLink[] = [];
-  const regex = /\[\[([^\]]+)\]\]/g;
-  let match;
-
-  while ((match = regex.exec(cleaned)) !== null) {
-    const inner = match[1];
-    const pipeIndex = inner.indexOf('|');
-    const target = pipeIndex >= 0 ? inner.slice(0, pipeIndex).trim() : inner.trim();
-    const display = pipeIndex >= 0 ? inner.slice(pipeIndex + 1).trim() : inner.trim();
-
-    links.push({
-      raw: match[0],
-      target,
-      display,
-      resolved: false,
-    });
-  }
-
-  return links;
-}
+// WikiLink type re-exported from shared module
+type WikiLink = ReturnType<typeof parseWikilinks>[number];
 
 function parseFrontmatter(content: string): { frontmatter: Record<string, unknown>; body: string } {
   const { data, content: body } = matter(content);
@@ -264,14 +234,7 @@ export class CloudMcpRuntime {
 
     const allNotes = await this.db.getAllNotesMeta();
     const links = parseWikilinks(body);
-    const resolvedLinks = links.map(link => {
-      const targetSlug = slugify(link.target);
-      const found = allNotes.find(n =>
-        n.slug === targetSlug ||
-        n.title.toLowerCase() === link.target.toLowerCase()
-      );
-      return { ...link, resolved: !!found, resolved_slug: found?.slug };
-    });
+    const resolvedLinks = resolveWikilinks(links, allNotes);
 
     return {
       ...this.toNoteSummary(indexed),
@@ -390,7 +353,7 @@ export class CloudMcpRuntime {
       source: input.source ?? 'human',
     });
 
-    await this.indexLinks(finalSlug, body, links);
+    await indexLinks(this.db,finalSlug, body, links);
 
     const note = await this.getNote(finalSlug);
     return { note, recommendations: emptyRecommendations() };
@@ -459,7 +422,7 @@ export class CloudMcpRuntime {
       source: String(frontmatter.source),
     });
 
-    await this.indexLinks(slug, body);
+    await indexLinks(this.db,slug, body);
 
     const note = await this.getNote(slug);
     return { note, recommendations: emptyRecommendations() };
@@ -476,25 +439,6 @@ export class CloudMcpRuntime {
     const typeConfig = config.note_types[indexed.type];
     const folder = resolveTypeFolder(indexed.type, typeConfig?.folder);
     return this.storage.readNote(folder, slug);
-  }
-
-  private async indexLinks(slug: string, body: string, links?: WikiLink[]): Promise<void> {
-    const wikilinks = links ?? parseWikilinks(body);
-    const allNotes = await this.db.getAllNotesMeta();
-    const bodyLines = body.split('\n');
-    const indexedLinks = wikilinks.map(link => {
-      const targetSlug = slugify(link.target);
-      const found = allNotes.find(n =>
-        n.slug === targetSlug || n.title.toLowerCase() === link.target.toLowerCase(),
-      );
-      const contextLine = bodyLines.find(l => l.includes(link.raw)) ?? '';
-      return {
-        target_slug: found?.slug ?? null,
-        target_raw: link.target,
-        context: contextLine.trim(),
-      };
-    });
-    await this.db.setLinks(slug, indexedLinks);
   }
 
   private toNoteSummary(n: { slug: string; title: string; type: string; created: string; modified: string; tags: string; aliases: string; status: string; source: string; filepath: string }): NoteSummary {

--- a/packages/worker/src/storage/d1.ts
+++ b/packages/worker/src/storage/d1.ts
@@ -102,10 +102,32 @@ export class D1IndexDatabase {
       .first<IndexedNote>();
   }
 
+  async getNotesByIds(noteIds: string[]): Promise<Map<string, IndexedNote>> {
+    const map = new Map<string, IndexedNote>();
+    if (noteIds.length === 0) return map;
+    // D1 doesn't support IN with bind params well, so batch individual queries
+    const stmts = noteIds.map(id =>
+      this.db.prepare('SELECT * FROM notes WHERE id = ? AND vault_id = ?').bind(id, this.vaultId),
+    );
+    const results = await this.db.batch(stmts);
+    for (const result of results) {
+      const rows = (result as D1Result<IndexedNote>).results;
+      if (rows.length > 0) map.set(rows[0].id, rows[0]);
+    }
+    return map;
+  }
+
   async getAllNotes(): Promise<IndexedNote[]> {
     const result = await this.db.prepare(
       'SELECT * FROM notes WHERE vault_id = ? ORDER BY modified DESC',
     ).bind(this.vaultId).all<IndexedNote>();
+    return result.results;
+  }
+
+  async getAllNotesMeta(): Promise<Array<{ slug: string; title: string; type: string; created: string; modified: string; tags: string; aliases: string; status: string; source: string; filepath: string }>> {
+    const result = await this.db.prepare(
+      'SELECT slug, title, type, created, modified, tags, aliases, status, source, filepath FROM notes WHERE vault_id = ? ORDER BY modified DESC',
+    ).bind(this.vaultId).all<{ slug: string; title: string; type: string; created: string; modified: string; tags: string; aliases: string; status: string; source: string; filepath: string }>();
     return result.results;
   }
 

--- a/packages/worker/src/storage/d1.ts
+++ b/packages/worker/src/storage/d1.ts
@@ -1,0 +1,285 @@
+interface IndexedNote {
+  slug: string;
+  id: string;
+  title: string;
+  type: string;
+  created: string;
+  modified: string;
+  tags: string;
+  aliases: string;
+  body: string;
+  filepath: string;
+  status: string;
+  source: string;
+}
+
+interface IndexedLink {
+  target_slug: string | null;
+  target_raw: string;
+  context: string;
+}
+
+interface SearchResult {
+  slug: string;
+  title: string;
+  snippet: string;
+  score: number;
+}
+
+interface BacklinkEntry {
+  source_slug: string;
+  source_title: string;
+  context: string;
+}
+
+interface ChangelogRow {
+  seq: number;
+  vault_id: string;
+  note_id: string;
+  operation: string;
+  timestamp: string;
+  device_id: string;
+  checksum: string;
+  slug: string;
+}
+
+interface DeviceRow {
+  device_id: string;
+  vault_id: string;
+  device_name: string;
+  last_seen: string;
+  last_seq: number;
+}
+
+export class D1IndexDatabase {
+  constructor(
+    private db: D1Database,
+    private vaultId: string,
+  ) {}
+
+  // --- Notes ---
+
+  async upsertNote(note: IndexedNote): Promise<void> {
+    await this.db.prepare(`
+      INSERT INTO notes (slug, id, title, type, created, modified, tags, aliases, body, filepath, status, source)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(slug) DO UPDATE SET
+        id = excluded.id,
+        title = excluded.title,
+        type = excluded.type,
+        created = excluded.created,
+        modified = excluded.modified,
+        tags = excluded.tags,
+        aliases = excluded.aliases,
+        body = excluded.body,
+        filepath = excluded.filepath,
+        status = excluded.status,
+        source = excluded.source
+    `).bind(
+      note.slug, note.id, note.title, note.type,
+      note.created, note.modified, note.tags, note.aliases,
+      note.body, note.filepath, note.status, note.source,
+    ).run();
+  }
+
+  async deleteNoteBySlug(slug: string): Promise<void> {
+    await this.db.batch([
+      this.db.prepare('DELETE FROM links WHERE source_slug = ?').bind(slug),
+      this.db.prepare('DELETE FROM notes WHERE slug = ?').bind(slug),
+    ]);
+  }
+
+  async getNote(slug: string): Promise<IndexedNote | null> {
+    return this.db.prepare('SELECT * FROM notes WHERE slug = ?')
+      .bind(slug)
+      .first<IndexedNote>();
+  }
+
+  async getNoteById(noteId: string): Promise<IndexedNote | null> {
+    return this.db.prepare('SELECT * FROM notes WHERE id = ?')
+      .bind(noteId)
+      .first<IndexedNote>();
+  }
+
+  async getAllNotes(): Promise<IndexedNote[]> {
+    const result = await this.db.prepare('SELECT * FROM notes ORDER BY modified DESC').all<IndexedNote>();
+    return result.results;
+  }
+
+  async countNotes(): Promise<number> {
+    const row = await this.db.prepare('SELECT COUNT(*) as c FROM notes').first<{ c: number }>();
+    return row?.c ?? 0;
+  }
+
+  // --- Search (same FTS5 query as src/core/search.ts) ---
+
+  async searchNotes(query: string, limit: number): Promise<SearchResult[]> {
+    const cappedLimit = Math.max(1, Math.min(limit, 100));
+    const result = await this.db.prepare(`
+      SELECT
+        n.slug,
+        n.title,
+        snippet(notes_fts, 1, '>>>', '<<<', '...', 30) as snippet,
+        rank as score
+      FROM notes_fts
+      JOIN notes n ON n.rowid = notes_fts.rowid
+      WHERE notes_fts MATCH ?
+      ORDER BY rank
+      LIMIT ?
+    `).bind(query, cappedLimit).all<SearchResult>();
+    return result.results;
+  }
+
+  // --- Links (same queries as src/core/backlinks.ts) ---
+
+  async setLinks(sourceSlug: string, links: IndexedLink[]): Promise<void> {
+    const stmts: D1PreparedStatement[] = [
+      this.db.prepare('DELETE FROM links WHERE source_slug = ?').bind(sourceSlug),
+    ];
+
+    for (const link of links) {
+      stmts.push(
+        this.db.prepare(
+          'INSERT INTO links (source_slug, target_slug, target_raw, context) VALUES (?, ?, ?, ?)'
+        ).bind(sourceSlug, link.target_slug, link.target_raw, link.context),
+      );
+    }
+
+    await this.db.batch(stmts);
+  }
+
+  async getBacklinks(slug: string): Promise<BacklinkEntry[]> {
+    const result = await this.db.prepare(`
+      SELECT
+        l.source_slug,
+        n.title as source_title,
+        l.context
+      FROM links l
+      JOIN notes n ON n.slug = l.source_slug
+      WHERE l.target_slug = ?
+      ORDER BY n.title
+    `).bind(slug).all<BacklinkEntry>();
+    return result.results;
+  }
+
+  async getOutgoingLinks(slug: string): Promise<Array<{ target_slug: string | null; target_raw: string }>> {
+    const result = await this.db.prepare(
+      'SELECT target_slug, target_raw FROM links WHERE source_slug = ?'
+    ).bind(slug).all<{ target_slug: string | null; target_raw: string }>();
+    return result.results;
+  }
+
+  // --- Meta ---
+
+  async getMeta(key: string): Promise<string | null> {
+    const row = await this.db.prepare('SELECT value FROM meta WHERE key = ?')
+      .bind(key)
+      .first<{ value: string }>();
+    return row?.value ?? null;
+  }
+
+  async setMeta(key: string, value: string): Promise<void> {
+    await this.db.prepare('INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)')
+      .bind(key, value)
+      .run();
+  }
+
+  // --- Rebuild ---
+
+  async rebuildFromNotes(entries: Array<{ note: IndexedNote; links: IndexedLink[] }>): Promise<void> {
+    const stmts: D1PreparedStatement[] = [
+      this.db.prepare('DELETE FROM links'),
+      this.db.prepare('DELETE FROM notes'),
+      this.db.prepare("INSERT INTO notes_fts(notes_fts) VALUES('rebuild')"),
+    ];
+
+    for (const entry of entries) {
+      const n = entry.note;
+      stmts.push(
+        this.db.prepare(`
+          INSERT INTO notes (slug, id, title, type, created, modified, tags, aliases, body, filepath, status, source)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `).bind(
+          n.slug, n.id, n.title, n.type,
+          n.created, n.modified, n.tags, n.aliases,
+          n.body, n.filepath, n.status, n.source,
+        ),
+      );
+
+      for (const link of entry.links) {
+        stmts.push(
+          this.db.prepare(
+            'INSERT INTO links (source_slug, target_slug, target_raw, context) VALUES (?, ?, ?, ?)'
+          ).bind(n.slug, link.target_slug, link.target_raw, link.context),
+        );
+      }
+    }
+
+    stmts.push(
+      this.db.prepare("INSERT OR REPLACE INTO meta (key, value) VALUES ('last_rebuild', ?)")
+        .bind(new Date().toISOString()),
+    );
+
+    await this.db.batch(stmts);
+  }
+
+  // --- Sync Changelog ---
+
+  async recordChange(
+    noteId: string,
+    operation: string,
+    deviceId: string,
+    checksum: string,
+    slug: string,
+  ): Promise<number> {
+    const result = await this.db.prepare(`
+      INSERT INTO sync_changelog (vault_id, note_id, operation, timestamp, device_id, checksum, slug)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `).bind(
+      this.vaultId, noteId, operation,
+      new Date().toISOString(), deviceId, checksum, slug,
+    ).run();
+    return result.meta.last_row_id;
+  }
+
+  async getChangesSince(sinceSeq: number, excludeDeviceId: string): Promise<ChangelogRow[]> {
+    const result = await this.db.prepare(`
+      SELECT * FROM sync_changelog
+      WHERE vault_id = ? AND seq > ? AND device_id != ?
+      ORDER BY seq ASC
+    `).bind(this.vaultId, sinceSeq, excludeDeviceId).all<ChangelogRow>();
+    return result.results;
+  }
+
+  async getLatestSeq(): Promise<number> {
+    const row = await this.db.prepare(
+      'SELECT MAX(seq) as max_seq FROM sync_changelog WHERE vault_id = ?'
+    ).bind(this.vaultId).first<{ max_seq: number | null }>();
+    return row?.max_seq ?? 0;
+  }
+
+  // --- Devices ---
+
+  async upsertDevice(deviceId: string, deviceName: string): Promise<void> {
+    await this.db.prepare(`
+      INSERT INTO devices (device_id, vault_id, device_name, last_seen, last_seq)
+      VALUES (?, ?, ?, ?, 0)
+      ON CONFLICT(device_id) DO UPDATE SET
+        device_name = excluded.device_name,
+        last_seen = excluded.last_seen
+    `).bind(deviceId, this.vaultId, deviceName, new Date().toISOString()).run();
+  }
+
+  async getDevices(): Promise<DeviceRow[]> {
+    const result = await this.db.prepare(
+      'SELECT * FROM devices WHERE vault_id = ?'
+    ).bind(this.vaultId).all<DeviceRow>();
+    return result.results;
+  }
+
+  async updateDeviceSeq(deviceId: string, seq: number): Promise<void> {
+    await this.db.prepare(
+      'UPDATE devices SET last_seq = ?, last_seen = ? WHERE device_id = ?'
+    ).bind(seq, new Date().toISOString(), deviceId).run();
+  }
+}

--- a/packages/worker/src/storage/d1.ts
+++ b/packages/worker/src/storage/d1.ts
@@ -309,4 +309,19 @@ export class D1IndexDatabase {
       'UPDATE devices SET last_seq = ?, last_seen = ? WHERE device_id = ? AND vault_id = ?',
     ).bind(seq, new Date().toISOString(), deviceId, this.vaultId).run();
   }
+
+  // --- Storage tracking ---
+
+  async getStorageBytes(): Promise<number> {
+    const row = await this.db.prepare(
+      'SELECT storage_bytes FROM vaults WHERE vault_id = ?',
+    ).bind(this.vaultId).first<{ storage_bytes: number }>();
+    return row?.storage_bytes ?? 0;
+  }
+
+  async adjustStorageBytes(delta: number): Promise<void> {
+    await this.db.prepare(
+      'UPDATE vaults SET storage_bytes = MAX(0, storage_bytes + ?) WHERE vault_id = ?',
+    ).bind(delta, this.vaultId).run();
+  }
 }

--- a/packages/worker/src/storage/d1.ts
+++ b/packages/worker/src/storage/d1.ts
@@ -61,8 +61,8 @@ export class D1IndexDatabase {
 
   async upsertNote(note: IndexedNote): Promise<void> {
     await this.db.prepare(`
-      INSERT INTO notes (slug, id, title, type, created, modified, tags, aliases, body, filepath, status, source)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT INTO notes (slug, id, title, type, created, modified, tags, aliases, body, filepath, status, source, vault_id)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       ON CONFLICT(slug) DO UPDATE SET
         id = excluded.id,
         title = excluded.title,
@@ -79,39 +79,44 @@ export class D1IndexDatabase {
       note.slug, note.id, note.title, note.type,
       note.created, note.modified, note.tags, note.aliases,
       note.body, note.filepath, note.status, note.source,
+      this.vaultId,
     ).run();
   }
 
   async deleteNoteBySlug(slug: string): Promise<void> {
     await this.db.batch([
-      this.db.prepare('DELETE FROM links WHERE source_slug = ?').bind(slug),
-      this.db.prepare('DELETE FROM notes WHERE slug = ?').bind(slug),
+      this.db.prepare('DELETE FROM links WHERE source_slug = ? AND vault_id = ?').bind(slug, this.vaultId),
+      this.db.prepare('DELETE FROM notes WHERE slug = ? AND vault_id = ?').bind(slug, this.vaultId),
     ]);
   }
 
   async getNote(slug: string): Promise<IndexedNote | null> {
-    return this.db.prepare('SELECT * FROM notes WHERE slug = ?')
-      .bind(slug)
+    return this.db.prepare('SELECT * FROM notes WHERE slug = ? AND vault_id = ?')
+      .bind(slug, this.vaultId)
       .first<IndexedNote>();
   }
 
   async getNoteById(noteId: string): Promise<IndexedNote | null> {
-    return this.db.prepare('SELECT * FROM notes WHERE id = ?')
-      .bind(noteId)
+    return this.db.prepare('SELECT * FROM notes WHERE id = ? AND vault_id = ?')
+      .bind(noteId, this.vaultId)
       .first<IndexedNote>();
   }
 
   async getAllNotes(): Promise<IndexedNote[]> {
-    const result = await this.db.prepare('SELECT * FROM notes ORDER BY modified DESC').all<IndexedNote>();
+    const result = await this.db.prepare(
+      'SELECT * FROM notes WHERE vault_id = ? ORDER BY modified DESC',
+    ).bind(this.vaultId).all<IndexedNote>();
     return result.results;
   }
 
   async countNotes(): Promise<number> {
-    const row = await this.db.prepare('SELECT COUNT(*) as c FROM notes').first<{ c: number }>();
+    const row = await this.db.prepare(
+      'SELECT COUNT(*) as c FROM notes WHERE vault_id = ?',
+    ).bind(this.vaultId).first<{ c: number }>();
     return row?.c ?? 0;
   }
 
-  // --- Search (same FTS5 query as src/core/search.ts) ---
+  // --- Search ---
 
   async searchNotes(query: string, limit: number): Promise<SearchResult[]> {
     const cappedLimit = Math.max(1, Math.min(limit, 100));
@@ -123,25 +128,25 @@ export class D1IndexDatabase {
         rank as score
       FROM notes_fts
       JOIN notes n ON n.rowid = notes_fts.rowid
-      WHERE notes_fts MATCH ?
+      WHERE notes_fts MATCH ? AND n.vault_id = ?
       ORDER BY rank
       LIMIT ?
-    `).bind(query, cappedLimit).all<SearchResult>();
+    `).bind(query, this.vaultId, cappedLimit).all<SearchResult>();
     return result.results;
   }
 
-  // --- Links (same queries as src/core/backlinks.ts) ---
+  // --- Links ---
 
   async setLinks(sourceSlug: string, links: IndexedLink[]): Promise<void> {
     const stmts: D1PreparedStatement[] = [
-      this.db.prepare('DELETE FROM links WHERE source_slug = ?').bind(sourceSlug),
+      this.db.prepare('DELETE FROM links WHERE source_slug = ? AND vault_id = ?').bind(sourceSlug, this.vaultId),
     ];
 
     for (const link of links) {
       stmts.push(
         this.db.prepare(
-          'INSERT INTO links (source_slug, target_slug, target_raw, context) VALUES (?, ?, ?, ?)'
-        ).bind(sourceSlug, link.target_slug, link.target_raw, link.context),
+          'INSERT INTO links (source_slug, target_slug, target_raw, context, vault_id) VALUES (?, ?, ?, ?, ?)',
+        ).bind(sourceSlug, link.target_slug, link.target_raw, link.context, this.vaultId),
       );
     }
 
@@ -155,32 +160,32 @@ export class D1IndexDatabase {
         n.title as source_title,
         l.context
       FROM links l
-      JOIN notes n ON n.slug = l.source_slug
-      WHERE l.target_slug = ?
+      JOIN notes n ON n.slug = l.source_slug AND n.vault_id = l.vault_id
+      WHERE l.target_slug = ? AND l.vault_id = ?
       ORDER BY n.title
-    `).bind(slug).all<BacklinkEntry>();
+    `).bind(slug, this.vaultId).all<BacklinkEntry>();
     return result.results;
   }
 
   async getOutgoingLinks(slug: string): Promise<Array<{ target_slug: string | null; target_raw: string }>> {
     const result = await this.db.prepare(
-      'SELECT target_slug, target_raw FROM links WHERE source_slug = ?'
-    ).bind(slug).all<{ target_slug: string | null; target_raw: string }>();
+      'SELECT target_slug, target_raw FROM links WHERE source_slug = ? AND vault_id = ?',
+    ).bind(slug, this.vaultId).all<{ target_slug: string | null; target_raw: string }>();
     return result.results;
   }
 
   // --- Meta ---
 
   async getMeta(key: string): Promise<string | null> {
-    const row = await this.db.prepare('SELECT value FROM meta WHERE key = ?')
-      .bind(key)
+    const row = await this.db.prepare('SELECT value FROM meta WHERE key = ? AND vault_id = ?')
+      .bind(key, this.vaultId)
       .first<{ value: string }>();
     return row?.value ?? null;
   }
 
   async setMeta(key: string, value: string): Promise<void> {
-    await this.db.prepare('INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)')
-      .bind(key, value)
+    await this.db.prepare('INSERT OR REPLACE INTO meta (key, value, vault_id) VALUES (?, ?, ?)')
+      .bind(key, value, this.vaultId)
       .run();
   }
 
@@ -188,36 +193,36 @@ export class D1IndexDatabase {
 
   async rebuildFromNotes(entries: Array<{ note: IndexedNote; links: IndexedLink[] }>): Promise<void> {
     const stmts: D1PreparedStatement[] = [
-      this.db.prepare('DELETE FROM links'),
-      this.db.prepare('DELETE FROM notes'),
-      this.db.prepare("INSERT INTO notes_fts(notes_fts) VALUES('rebuild')"),
+      this.db.prepare('DELETE FROM links WHERE vault_id = ?').bind(this.vaultId),
+      this.db.prepare('DELETE FROM notes WHERE vault_id = ?').bind(this.vaultId),
     ];
 
     for (const entry of entries) {
       const n = entry.note;
       stmts.push(
         this.db.prepare(`
-          INSERT INTO notes (slug, id, title, type, created, modified, tags, aliases, body, filepath, status, source)
-          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          INSERT INTO notes (slug, id, title, type, created, modified, tags, aliases, body, filepath, status, source, vault_id)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         `).bind(
           n.slug, n.id, n.title, n.type,
           n.created, n.modified, n.tags, n.aliases,
           n.body, n.filepath, n.status, n.source,
+          this.vaultId,
         ),
       );
 
       for (const link of entry.links) {
         stmts.push(
           this.db.prepare(
-            'INSERT INTO links (source_slug, target_slug, target_raw, context) VALUES (?, ?, ?, ?)'
-          ).bind(n.slug, link.target_slug, link.target_raw, link.context),
+            'INSERT INTO links (source_slug, target_slug, target_raw, context, vault_id) VALUES (?, ?, ?, ?, ?)',
+          ).bind(n.slug, link.target_slug, link.target_raw, link.context, this.vaultId),
         );
       }
     }
 
     stmts.push(
-      this.db.prepare("INSERT OR REPLACE INTO meta (key, value) VALUES ('last_rebuild', ?)")
-        .bind(new Date().toISOString()),
+      this.db.prepare("INSERT OR REPLACE INTO meta (key, value, vault_id) VALUES ('last_rebuild', ?, ?)")
+        .bind(new Date().toISOString(), this.vaultId),
     );
 
     await this.db.batch(stmts);
@@ -253,7 +258,7 @@ export class D1IndexDatabase {
 
   async getLatestSeq(): Promise<number> {
     const row = await this.db.prepare(
-      'SELECT MAX(seq) as max_seq FROM sync_changelog WHERE vault_id = ?'
+      'SELECT MAX(seq) as max_seq FROM sync_changelog WHERE vault_id = ?',
     ).bind(this.vaultId).first<{ max_seq: number | null }>();
     return row?.max_seq ?? 0;
   }
@@ -272,14 +277,14 @@ export class D1IndexDatabase {
 
   async getDevices(): Promise<DeviceRow[]> {
     const result = await this.db.prepare(
-      'SELECT * FROM devices WHERE vault_id = ?'
+      'SELECT * FROM devices WHERE vault_id = ?',
     ).bind(this.vaultId).all<DeviceRow>();
     return result.results;
   }
 
   async updateDeviceSeq(deviceId: string, seq: number): Promise<void> {
     await this.db.prepare(
-      'UPDATE devices SET last_seq = ?, last_seen = ? WHERE device_id = ?'
+      'UPDATE devices SET last_seq = ?, last_seen = ? WHERE device_id = ?',
     ).bind(seq, new Date().toISOString(), deviceId).run();
   }
 }

--- a/packages/worker/src/storage/d1.ts
+++ b/packages/worker/src/storage/d1.ts
@@ -291,7 +291,7 @@ export class D1IndexDatabase {
     await this.db.prepare(`
       INSERT INTO devices (device_id, vault_id, device_name, last_seen, last_seq)
       VALUES (?, ?, ?, ?, 0)
-      ON CONFLICT(device_id) DO UPDATE SET
+      ON CONFLICT(vault_id, device_id) DO UPDATE SET
         device_name = excluded.device_name,
         last_seen = excluded.last_seen
     `).bind(deviceId, this.vaultId, deviceName, new Date().toISOString()).run();
@@ -306,7 +306,7 @@ export class D1IndexDatabase {
 
   async updateDeviceSeq(deviceId: string, seq: number): Promise<void> {
     await this.db.prepare(
-      'UPDATE devices SET last_seq = ?, last_seen = ? WHERE device_id = ?',
-    ).bind(seq, new Date().toISOString(), deviceId).run();
+      'UPDATE devices SET last_seq = ?, last_seen = ? WHERE device_id = ? AND vault_id = ?',
+    ).bind(seq, new Date().toISOString(), deviceId, this.vaultId).run();
   }
 }

--- a/packages/worker/src/storage/d1.ts
+++ b/packages/worker/src/storage/d1.ts
@@ -63,7 +63,7 @@ export class D1IndexDatabase {
     await this.db.prepare(`
       INSERT INTO notes (slug, id, title, type, created, modified, tags, aliases, body, filepath, status, source, vault_id)
       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-      ON CONFLICT(slug) DO UPDATE SET
+      ON CONFLICT(vault_id, slug) DO UPDATE SET
         id = excluded.id,
         title = excluded.title,
         type = excluded.type,

--- a/packages/worker/src/storage/r2.ts
+++ b/packages/worker/src/storage/r2.ts
@@ -1,0 +1,68 @@
+export class R2NoteStorage {
+  constructor(
+    private bucket: R2Bucket,
+    private vaultId: string,
+  ) {}
+
+  private noteKey(typeFolder: string, slug: string): string {
+    return `${this.vaultId}/${typeFolder}/${slug}.md`;
+  }
+
+  async readNote(typeFolder: string, slug: string): Promise<string> {
+    const key = this.noteKey(typeFolder, slug);
+    const obj = await this.bucket.get(key);
+    if (!obj) throw new Error(`Note not found in R2: ${typeFolder}/${slug}`);
+    return obj.text();
+  }
+
+  async writeNote(typeFolder: string, slug: string, content: string): Promise<void> {
+    const key = this.noteKey(typeFolder, slug);
+    await this.bucket.put(key, content, {
+      httpMetadata: { contentType: 'text/markdown' },
+    });
+  }
+
+  async deleteNote(typeFolder: string, slug: string): Promise<void> {
+    const key = this.noteKey(typeFolder, slug);
+    await this.bucket.delete(key);
+  }
+
+  async noteExists(typeFolder: string, slug: string): Promise<boolean> {
+    const key = this.noteKey(typeFolder, slug);
+    const head = await this.bucket.head(key);
+    return head !== null;
+  }
+
+  async listSlugs(typeFolder: string): Promise<string[]> {
+    const prefix = `${this.vaultId}/${typeFolder}/`;
+    const slugs: string[] = [];
+    let cursor: string | undefined;
+
+    do {
+      const listed = await this.bucket.list({ prefix, cursor });
+      for (const obj of listed.objects) {
+        const name = obj.key.slice(prefix.length);
+        if (name.endsWith('.md')) {
+          slugs.push(name.slice(0, -3));
+        }
+      }
+      cursor = listed.truncated ? listed.cursor : undefined;
+    } while (cursor);
+
+    return slugs;
+  }
+
+  async readConfig(): Promise<string> {
+    const key = `${this.vaultId}/granite.yml`;
+    const obj = await this.bucket.get(key);
+    if (!obj) throw new Error('Config not found in R2');
+    return obj.text();
+  }
+
+  async writeConfig(content: string): Promise<void> {
+    const key = `${this.vaultId}/granite.yml`;
+    await this.bucket.put(key, content, {
+      httpMetadata: { contentType: 'text/yaml' },
+    });
+  }
+}

--- a/packages/worker/tsconfig.json
+++ b/packages/worker/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/worker/wrangler.toml
+++ b/packages/worker/wrangler.toml
@@ -1,0 +1,13 @@
+name = "granite-cloud"
+main = "src/index.ts"
+compatibility_date = "2026-03-31"
+compatibility_flags = ["nodejs_compat"]
+
+[[r2_buckets]]
+binding = "VAULT_BUCKET"
+bucket_name = "granite-vaults"
+
+[[d1_databases]]
+binding = "DB"
+database_name = "granite-index"
+database_id = ""

--- a/packages/worker/wrangler.toml
+++ b/packages/worker/wrangler.toml
@@ -3,6 +3,19 @@ main = "src/index.ts"
 compatibility_date = "2026-03-31"
 compatibility_flags = ["nodejs_compat"]
 
+[triggers]
+crons = ["0 * * * *"]
+
+[vars]
+BASE_URL = "https://granite.cloud"
+
+# Secrets (set via `wrangler secret put`):
+# GITHUB_CLIENT_ID
+# GITHUB_CLIENT_SECRET
+# STRIPE_SECRET_KEY
+# STRIPE_WEBHOOK_SECRET
+# STRIPE_PRICE_ID
+
 [[r2_buckets]]
 binding = "VAULT_BUCKET"
 bucket_name = "granite-vaults"

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -4,6 +4,7 @@ import { requireVaultRoot } from '../core/vault.js';
 import { createNote } from '../core/note.js';
 import { jsonSuccess } from '../core/json-output.js';
 import { recommendNote, formatRecommendations } from '../core/recommendations.js';
+import { getSyncManager } from '../core/sync/manager.js';
 
 export function addNote(text?: string, options: { json?: boolean } = {}): void {
   const vaultRoot = requireVaultRoot();
@@ -33,6 +34,10 @@ export function addNote(text?: string, options: { json?: boolean } = {}): void {
 
   const note = createNote(vaultRoot, config, typeName, title, content + '\n');
   const recommendations = recommendNote(vaultRoot, config, note, { strategy: 'incremental' });
+
+  // Transparent sync: track + push in background
+  const sync = getSyncManager(vaultRoot, config);
+  sync?.trackAndPush(note, 'create');
 
   if (options.json) {
     console.log(jsonSuccess({

--- a/src/commands/edit.ts
+++ b/src/commands/edit.ts
@@ -6,6 +6,7 @@ import { findNoteBySlug, readNote } from '../core/note.js';
 import { parseFrontmatter, serializeFrontmatter } from '../core/frontmatter.js';
 import { validateStatus, validateSource } from '../core/json-output.js';
 import { recommendNote, formatRecommendations } from '../core/recommendations.js';
+import { getSyncManager } from '../core/sync/manager.js';
 
 interface EditOptions {
   body?: string;
@@ -72,6 +73,11 @@ export function editCommand(slug: string, options: EditOptions): void {
     frontmatter.modified = new Date().toISOString();
     fs.writeFileSync(note.filepath, serializeFrontmatter(frontmatter, body), 'utf-8');
 
+    // Transparent sync: track + push in background
+    const sync = getSyncManager(vaultRoot, config);
+    const updatedForSync = readNote(note.filepath);
+    sync?.trackAndPush(updatedForSync, 'update');
+
     console.log(note.filepath);
     const recommendationStrategy = options.title !== undefined || options.alias !== undefined ? 'rebuild' : 'incremental';
     printRecommendations(vaultRoot, config, note.filepath, recommendationStrategy);
@@ -93,6 +99,12 @@ export function editCommand(slug: string, options: EditOptions): void {
       const { frontmatter, body } = parseFrontmatter(fs.readFileSync(note.filepath, 'utf-8'));
       frontmatter.modified = new Date().toISOString();
       fs.writeFileSync(note.filepath, serializeFrontmatter(frontmatter, body), 'utf-8');
+
+      // Transparent sync: track + push in background
+      const sync = getSyncManager(vaultRoot, config);
+      const updatedForSync = readNote(note.filepath);
+      sync?.trackAndPush(updatedForSync, 'update');
+
       console.log(`Updated: ${note.filepath}`);
       printRecommendations(vaultRoot, config, note.filepath, 'rebuild');
     }

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -5,6 +5,7 @@ import { createNote } from '../core/note.js';
 import { parseFrontmatter, serializeFrontmatter } from '../core/frontmatter.js';
 import { jsonSuccess, validateStatus, validateSource } from '../core/json-output.js';
 import { recommendNote, formatRecommendations } from '../core/recommendations.js';
+import { getSyncManager } from '../core/sync/manager.js';
 
 export function newNote(title: string, options: { type?: string; source?: string; status?: string; json?: boolean }): void {
   const vaultRoot = requireVaultRoot();
@@ -33,6 +34,10 @@ export function newNote(title: string, options: { type?: string; source?: string
 
   const lines = note.body.split('\n').length;
   const overLimit = typeConfig && typeConfig.line_limit && lines > typeConfig.line_limit;
+
+  // Transparent sync: track + push in background
+  const sync = getSyncManager(vaultRoot, config);
+  sync?.trackAndPush(note, 'create');
 
   if (options.json) {
     console.log(jsonSuccess({

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -1,0 +1,97 @@
+import { loadConfig } from '../core/config.js';
+import { requireVaultRoot } from '../core/vault.js';
+import { SyncManager } from '../core/sync/manager.js';
+import { listConflicts, clearResolvedConflicts } from '../core/sync/conflict.js';
+
+export async function syncCommand(options: { json?: boolean }): Promise<void> {
+  const vaultRoot = requireVaultRoot();
+  const config = loadConfig(vaultRoot);
+  const manager = new SyncManager(vaultRoot, config);
+
+  const result = await manager.sync();
+
+  if (options.json) {
+    console.log(JSON.stringify(result));
+    return;
+  }
+
+  console.log(`Sync complete: ${result.pushed} pushed, ${result.pulled} pulled`);
+  if (result.conflicts > 0) {
+    console.log(`  ${result.conflicts} conflict(s) resolved (backups in .granite/conflicts/)`);
+  }
+}
+
+export async function syncStatusCommand(options: { json?: boolean }): Promise<void> {
+  const vaultRoot = requireVaultRoot();
+  const config = loadConfig(vaultRoot);
+  const manager = new SyncManager(vaultRoot, config);
+
+  const status = manager.status();
+  const conflictFiles = manager.conflicts();
+
+  if (options.json) {
+    console.log(JSON.stringify({ ...status, conflicts: conflictFiles.length }));
+    return;
+  }
+
+  console.log(`Device:          ${status.device_name} (${status.device_id.slice(0, 8)}...)`);
+  console.log(`Last sync:       ${status.last_sync ?? 'never'}`);
+  console.log(`Pending changes: ${status.pending_changes}`);
+  console.log(`Server seq:      ${status.server_seq}`);
+  if (conflictFiles.length > 0) {
+    console.log(`Conflicts:       ${conflictFiles.length} file(s) in .granite/conflicts/`);
+  }
+}
+
+export async function syncDevicesCommand(options: { json?: boolean }): Promise<void> {
+  const vaultRoot = requireVaultRoot();
+  const config = loadConfig(vaultRoot);
+  const manager = new SyncManager(vaultRoot, config);
+
+  const devices = await manager.devices();
+
+  if (options.json) {
+    console.log(JSON.stringify(devices));
+    return;
+  }
+
+  if (devices.length === 0) {
+    console.log('No devices registered yet.');
+    return;
+  }
+
+  for (const d of devices) {
+    console.log(`  ${d.device_name} (${d.device_id.slice(0, 8)}...) — last seen ${d.last_seen}`);
+  }
+}
+
+export function syncConflictsCommand(options: { clear?: boolean; json?: boolean }): void {
+  const vaultRoot = requireVaultRoot();
+
+  if (options.clear) {
+    const cleared = clearResolvedConflicts(vaultRoot);
+    if (options.json) {
+      console.log(JSON.stringify({ cleared }));
+    } else {
+      console.log(`Cleared ${cleared} conflict file(s).`);
+    }
+    return;
+  }
+
+  const files = listConflicts(vaultRoot);
+
+  if (options.json) {
+    console.log(JSON.stringify({ conflicts: files }));
+    return;
+  }
+
+  if (files.length === 0) {
+    console.log('No conflicts.');
+    return;
+  }
+
+  console.log(`${files.length} conflict file(s):`);
+  for (const f of files) {
+    console.log(`  ${f}`);
+  }
+}

--- a/src/core/sync/changelog.ts
+++ b/src/core/sync/changelog.ts
@@ -1,0 +1,103 @@
+import Database from 'better-sqlite3';
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import type { ChangelogEntry, SyncOperation } from '../types.js';
+
+const SYNC_DB_FILE = 'sync.db';
+
+const SYNC_SCHEMA_SQL = `
+CREATE TABLE IF NOT EXISTS changelog (
+  seq         INTEGER PRIMARY KEY AUTOINCREMENT,
+  note_id     TEXT NOT NULL,
+  operation   TEXT NOT NULL,
+  timestamp   TEXT NOT NULL,
+  device_id   TEXT NOT NULL,
+  checksum    TEXT NOT NULL,
+  synced      INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_changelog_note_id ON changelog(note_id);
+CREATE INDEX IF NOT EXISTS idx_changelog_synced ON changelog(synced);
+
+CREATE TABLE IF NOT EXISTS sync_meta (
+  key   TEXT PRIMARY KEY,
+  value TEXT
+);
+`;
+
+function getSyncDbPath(vaultRoot: string): string {
+  const graniteDir = path.join(vaultRoot, '.granite');
+  fs.mkdirSync(graniteDir, { recursive: true });
+  return path.join(graniteDir, SYNC_DB_FILE);
+}
+
+export function openSyncDb(vaultRoot: string): Database.Database {
+  const dbPath = getSyncDbPath(vaultRoot);
+  const db = new Database(dbPath);
+  db.pragma('journal_mode = WAL');
+  db.exec(SYNC_SCHEMA_SQL);
+  return db;
+}
+
+export function computeChecksum(content: string): string {
+  return crypto.createHash('sha256').update(content, 'utf-8').digest('hex');
+}
+
+export function recordChange(
+  db: Database.Database,
+  noteId: string,
+  operation: SyncOperation,
+  deviceId: string,
+  fileContent: string,
+): ChangelogEntry {
+  const now = new Date().toISOString();
+  const checksum = computeChecksum(fileContent);
+
+  const stmt = db.prepare(`
+    INSERT INTO changelog (note_id, operation, timestamp, device_id, checksum, synced)
+    VALUES (?, ?, ?, ?, ?, 0)
+  `);
+  const result = stmt.run(noteId, operation, now, deviceId, checksum);
+
+  return {
+    seq: result.lastInsertRowid as number,
+    note_id: noteId,
+    operation,
+    timestamp: now,
+    device_id: deviceId,
+    checksum,
+    synced: false,
+  };
+}
+
+export function getPendingChanges(db: Database.Database): ChangelogEntry[] {
+  return db.prepare('SELECT * FROM changelog WHERE synced = 0 ORDER BY seq ASC').all() as ChangelogEntry[];
+}
+
+export function markChangesSynced(db: Database.Database, upToSeq: number): void {
+  db.prepare('UPDATE changelog SET synced = 1 WHERE seq <= ?').run(upToSeq);
+}
+
+export function getLastServerSeq(db: Database.Database): number {
+  const row = db.prepare("SELECT value FROM sync_meta WHERE key = 'last_server_seq'").get() as { value: string } | undefined;
+  return row ? Number(row.value) : 0;
+}
+
+export function setLastServerSeq(db: Database.Database, seq: number): void {
+  db.prepare("INSERT OR REPLACE INTO sync_meta (key, value) VALUES ('last_server_seq', ?)").run(String(seq));
+}
+
+export function getLastSyncTime(db: Database.Database): string | null {
+  const row = db.prepare("SELECT value FROM sync_meta WHERE key = 'last_sync'").get() as { value: string } | undefined;
+  return row?.value ?? null;
+}
+
+export function setLastSyncTime(db: Database.Database): void {
+  db.prepare("INSERT OR REPLACE INTO sync_meta (key, value) VALUES ('last_sync', ?)").run(new Date().toISOString());
+}
+
+export function getPendingCount(db: Database.Database): number {
+  const row = db.prepare('SELECT COUNT(*) as c FROM changelog WHERE synced = 0').get() as { c: number };
+  return row.c;
+}

--- a/src/core/sync/client.ts
+++ b/src/core/sync/client.ts
@@ -1,0 +1,82 @@
+import type { SyncPushPayload, SyncPullResponse, SyncChange, SyncConfig } from '../types.js';
+
+export class SyncClient {
+  private baseUrl: string;
+  private apiKey: string;
+  private timeoutMs: number;
+
+  constructor(config: SyncConfig, timeoutMs = 5000) {
+    this.baseUrl = config.server.replace(/\/$/, '');
+    this.apiKey = config.api_key;
+    this.timeoutMs = timeoutMs;
+  }
+
+  private async request<T>(method: string, endpoint: string, body?: unknown): Promise<T> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    try {
+      const response = await fetch(`${this.baseUrl}${endpoint}`, {
+        method,
+        headers: {
+          'Authorization': `Bearer ${this.apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: body ? JSON.stringify(body) : undefined,
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        const text = await response.text().catch(() => '');
+        throw new SyncApiError(response.status, text || response.statusText);
+      }
+
+      return await response.json() as T;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  async push(payload: SyncPushPayload): Promise<{ server_seq: number; accepted: number }> {
+    return this.request('POST', '/v1/sync/push', payload);
+  }
+
+  async pull(sinceSeq: number, deviceId: string): Promise<SyncPullResponse> {
+    return this.request('GET', `/v1/sync/pull?since_seq=${sinceSeq}&device_id=${deviceId}`);
+  }
+
+  async quickPull(sinceSeq: number, deviceId: string, timeoutMs = 200): Promise<SyncPullResponse | null> {
+    const oldTimeout = this.timeoutMs;
+    this.timeoutMs = timeoutMs;
+    try {
+      return await this.pull(sinceSeq, deviceId);
+    } catch {
+      return null;
+    } finally {
+      this.timeoutMs = oldTimeout;
+    }
+  }
+
+  async listDevices(): Promise<Array<{ device_id: string; device_name: string; last_seen: string }>> {
+    return this.request('GET', '/v1/sync/devices');
+  }
+
+  async ping(): Promise<boolean> {
+    try {
+      await this.request('GET', '/v1/sync/ping');
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
+export class SyncApiError extends Error {
+  constructor(
+    public statusCode: number,
+    public body: string,
+  ) {
+    super(`Sync API error ${statusCode}: ${body}`);
+    this.name = 'SyncApiError';
+  }
+}

--- a/src/core/sync/conflict.ts
+++ b/src/core/sync/conflict.ts
@@ -1,0 +1,105 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import type { Note, SyncChange, SyncConflict } from '../types.js';
+import { readNote } from '../note.js';
+import { serializeFrontmatter } from '../frontmatter.js';
+
+const CONFLICTS_DIR = '.granite/conflicts';
+
+function getConflictsDir(vaultRoot: string): string {
+  const dir = path.join(vaultRoot, CONFLICTS_DIR);
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+export function detectConflict(localNote: Note, remoteChange: SyncChange): boolean {
+  if (remoteChange.operation === 'delete') return false;
+  if (!remoteChange.frontmatter) return false;
+
+  const localModified = new Date(localNote.frontmatter.modified).getTime();
+  const remoteModified = new Date(remoteChange.frontmatter.modified).getTime();
+
+  // Both modified since last sync — conflict
+  return localModified !== remoteModified && remoteChange.checksum !== '';
+}
+
+export function resolveConflict(
+  vaultRoot: string,
+  localNote: Note,
+  remoteChange: SyncChange,
+  deviceId: string,
+): SyncConflict | null {
+  if (!remoteChange.frontmatter || remoteChange.body === undefined) return null;
+
+  const localModified = new Date(localNote.frontmatter.modified).getTime();
+  const remoteModified = new Date(remoteChange.frontmatter.modified).getTime();
+
+  // Last-Write-Wins: most recent timestamp wins
+  const remoteWins = remoteModified > localModified;
+
+  if (remoteWins) {
+    // Save local version as conflict backup
+    const conflictFile = saveConflictBackup(vaultRoot, localNote, deviceId);
+
+    return {
+      note_id: localNote.frontmatter.id,
+      local_modified: localNote.frontmatter.modified,
+      remote_modified: remoteChange.frontmatter.modified,
+      resolved: true,
+      conflict_file: conflictFile,
+    };
+  }
+
+  // Local wins — save remote version as conflict backup
+  const conflictFile = saveRemoteConflictBackup(vaultRoot, remoteChange);
+
+  return {
+    note_id: localNote.frontmatter.id,
+    local_modified: localNote.frontmatter.modified,
+    remote_modified: remoteChange.frontmatter.modified,
+    resolved: true,
+    conflict_file: conflictFile,
+  };
+}
+
+function saveConflictBackup(vaultRoot: string, note: Note, deviceId: string): string {
+  const conflictsDir = getConflictsDir(vaultRoot);
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const filename = `${note.frontmatter.id}_${deviceId}_${timestamp}.md`;
+  const filePath = path.join(conflictsDir, filename);
+
+  const content = serializeFrontmatter(note.frontmatter, note.body);
+  fs.writeFileSync(filePath, content, 'utf-8');
+
+  return filePath;
+}
+
+function saveRemoteConflictBackup(vaultRoot: string, change: SyncChange): string {
+  const conflictsDir = getConflictsDir(vaultRoot);
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const filename = `${change.note_id}_remote_${timestamp}.md`;
+  const filePath = path.join(conflictsDir, filename);
+
+  if (change.frontmatter && change.body !== undefined) {
+    const content = serializeFrontmatter(change.frontmatter, change.body);
+    fs.writeFileSync(filePath, content, 'utf-8');
+  }
+
+  return filePath;
+}
+
+export function listConflicts(vaultRoot: string): string[] {
+  const conflictsDir = path.join(vaultRoot, CONFLICTS_DIR);
+  if (!fs.existsSync(conflictsDir)) return [];
+  return fs.readdirSync(conflictsDir)
+    .filter((f: string) => f.endsWith('.md'))
+    .map((f: string) => path.join(conflictsDir, f));
+}
+
+export function clearResolvedConflicts(vaultRoot: string): number {
+  const files = listConflicts(vaultRoot);
+  for (const f of files) {
+    fs.unlinkSync(f);
+  }
+  return files.length;
+}

--- a/src/core/sync/device.ts
+++ b/src/core/sync/device.ts
@@ -1,0 +1,40 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { v4 as uuidv4 } from 'uuid';
+
+const DEVICE_FILE = 'device.json';
+
+interface DeviceInfo {
+  device_id: string;
+  device_name: string;
+  created: string;
+}
+
+function getDeviceFilePath(vaultRoot: string): string {
+  const graniteDir = path.join(vaultRoot, '.granite');
+  fs.mkdirSync(graniteDir, { recursive: true });
+  return path.join(graniteDir, DEVICE_FILE);
+}
+
+export function getOrCreateDeviceId(vaultRoot: string, deviceName?: string): DeviceInfo {
+  const filePath = getDeviceFilePath(vaultRoot);
+
+  if (fs.existsSync(filePath)) {
+    const raw = fs.readFileSync(filePath, 'utf-8');
+    return JSON.parse(raw) as DeviceInfo;
+  }
+
+  const info: DeviceInfo = {
+    device_id: uuidv4(),
+    device_name: deviceName || os.hostname(),
+    created: new Date().toISOString(),
+  };
+
+  fs.writeFileSync(filePath, JSON.stringify(info, null, 2), 'utf-8');
+  return info;
+}
+
+export function getDeviceId(vaultRoot: string): string {
+  return getOrCreateDeviceId(vaultRoot).device_id;
+}

--- a/src/core/sync/manager.ts
+++ b/src/core/sync/manager.ts
@@ -1,0 +1,296 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import type { GraniteConfig, Note, SyncChange, SyncConfig, SyncOperation, SyncStatus } from '../types.js';
+import { findNoteBySlug, listNotes, readNote } from '../note.js';
+import { parseFrontmatter, serializeFrontmatter } from '../frontmatter.js';
+import { SyncClient } from './client.js';
+import { getDeviceId, getOrCreateDeviceId } from './device.js';
+import {
+  computeChecksum,
+  getLastServerSeq,
+  getLastSyncTime,
+  getPendingChanges,
+  getPendingCount,
+  markChangesSynced,
+  openSyncDb,
+  recordChange,
+  setLastServerSeq,
+  setLastSyncTime,
+} from './changelog.js';
+import { detectConflict, listConflicts, resolveConflict } from './conflict.js';
+
+export class SyncManager {
+  private vaultRoot: string;
+  private config: GraniteConfig;
+  private syncConfig: SyncConfig;
+  private client: SyncClient;
+  private deviceId: string;
+
+  constructor(vaultRoot: string, config: GraniteConfig) {
+    if (!config.sync?.enabled) {
+      throw new Error('Sync is not enabled. Add a sync section to granite.yml.');
+    }
+    this.vaultRoot = vaultRoot;
+    this.config = config;
+    this.syncConfig = config.sync;
+    this.client = new SyncClient(this.syncConfig);
+    this.deviceId = getDeviceId(vaultRoot);
+  }
+
+  /**
+   * Track a local mutation and push it in the background (fire-and-forget).
+   * This is the hook called after every note create/update/delete.
+   */
+  trackAndPush(note: Note, operation: SyncOperation): void {
+    const db = openSyncDb(this.vaultRoot);
+    try {
+      const content = fs.existsSync(note.filepath)
+        ? fs.readFileSync(note.filepath, 'utf-8')
+        : '';
+      recordChange(db, note.frontmatter.id, operation, this.deviceId, content);
+    } finally {
+      db.close();
+    }
+
+    // Fire-and-forget push — don't block the CLI
+    this.push().catch(() => {
+      // Silently fail — will retry on next operation or manual sync
+    });
+  }
+
+  /**
+   * Push all pending local changes to the relay server.
+   */
+  async push(): Promise<{ pushed: number; server_seq: number }> {
+    const db = openSyncDb(this.vaultRoot);
+    try {
+      const pending = getPendingChanges(db);
+      if (pending.length === 0) {
+        return { pushed: 0, server_seq: getLastServerSeq(db) };
+      }
+
+      const changes: SyncChange[] = [];
+      for (const entry of pending) {
+        const note = this.findNoteById(entry.note_id);
+        changes.push({
+          note_id: entry.note_id,
+          operation: entry.operation as SyncOperation,
+          timestamp: entry.timestamp,
+          checksum: entry.checksum,
+          slug: note?.slug ?? '',
+          frontmatter: note?.frontmatter,
+          body: note?.body,
+        });
+      }
+
+      const lastSeq = getLastServerSeq(db);
+      const result = await this.client.push({
+        device_id: this.deviceId,
+        last_server_seq: lastSeq,
+        changes,
+      });
+
+      const maxSeq = Math.max(...pending.map(p => p.seq));
+      markChangesSynced(db, maxSeq);
+      setLastServerSeq(db, result.server_seq);
+      setLastSyncTime(db);
+
+      return { pushed: result.accepted, server_seq: result.server_seq };
+    } finally {
+      db.close();
+    }
+  }
+
+  /**
+   * Pull remote changes and apply them locally.
+   */
+  async pull(): Promise<{ applied: number; conflicts: number }> {
+    const db = openSyncDb(this.vaultRoot);
+    try {
+      const lastSeq = getLastServerSeq(db);
+      const response = await this.client.pull(lastSeq, this.deviceId);
+
+      let applied = 0;
+      let conflicts = 0;
+
+      for (const change of response.changes) {
+        const result = this.applyRemoteChange(change);
+        if (result === 'applied') applied++;
+        if (result === 'conflict') conflicts++;
+      }
+
+      setLastServerSeq(db, response.server_seq);
+      setLastSyncTime(db);
+
+      return { applied, conflicts };
+    } finally {
+      db.close();
+    }
+  }
+
+  /**
+   * Quick pull with a tight timeout — used before read commands.
+   * Returns silently if server is unreachable.
+   */
+  async quickPull(): Promise<void> {
+    const db = openSyncDb(this.vaultRoot);
+    try {
+      const lastSeq = getLastServerSeq(db);
+      const response = await this.client.quickPull(lastSeq, this.deviceId);
+      if (!response) return;
+
+      for (const change of response.changes) {
+        this.applyRemoteChange(change);
+      }
+
+      setLastServerSeq(db, response.server_seq);
+      setLastSyncTime(db);
+    } finally {
+      db.close();
+    }
+  }
+
+  /**
+   * Full bidirectional sync: push then pull.
+   */
+  async sync(): Promise<{ pushed: number; pulled: number; conflicts: number }> {
+    const pushResult = await this.push();
+    const pullResult = await this.pull();
+    return {
+      pushed: pushResult.pushed,
+      pulled: pullResult.applied,
+      conflicts: pullResult.conflicts,
+    };
+  }
+
+  /**
+   * Get current sync status.
+   */
+  status(): SyncStatus {
+    const db = openSyncDb(this.vaultRoot);
+    try {
+      const deviceInfo = getOrCreateDeviceId(this.vaultRoot);
+      return {
+        device_id: deviceInfo.device_id,
+        device_name: deviceInfo.device_name,
+        last_sync: getLastSyncTime(db),
+        pending_changes: getPendingCount(db),
+        server_seq: getLastServerSeq(db),
+      };
+    } finally {
+      db.close();
+    }
+  }
+
+  /**
+   * List connected devices.
+   */
+  async devices(): Promise<Array<{ device_id: string; device_name: string; last_seen: string }>> {
+    return this.client.listDevices();
+  }
+
+  /**
+   * List unresolved conflict files.
+   */
+  conflicts(): string[] {
+    return listConflicts(this.vaultRoot);
+  }
+
+  private applyRemoteChange(change: SyncChange): 'applied' | 'conflict' | 'skipped' {
+    switch (change.operation) {
+      case 'create':
+        return this.applyRemoteCreate(change);
+      case 'update':
+        return this.applyRemoteUpdate(change);
+      case 'delete':
+        return this.applyRemoteDelete(change);
+      default:
+        return 'skipped';
+    }
+  }
+
+  private applyRemoteCreate(change: SyncChange): 'applied' | 'skipped' {
+    if (!change.frontmatter || change.body === undefined) return 'skipped';
+
+    // Check if note already exists locally (by id)
+    const existing = this.findNoteById(change.note_id);
+    if (existing) return 'skipped'; // Already have it
+
+    const typeConfig = this.config.note_types[change.frontmatter.type];
+    if (!typeConfig) return 'skipped';
+
+    const folder = path.join(this.vaultRoot, typeConfig.folder);
+    fs.mkdirSync(folder, { recursive: true });
+
+    const slug = change.slug || change.note_id;
+    const filepath = path.join(folder, `${slug}.md`);
+    const content = serializeFrontmatter(change.frontmatter, change.body);
+    fs.writeFileSync(filepath, content, 'utf-8');
+
+    return 'applied';
+  }
+
+  private applyRemoteUpdate(change: SyncChange): 'applied' | 'conflict' | 'skipped' {
+    if (!change.frontmatter || change.body === undefined) return 'skipped';
+
+    const localNote = this.findNoteById(change.note_id);
+    if (!localNote) {
+      // Note doesn't exist locally — treat as create
+      return this.applyRemoteCreate(change);
+    }
+
+    // Check for conflict
+    const localContent = fs.readFileSync(localNote.filepath, 'utf-8');
+    const localChecksum = computeChecksum(localContent);
+
+    if (localChecksum === change.checksum) return 'skipped'; // Already identical
+
+    if (detectConflict(localNote, change)) {
+      resolveConflict(this.vaultRoot, localNote, change, this.deviceId);
+
+      // LWW: apply whichever is newer
+      const localTime = new Date(localNote.frontmatter.modified).getTime();
+      const remoteTime = new Date(change.frontmatter.modified).getTime();
+
+      if (remoteTime > localTime) {
+        const content = serializeFrontmatter(change.frontmatter, change.body);
+        fs.writeFileSync(localNote.filepath, content, 'utf-8');
+      }
+
+      return 'conflict';
+    }
+
+    // No conflict — apply remote
+    const content = serializeFrontmatter(change.frontmatter, change.body);
+    fs.writeFileSync(localNote.filepath, content, 'utf-8');
+    return 'applied';
+  }
+
+  private applyRemoteDelete(change: SyncChange): 'applied' | 'skipped' {
+    const localNote = this.findNoteById(change.note_id);
+    if (!localNote) return 'skipped';
+
+    if (fs.existsSync(localNote.filepath)) {
+      fs.unlinkSync(localNote.filepath);
+    }
+    return 'applied';
+  }
+
+  private findNoteById(noteId: string): Note | null {
+    const allNotes = listNotes(this.vaultRoot, this.config);
+    return allNotes.find(n => n.frontmatter.id === noteId) ?? null;
+  }
+}
+
+/**
+ * Create a SyncManager if sync is enabled, otherwise return null.
+ * This is the safe entry point used by the transparent hooks.
+ */
+export function getSyncManager(vaultRoot: string, config: GraniteConfig): SyncManager | null {
+  if (!config.sync?.enabled) return null;
+  try {
+    return new SyncManager(vaultRoot, config);
+  } catch {
+    return null;
+  }
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -18,6 +18,15 @@ export interface FieldDefinition {
   description?: string;
 }
 
+export interface SyncConfig {
+  enabled: boolean;
+  server: string;
+  api_key: string;
+  device_name: string;
+  auto_sync: boolean;
+  interval: number;
+}
+
 export interface GraniteConfig {
   vault_name: string;
   version: number;
@@ -29,6 +38,7 @@ export interface GraniteConfig {
   index: {
     auto_rebuild: boolean;
   };
+  sync?: SyncConfig;
 }
 
 export interface NoteFrontmatter {
@@ -77,4 +87,55 @@ export interface DoctorIssue {
   level: 'error' | 'warning' | 'info';
   file: string;
   message: string;
+}
+
+// --- Sync types ---
+
+export type SyncOperation = 'create' | 'update' | 'delete' | 'rename';
+
+export interface ChangelogEntry {
+  seq: number;
+  note_id: string;
+  operation: SyncOperation;
+  timestamp: string;
+  device_id: string;
+  checksum: string;
+  synced: boolean;
+}
+
+export interface SyncPushPayload {
+  device_id: string;
+  last_server_seq: number;
+  changes: SyncChange[];
+}
+
+export interface SyncChange {
+  note_id: string;
+  operation: SyncOperation;
+  timestamp: string;
+  checksum: string;
+  slug: string;
+  frontmatter?: NoteFrontmatter;
+  body?: string;
+}
+
+export interface SyncPullResponse {
+  changes: SyncChange[];
+  server_seq: number;
+}
+
+export interface SyncStatus {
+  device_id: string;
+  device_name: string;
+  last_sync: string | null;
+  pending_changes: number;
+  server_seq: number;
+}
+
+export interface SyncConflict {
+  note_id: string;
+  local_modified: string;
+  remote_modified: string;
+  resolved: boolean;
+  conflict_file: string;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import { typesCommand } from './commands/types.js';
 import { listCommand } from './commands/list.js';
 import { editCommand } from './commands/edit.js';
 import { mcpCommand, parseTransport } from './commands/mcp.js';
+import { syncCommand, syncStatusCommand, syncDevicesCommand, syncConflictsCommand } from './commands/sync.js';
 import { GRANITE_VERSION } from './version.js';
 
 const program = new Command();
@@ -174,6 +175,39 @@ program
     jsonResponse?: boolean;
   }) => {
     await mcpCommand(options);
+  });
+
+const syncCmd = program
+  .command('sync')
+  .description('Sync vault across devices')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { json?: boolean }) => {
+    await syncCommand(options);
+  });
+
+syncCmd
+  .command('status')
+  .description('Show sync status')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { json?: boolean }) => {
+    await syncStatusCommand(options);
+  });
+
+syncCmd
+  .command('devices')
+  .description('List connected devices')
+  .option('--json', 'Output as JSON')
+  .action(async (options: { json?: boolean }) => {
+    await syncDevicesCommand(options);
+  });
+
+syncCmd
+  .command('conflicts')
+  .description('List or clear conflict files')
+  .option('--clear', 'Remove all conflict backup files')
+  .option('--json', 'Output as JSON')
+  .action((options: { clear?: boolean; json?: boolean }) => {
+    syncConflictsCommand(options);
   });
 
 await program.parseAsync();

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -5,10 +5,11 @@ import path from 'node:path';
 import fs from 'node:fs';
 import type { GraniteConfig } from '../core/types.js';
 import { ensureIndex } from '../core/index-db.js';
-import { createNote, findNoteBySlug, listNotes } from '../core/note.js';
+import { createNote, findNoteBySlug, listNotes, readNote } from '../core/note.js';
 import { searchNotes } from '../core/search.js';
 import { getBacklinks } from '../core/backlinks.js';
 import { parseWikilinks, resolveWikilinks } from '../core/wikilinks.js';
+import { getSyncManager } from '../core/sync/manager.js';
 
 export function createApp(vaultRoot: string, config: GraniteConfig) {
   const app = new Hono();
@@ -93,6 +94,11 @@ export function createApp(vaultRoot: string, config: GraniteConfig) {
 
     try {
       const note = createNote(vaultRoot, config, type, title, noteBody || undefined);
+
+      // Transparent sync
+      const sync = getSyncManager(vaultRoot, config);
+      sync?.trackAndPush(note, 'create');
+
       return c.json({
         slug: note.slug,
         title: note.frontmatter.title,

--- a/test/core/sync.test.ts
+++ b/test/core/sync.test.ts
@@ -1,0 +1,308 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createNote, readNote, listNotes } from '../../src/core/note.js';
+import { writeDefaultConfig, loadConfig } from '../../src/core/config.js';
+import { serializeFrontmatter } from '../../src/core/frontmatter.js';
+import type { GraniteConfig, SyncChange } from '../../src/core/types.js';
+import { getOrCreateDeviceId, getDeviceId } from '../../src/core/sync/device.js';
+import {
+  openSyncDb,
+  recordChange,
+  getPendingChanges,
+  markChangesSynced,
+  computeChecksum,
+  getLastServerSeq,
+  setLastServerSeq,
+  getPendingCount,
+} from '../../src/core/sync/changelog.js';
+import { detectConflict, listConflicts, resolveConflict, clearResolvedConflicts } from '../../src/core/sync/conflict.js';
+import { getSyncManager } from '../../src/core/sync/manager.js';
+
+describe('sync/device', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'granite-sync-'));
+    fs.mkdirSync(path.join(tmpDir, '.granite'), { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('creates a device ID on first call and persists it', () => {
+    const info = getOrCreateDeviceId(tmpDir);
+    expect(info.device_id).toBeTruthy();
+    expect(info.device_name).toBeTruthy();
+    expect(info.created).toBeTruthy();
+
+    // Second call returns same ID
+    const info2 = getOrCreateDeviceId(tmpDir);
+    expect(info2.device_id).toBe(info.device_id);
+  });
+
+  it('getDeviceId returns the same id', () => {
+    const id1 = getDeviceId(tmpDir);
+    const id2 = getDeviceId(tmpDir);
+    expect(id1).toBe(id2);
+  });
+
+  it('respects custom device name', () => {
+    const info = getOrCreateDeviceId(tmpDir, 'my-laptop');
+    expect(info.device_name).toBe('my-laptop');
+  });
+});
+
+describe('sync/changelog', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'granite-sync-'));
+    fs.mkdirSync(path.join(tmpDir, '.granite'), { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('records a change and retrieves it as pending', () => {
+    const db = openSyncDb(tmpDir);
+    try {
+      const entry = recordChange(db, 'note-uuid-1', 'create', 'device-1', 'some content');
+      expect(entry.note_id).toBe('note-uuid-1');
+      expect(entry.operation).toBe('create');
+      expect(entry.synced).toBe(false);
+
+      const pending = getPendingChanges(db);
+      expect(pending).toHaveLength(1);
+      expect(pending[0].note_id).toBe('note-uuid-1');
+    } finally {
+      db.close();
+    }
+  });
+
+  it('marks changes as synced', () => {
+    const db = openSyncDb(tmpDir);
+    try {
+      const e1 = recordChange(db, 'note-1', 'create', 'device-1', 'content 1');
+      const e2 = recordChange(db, 'note-2', 'create', 'device-1', 'content 2');
+
+      markChangesSynced(db, e1.seq);
+
+      const pending = getPendingChanges(db);
+      expect(pending).toHaveLength(1);
+      expect(pending[0].note_id).toBe('note-2');
+    } finally {
+      db.close();
+    }
+  });
+
+  it('computes consistent checksums', () => {
+    const c1 = computeChecksum('hello world');
+    const c2 = computeChecksum('hello world');
+    const c3 = computeChecksum('different');
+
+    expect(c1).toBe(c2);
+    expect(c1).not.toBe(c3);
+    expect(c1).toHaveLength(64); // SHA-256 hex
+  });
+
+  it('tracks server seq', () => {
+    const db = openSyncDb(tmpDir);
+    try {
+      expect(getLastServerSeq(db)).toBe(0);
+      setLastServerSeq(db, 42);
+      expect(getLastServerSeq(db)).toBe(42);
+    } finally {
+      db.close();
+    }
+  });
+
+  it('counts pending changes', () => {
+    const db = openSyncDb(tmpDir);
+    try {
+      expect(getPendingCount(db)).toBe(0);
+      recordChange(db, 'note-1', 'create', 'device-1', 'c1');
+      recordChange(db, 'note-2', 'update', 'device-1', 'c2');
+      expect(getPendingCount(db)).toBe(2);
+    } finally {
+      db.close();
+    }
+  });
+});
+
+describe('sync/conflict', () => {
+  let tmpDir: string;
+  let config: GraniteConfig;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'granite-sync-'));
+    writeDefaultConfig(tmpDir);
+    config = loadConfig(tmpDir);
+    for (const tc of Object.values(config.note_types)) {
+      fs.mkdirSync(path.join(tmpDir, tc.folder), { recursive: true });
+    }
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('detects a conflict when both local and remote are modified', () => {
+    const note = createNote(tmpDir, config, 'permanent', 'Conflict Test');
+    const remoteChange: SyncChange = {
+      note_id: note.frontmatter.id,
+      operation: 'update',
+      timestamp: new Date().toISOString(),
+      checksum: 'different-checksum',
+      slug: note.slug,
+      frontmatter: {
+        ...note.frontmatter,
+        modified: new Date(Date.now() + 60000).toISOString(), // 1 min later
+      },
+      body: 'Remote body content',
+    };
+
+    expect(detectConflict(note, remoteChange)).toBe(true);
+  });
+
+  it('does not detect conflict for delete operations', () => {
+    const note = createNote(tmpDir, config, 'permanent', 'Delete Test');
+    const remoteChange: SyncChange = {
+      note_id: note.frontmatter.id,
+      operation: 'delete',
+      timestamp: new Date().toISOString(),
+      checksum: '',
+      slug: note.slug,
+    };
+
+    expect(detectConflict(note, remoteChange)).toBe(false);
+  });
+
+  it('resolves conflict with LWW and saves backup', () => {
+    const note = createNote(tmpDir, config, 'permanent', 'LWW Test');
+    const remoteChange: SyncChange = {
+      note_id: note.frontmatter.id,
+      operation: 'update',
+      timestamp: new Date().toISOString(),
+      checksum: 'remote-checksum',
+      slug: note.slug,
+      frontmatter: {
+        ...note.frontmatter,
+        modified: new Date(Date.now() + 60000).toISOString(),
+      },
+      body: 'Remote wins body',
+    };
+
+    const conflict = resolveConflict(tmpDir, note, remoteChange, 'device-1');
+    expect(conflict).not.toBeNull();
+    expect(conflict!.resolved).toBe(true);
+    expect(fs.existsSync(conflict!.conflict_file)).toBe(true);
+  });
+
+  it('lists and clears conflicts', () => {
+    // Create a conflict file manually
+    const conflictsDir = path.join(tmpDir, '.granite', 'conflicts');
+    fs.mkdirSync(conflictsDir, { recursive: true });
+    fs.writeFileSync(path.join(conflictsDir, 'test_conflict.md'), 'backup content');
+
+    const files = listConflicts(tmpDir);
+    expect(files).toHaveLength(1);
+
+    const cleared = clearResolvedConflicts(tmpDir);
+    expect(cleared).toBe(1);
+
+    expect(listConflicts(tmpDir)).toHaveLength(0);
+  });
+});
+
+describe('sync/manager', () => {
+  let tmpDir: string;
+  let config: GraniteConfig;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'granite-sync-'));
+    writeDefaultConfig(tmpDir);
+    config = loadConfig(tmpDir);
+    for (const tc of Object.values(config.note_types)) {
+      fs.mkdirSync(path.join(tmpDir, tc.folder), { recursive: true });
+    }
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('getSyncManager returns null when sync is disabled', () => {
+    const manager = getSyncManager(tmpDir, config);
+    expect(manager).toBeNull();
+  });
+
+  it('getSyncManager returns manager when sync is enabled', () => {
+    const syncConfig: GraniteConfig = {
+      ...config,
+      sync: {
+        enabled: true,
+        server: 'https://sync.example.com',
+        api_key: 'test-key',
+        device_name: 'test-device',
+        auto_sync: true,
+        interval: 30,
+      },
+    };
+    const manager = getSyncManager(tmpDir, syncConfig);
+    expect(manager).not.toBeNull();
+  });
+
+  it('trackAndPush records change in changelog without throwing', () => {
+    const syncConfig: GraniteConfig = {
+      ...config,
+      sync: {
+        enabled: true,
+        server: 'https://sync.example.com',
+        api_key: 'test-key',
+        device_name: 'test-device',
+        auto_sync: true,
+        interval: 30,
+      },
+    };
+    const manager = getSyncManager(tmpDir, syncConfig)!;
+    const note = createNote(tmpDir, config, 'permanent', 'Sync Track Test');
+
+    // Should not throw even though server is unreachable
+    expect(() => manager.trackAndPush(note, 'create')).not.toThrow();
+
+    // Verify it was recorded in the changelog
+    const db = openSyncDb(tmpDir);
+    try {
+      const pending = getPendingChanges(db);
+      expect(pending).toHaveLength(1);
+      expect(pending[0].note_id).toBe(note.frontmatter.id);
+      expect(pending[0].operation).toBe('create');
+    } finally {
+      db.close();
+    }
+  });
+
+  it('status returns device info and pending count', () => {
+    const syncConfig: GraniteConfig = {
+      ...config,
+      sync: {
+        enabled: true,
+        server: 'https://sync.example.com',
+        api_key: 'test-key',
+        device_name: 'test-device',
+        auto_sync: true,
+        interval: 30,
+      },
+    };
+    const manager = getSyncManager(tmpDir, syncConfig)!;
+    const status = manager.status();
+
+    expect(status.device_id).toBeTruthy();
+    expect(status.pending_changes).toBe(0);
+    expect(status.last_sync).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- **Local sync system** — transparent multi-device sync that hooks into `mem new`, `mem add`, `mem edit`, and the web API. Fire-and-forget push with local changelog tracking in `.granite/sync.db`, device ID management, and Last-Write-Wins conflict resolution with backup files.
- **Granite Cloud Worker** (`packages/worker/`) — Cloudflare Worker (D1 + R2) providing a full serverless backend: remote MCP server with 10 tools, sync relay endpoints, and vault storage. FTS5 search works unchanged since D1 is SQLite.
- **GitHub OAuth + API keys** — `gsk_` prefixed keys with SHA-256 hashing, CLI polling flow (`/auth/github` → `/auth/callback` → `/auth/poll`), revocable keys with safe prefix display.
- **Stripe billing** — lightweight REST client (no SDK), checkout/portal/webhooks, `free`/`pro` tiers with vault and rate limits.
- **Multi-vault support** — users own vaults, vault resolution middleware, tier-based limits (free: 1 vault/100 notes, pro: 10 vaults/10K notes).
- **Rate limiting** — D1-based per-hour rate limiting on sync push, with hourly cron cleanup.
- **Accessibility** — all HTML pages have viewport meta, `lang` attr, dark mode, semantic landmarks.

## Architecture

```
src/core/sync/          → Local sync (device, changelog, client, conflict, manager)
src/commands/sync.ts    → CLI: mem sync, mem sync status, mem sync devices, mem sync conflicts
packages/worker/        → Granite Cloud (Cloudflare Worker)
├── src/routes/         → auth, keys, billing, user
├── src/handlers/       → MCP, sync relay
├── src/middleware/      → auth, vault resolution, rate limiting
├── src/storage/        → R2 (notes), D1 (index + FTS5)
├── src/lib/            → api-key, stripe, rate-limit, json
└── src/cron/           → cleanup (sessions, rate limits, old changelog)
```

## Test plan

- [x] All 96 existing tests pass
- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] Worker builds successfully (`wrangler deploy --dry-run` → 195KB gzipped)
- [ ] Test OAuth flow end-to-end with `wrangler dev` + GitHub OAuth app
- [ ] Test sync push/pull between two devices
- [ ] Test Stripe checkout webhook flow
- [ ] Test MCP endpoint with Claude Desktop

https://claude.ai/code/session_011j7adtKZPz4VyBpDTPjxzT

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it adds new auth/billing/webhook handling, storage/FTS indexing, and sync state mutation across both server (D1/R2) and client (local SQLite), which can impact data integrity and access control if incorrect.
> 
> **Overview**
> Adds a new `packages/worker/` Cloudflare Worker providing the Granite Cloud backend: GitHub OAuth login with `gsk_` API keys, user/vault management, Pro-tier gating, Stripe checkout/portal + webhook-driven tier updates, and scheduled cleanup.
> 
> Implements sync + indexing services in the worker using D1 (notes index, FTS, links/backlinks, devices, changelog, rate limits) and R2 (note/config storage), including per-vault storage accounting/limits, rate-limited `POST /v1/sync/push`, and `pull/devices` endpoints.
> 
> Adds a local multi-device sync client that records note mutations to `.granite/sync.db`, introduces `mem sync` commands, and hooks `mem new`/`mem add`/`mem edit` to fire-and-forget `trackAndPush` so changes are pushed automatically.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31d379225f806ad26f5c84a9c1e7a7bdac7e7a5b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds transparent multi-device sync to the CLI and web, plus a new `Granite Cloud` Worker (`Cloudflare D1 + R2`) for sync relay, remote MCP, auth, billing, and multi-vault. Adds storage-based pricing with Pro-only sync/MCP and a 1 GB per-vault cap enforced on push and MCP, with live usage returned by `/me`.

- **New Features**
  - Local sync: hooks into mem new/add/edit and web API; tracks changes in `.granite/sync.db`; per-device IDs; LWW conflicts with backups in `.granite/conflicts/`.
  - CLI: `mem sync`, `mem sync status`, `mem sync devices`, `mem sync conflicts`.
  - `packages/worker`: Cloudflare Worker (D1 + R2) with sync push/pull/devices, remote MCP via `@modelcontextprotocol/sdk`, FTS5 search, and vault storage; rate limiting; Pro-only gate for sync/MCP.
  - Auth & billing: GitHub OAuth, `gsk_` API keys (SHA-256 hashed, max 10 per user with oldest auto-revoked), Stripe free/pro tiers; storage-based pricing (Pro: 1 GB, 10 vaults, 300 ops/hour); track `storage_bytes` per vault and enforce limits; `/me` returns usage and limits.
  - Platform polish and hardening: standardized ISO timestamps; shared folder resolution; normalize tags/aliases; batched wikilink indexing with preload and delete handling; per-vault note limits; composite PKs; HMAC-signed OAuth state with timing-safe compare; stricter auth/rate-limit order; require `device_id` on pull; accessibility and dark mode fixes; accurate storage accounting by reading actual R2 content on update/delete.

- **Migration**
  - Deploy the Worker: run D1 schema (`wrangler d1 execute --file=schema.sql`), bind R2/D1, set `BASE_URL`, GitHub, and Stripe secrets, then `wrangler deploy`.
  - Get an API key via the `/auth/github` flow and put it in your config; enable sync in `granite.yml` (requires Pro).
  - Optionally run `mem sync` once; afterward, pushes happen automatically in the background.

<sup>Written for commit 31d379225f806ad26f5c84a9c1e7a7bdac7e7a5b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

