### PR TITLE
feat: rename installed cli to granite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance to Codex (Codex.ai/code) when working with code in t
 
 ## What is Granite?
 
-Granite (`mem` CLI) is a local-first markdown memory system for humans and agents. Notes are plain markdown files with YAML frontmatter, organized by configurable note types (fleeting, permanent, reference, person, meeting, project, decision). Configuration lives in `granite.yml` at the vault root. A SQLite index (`.granite/index.db`) provides full-text search and wikilink resolution.
+Granite (`granite` CLI) is a local-first markdown memory system for humans and agents. Notes are plain markdown files with YAML frontmatter, organized by configurable note types (fleeting, permanent, reference, person, meeting, project, decision). Configuration lives in `granite.yml` at the vault root. A SQLite index (`.granite/index.db`) provides full-text search and wikilink resolution.
 
 ## Commands
 
@@ -36,7 +36,7 @@ npx tsx src/index.ts <command>
   - `slugify.ts` — Title-to-slug conversion
   - `search.ts`, `backlinks.ts`, `suggest.ts`, `doctor.ts` — Query/validation logic
 - **`src/commands/`** — Thin CLI wrappers that call into `src/core/`
-- **`src/web/`** — Hono-based local web UI served by `mem serve`
+- **`src/web/`** — Hono-based local web UI served by `granite serve`
 
 ## Key Patterns
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What is Granite?
 
-Granite (`mem` CLI) is a local-first markdown memory system for humans and agents. Notes are plain markdown files with YAML frontmatter, organized by configurable note types (fleeting, permanent, reference, person, meeting, project, decision). Configuration lives in `granite.yml` at the vault root. A SQLite index (`.granite/index.db`) provides full-text search and wikilink resolution.
+Granite (`granite` CLI) is a local-first markdown memory system for humans and agents. Notes are plain markdown files with YAML frontmatter, organized by configurable note types (fleeting, permanent, reference, person, meeting, project, decision). Configuration lives in `granite.yml` at the vault root. A SQLite index (`.granite/index.db`) provides full-text search and wikilink resolution.
 
 ## Commands
 
@@ -36,7 +36,7 @@ npx tsx src/index.ts <command>
   - `slugify.ts` — Title-to-slug conversion
   - `search.ts`, `backlinks.ts`, `suggest.ts`, `doctor.ts` — Query/validation logic
 - **`src/commands/`** — Thin CLI wrappers that call into `src/core/`
-- **`src/web/`** — Hono-based local web UI served by `mem serve`
+- **`src/web/`** — Hono-based local web UI served by `granite serve`
 
 ## Key Patterns
 

--- a/README.md
+++ b/README.md
@@ -81,48 +81,48 @@ npm link
 Create the default vault in `~/.granite` and start capturing:
 
 ```bash
-mem init
-mem add "Talked to Alice about local-first sync tradeoffs"
-mem new "Local-first sync tradeoffs" --type permanent
-mem list
-mem search "sync"
+granite init
+granite add "Talked to Alice about local-first sync tradeoffs"
+granite new "Local-first sync tradeoffs" --type permanent
+granite list
+granite search "sync"
 ```
 
 Start one long-running interface when you need it:
 
 ```bash
-mem serve   # local web UI
-mem mcp     # MCP server for agent clients
+granite serve   # local web UI
+granite mcp     # MCP server for agent clients
 ```
 
-`mem new` does more than create a file. It can immediately suggest related links, tags, and the next note to create, which is the core of Granite's value loop.
+`granite new` does more than create a file. It can immediately suggest related links, tags, and the next note to create, which is the core of Granite's value loop.
 
 ## Example Workflow
 
 Capture something quickly:
 
 ```bash
-mem add "Users want fewer note types, but stronger defaults."
+granite add "Users want fewer note types, but stronger defaults."
 ```
 
 Turn it into a durable note:
 
 ```bash
-mem new "Strong defaults beat infinite flexibility" --type permanent
+granite new "Strong defaults beat infinite flexibility" --type permanent
 ```
 
 Find connections:
 
 ```bash
-mem suggest-links strong-defaults-beat-infinite-flexibility
-mem recommend strong-defaults-beat-infinite-flexibility
-mem backlinks strong-defaults-beat-infinite-flexibility
+granite suggest-links strong-defaults-beat-infinite-flexibility
+granite recommend strong-defaults-beat-infinite-flexibility
+granite backlinks strong-defaults-beat-infinite-flexibility
 ```
 
 Open the local UI:
 
 ```bash
-mem serve
+granite serve
 ```
 
 Then browse notes, search the vault, inspect backlinks, and explore the graph locally.
@@ -172,12 +172,12 @@ This keeps the system transparent, portable, and inspectable.
 Many commands support JSON output:
 
 ```bash
-mem new "Sync constraints" --type permanent --json
-mem list --json
-mem show sync-constraints --json
-mem search "constraints" --json
-mem backlinks sync-constraints --json
-mem recommend sync-constraints --json
+granite new "Sync constraints" --type permanent --json
+granite list --json
+granite show sync-constraints --json
+granite search "constraints" --json
+granite backlinks sync-constraints --json
+granite recommend sync-constraints --json
 ```
 
 That makes Granite a useful substrate for local workflows, scripts, and agent memory.
@@ -189,13 +189,13 @@ Granite ships with an MCP server so LLM clients can control the vault directly t
 Start it over stdio for local MCP clients:
 
 ```bash
-mem mcp --vault /path/to/vault
+granite mcp --vault /path/to/vault
 ```
 
 Start it over Streamable HTTP:
 
 ```bash
-mem mcp --transport http --host 127.0.0.1 --port 3321
+granite mcp --transport http --host 127.0.0.1 --port 3321
 ```
 
 The server exposes:
@@ -208,7 +208,7 @@ Example stdio client configuration:
 
 ```json
 {
-  "command": "mem",
+  "command": "granite",
   "args": ["mcp", "--vault", "/path/to/vault"]
 }
 ```
@@ -216,21 +216,21 @@ Example stdio client configuration:
 ## Commands
 
 ```bash
-mem init
-mem new <title> [--type <type>] [--json]
-mem add [text] [--json]
-mem list [--type <type>] [--json]
-mem edit <slug>
-mem open <slug>
-mem show <slug> [--json] [--body]
-mem search <query> [--json]
-mem backlinks <slug> [--json]
-mem suggest-links <slug> [--json]
-mem recommend <slug> [--json]
-mem types
-mem doctor
-mem serve [-p <port>]
-mem mcp [--vault <path>] [--transport <stdio|http>]
+granite init
+granite new <title> [--type <type>] [--json]
+granite add [text] [--json]
+granite list [--type <type>] [--json]
+granite edit <slug>
+granite open <slug>
+granite show <slug> [--json] [--body]
+granite search <query> [--json]
+granite backlinks <slug> [--json]
+granite suggest-links <slug> [--json]
+granite recommend <slug> [--json]
+granite types
+granite doctor
+granite serve [-p <port>]
+granite mcp [--vault <path>] [--transport <stdio|http>]
 ```
 
 ## Development

--- a/docs/GRANITE_OBJECT_STANDARD.md
+++ b/docs/GRANITE_OBJECT_STANDARD.md
@@ -165,8 +165,8 @@ are **structured, queryable, and carry semantic meaning**:
 - `attendees` links are of type "person attended meeting"
 - `project` links are of type "meeting about project"
 
-This enables queries like: `mem search --field attendees:jane-smith` or
-`mem list --type meeting --field project:project-granite`.
+This enables queries like: `granite search --field attendees:jane-smith` or
+`granite list --type meeting --field project:project-granite`.
 
 ---
 
@@ -209,23 +209,23 @@ Piped / --json      →  structured JSON with envelope
 ### 3.3 Field selection (gh CLI pattern)
 
 ```bash
-mem list --json slug,title,type,tags
-mem show note-slug --json title,body,backlinks
-mem search "query" --json slug,title,score
+granite list --json slug,title,type,tags
+granite show note-slug --json title,body,backlinks
+granite search "query" --json slug,title,score
 ```
 
 `--json` without field names = list available fields (self-documenting):
 ```
-$ mem list --json
+$ granite list --json
 Available fields: slug, title, type, created, modified, tags, aliases, status, source, filepath
 ```
 
 ### 3.4 Structured filtering
 
 ```bash
-mem list --type meeting --tag project-x --status active --since 2026-03-01
-mem list --field attendees:jane-smith          # Type-specific field query
-mem search "api design" --type decision        # Full-text + type filter
+granite list --type meeting --tag project-x --status active --since 2026-03-01
+granite list --field attendees:jane-smith          # Type-specific field query
+granite search "api design" --type decision        # Full-text + type filter
 ```
 
 ### 3.5 Exit codes
@@ -240,7 +240,7 @@ mem search "api design" --type decision        # Full-text + type filter
 ### 3.6 NDJSON streaming (for large vaults)
 
 ```bash
-mem list --format ndjson
+granite list --format ndjson
 ```
 ```jsonl
 {"slug":"note-1","title":"First","type":"fleeting","status":"inbox"}
@@ -269,8 +269,8 @@ Every agent interaction with the vault follows this pattern:
 
 **Step 2 — Compare:** Search the vault for existing notes about the same entities.
 ```bash
-mem search "Jane Smith" --json slug,title,type
-mem list --type person --json slug,title --field role:CTO
+granite search "Jane Smith" --json slug,title,type
+granite list --type person --json slug,title --field role:CTO
 ```
 
 **Step 3 — Decide:**
@@ -280,8 +280,8 @@ mem list --type person --json slug,title --field role:CTO
 
 **Step 4 — Act:**
 ```bash
-mem new "Jane Smith" -t person --json               # ADD
-mem edit jane-smith --append $'- 2026-03-30: ...'    # UPDATE
+granite new "Jane Smith" -t person --json               # ADD
+granite edit jane-smith --append $'- 2026-03-30: ...'    # UPDATE
 # NOOP = do nothing
 ```
 
@@ -371,7 +371,7 @@ The fleeting note is then archived (not deleted — it's the provenance chain).
 ## 6. Implementation Priorities for Granite
 
 ### Phase 1 (shipped): Agent-readable CLI
-✅ `mem show` command
+✅ `granite show` command
 ✅ `--json` on all commands
 ✅ Consistent JSON envelope
 ✅ `--alias` on edit
@@ -388,13 +388,13 @@ The fleeting note is then archived (not deleted — it's the provenance chain).
 - Auto-detect TTY for format switching
 - NDJSON streaming output
 - Exit code 4 for "not found" (distinct from error)
-- `mem --capabilities` for agent discovery
+- `granite --capabilities` for agent discovery
 - Fuzzy suggestions on "not found" errors
 - MCP server exposing resources + tools
 
 ### Phase 4 (later): Knowledge graph intelligence
 - Typed relationship indexing (frontmatter wikilinks stored with relationship type)
-- `mem graph` command for traversing the link graph
-- `mem promote <slug> --to permanent` for lifecycle transitions
-- `mem orphans` to find unlinked notes
+- `granite graph` command for traversing the link graph
+- `granite promote <slug> --to permanent` for lifecycle transitions
+- `granite orphans` to find unlinked notes
 - Hub note auto-generation from tag clusters

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "zod": "^3.25.76"
       },
       "bin": {
-        "mem": "dist/index.js"
+        "granite": "dist/index.js"
       },
       "devDependencies": {
         "@commitlint/cli": "^20.0.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A local-first markdown memory system for humans and agents",
   "type": "module",
   "bin": {
-    "mem": "./dist/index.js"
+    "granite": "./dist/index.js"
   },
   "files": [
     "dist"

--- a/packages/worker/src/auth.ts
+++ b/packages/worker/src/auth.ts
@@ -25,7 +25,7 @@ export const authMiddleware = createMiddleware<{ Bindings: Env }>(async (c, next
   const apiKey = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : (queryKey || '');
 
   if (!apiKey || !apiKey.startsWith('gsk_')) {
-    return c.json({ error: 'Missing or invalid API key. Run: mem cloud login' }, 401);
+    return c.json({ error: 'Missing or invalid API key. Run: granite cloud login' }, 401);
   }
 
   const keyHash = await hashApiKey(apiKey);

--- a/packages/worker/src/middleware/tier-gate.ts
+++ b/packages/worker/src/middleware/tier-gate.ts
@@ -11,7 +11,7 @@ export const requirePaidTier = createMiddleware<{ Bindings: Env }>(async (c, nex
 
   if (!TIER_LIMITS[tier].syncEnabled) {
     return c.json({
-      error: 'Sync requires a Pro subscription. Run: mem cloud upgrade',
+      error: 'Sync requires a Pro subscription. Run: granite cloud upgrade',
       tier,
       upgrade_url: `${c.env.BASE_URL}/billing/checkout`,
     }, 403);

--- a/packages/worker/src/routes/auth.ts
+++ b/packages/worker/src/routes/auth.ts
@@ -276,7 +276,7 @@ auth.get('/auth/callback', async (c) => {
     <button class="copy-btn" id="copy-btn">Copy to clipboard</button>
     <script>document.getElementById('copy-btn').addEventListener('click',function(){navigator.clipboard.writeText(document.getElementById('key').textContent);this.textContent='Copied!'});</script>
     <p class="warning">This key is shown only once. Save it now.</p>
-    <p>If you used <code>mem cloud login</code>, the CLI has already picked it up. You can close this tab.</p>
+    <p>If you used <code>granite cloud login</code>, the CLI has already picked it up. You can close this tab.</p>
     <p>Add to your <code>granite.yml</code>:</p>
     <pre>sync:
   server: ${safeBaseUrl}

--- a/packages/worker/src/routes/billing.ts
+++ b/packages/worker/src/routes/billing.ts
@@ -9,7 +9,7 @@ const billing = new Hono<{ Bindings: Env }>();
  */
 billing.get('/billing/checkout', async (c) => {
   const user = c.get('user');
-  if (!user) return c.json({ error: 'Authentication required. Run: mem cloud login' }, 401);
+  if (!user) return c.json({ error: 'Authentication required. Run: granite cloud login' }, 401);
 
   if (user.tier === 'pro') {
     return c.json({ error: 'Already on Pro tier', tier: 'pro' }, 400);
@@ -41,7 +41,7 @@ billing.get('/billing/portal', async (c) => {
   if (!user) return c.json({ error: 'Authentication required' }, 401);
 
   if (!user.stripe_customer_id) {
-    return c.json({ error: 'No billing account found. Upgrade first: mem cloud upgrade' }, 400);
+    return c.json({ error: 'No billing account found. Upgrade first: granite cloud upgrade' }, 400);
   }
 
   if (!c.env.STRIPE_SECRET_KEY) {
@@ -83,13 +83,13 @@ billing.get('/billing/success', (c) => {
       <li>Up to 10 vaults</li>
       <li>Remote MCP access</li>
     </ul>
-    <p>You can close this tab and continue using <code>mem</code>.</p>`));
+    <p>You can close this tab and continue using <code>granite</code>.</p>`));
 });
 
 billing.get('/billing/cancel', (c) => {
   return c.html(billingPage('Checkout cancelled', `
     <h1>Checkout cancelled</h1>
-    <p>No worries! You can upgrade anytime by running <code>mem cloud upgrade</code>.</p>`));
+    <p>No worries! You can upgrade anytime by running <code>granite cloud upgrade</code>.</p>`));
 });
 
 billing.get('/billing/portal-return', (c) => {

--- a/skills/mem/SKILL.md
+++ b/skills/mem/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: mem
-description: Manage a local-first markdown memory system using the `mem` CLI. Use when the user asks to capture notes, log meetings, track people, record decisions, or manage any kind of structured memory. Enforces brevity and atomic note-taking.
+description: Manage a local-first markdown memory system using the `granite` CLI. Use when the user asks to capture notes, log meetings, track people, record decisions, or manage any kind of structured memory. Enforces brevity and atomic note-taking.
 user-invocable: true
 argument-hint: [action]
 allowed-tools: Bash
 ---
 
-You are an expert at managing a structured knowledge base using the `mem` CLI — a local-first markdown memory system built on Zettelkasten principles.
+You are an expert at managing a structured knowledge base using the `granite` CLI — a local-first markdown memory system built on Zettelkasten principles.
 
 ## Core Workflow (ECDA Loop)
 
@@ -52,58 +52,58 @@ If a note exceeds its limit, **split it** into multiple linked notes.
 ### Create
 
 ```bash
-mem new "Note title" -t permanent                      # Create typed note
-mem new "Quick thought"                                # Fleeting note (default)
-mem new "Sprint review" -t meeting --source agent --json  # Agent-created, JSON output
-mem add "Quick thought"                                # Quick-capture fleeting note
-echo "Piped content" | mem add --json                  # Stdin + JSON output
+granite new "Note title" -t permanent                      # Create typed note
+granite new "Quick thought"                                # Fleeting note (default)
+granite new "Sprint review" -t meeting --source agent --json  # Agent-created, JSON output
+granite add "Quick thought"                                # Quick-capture fleeting note
+echo "Piped content" | granite add --json                  # Stdin + JSON output
 ```
 
 ### Read
 
 ```bash
-mem show <slug>                          # Display note with header
-mem show <slug> --json                   # Full note as JSON (agent-friendly)
-mem show <slug> --body                   # Raw body only (for piping)
-mem list                                 # All notes, sorted by modified
-mem list -t person                       # Filter by type
-mem list -s active                       # Filter by status
-mem list --source agent                  # Filter by source
-mem list --since 2026-03-01              # Filter by modified date
-mem list --json slug,title,type,status   # Field selection (gh-style)
-mem search "query"                       # Full-text search
-mem search "query" --json                # JSON output
+granite show <slug>                          # Display note with header
+granite show <slug> --json                   # Full note as JSON (agent-friendly)
+granite show <slug> --body                   # Raw body only (for piping)
+granite list                                 # All notes, sorted by modified
+granite list -t person                       # Filter by type
+granite list -s active                       # Filter by status
+granite list --source agent                  # Filter by source
+granite list --since 2026-03-01              # Filter by modified date
+granite list --json slug,title,type,status   # Field selection (gh-style)
+granite search "query"                       # Full-text search
+granite search "query" --json                # JSON output
 ```
 
 ### Update
 
 ```bash
-mem edit <slug> --body $'## Section\n\nContent here.'   # Replace body
-mem edit <slug> --append $'- 2026-03-30: Met at conf'   # Append text
-mem edit <slug> --title "New Title"                      # Update title
-mem edit <slug> --tag "tag1,tag2"                        # Add tags
-mem edit <slug> --alias "short-name,abbreviation"        # Add aliases
-mem edit <slug> --status archived                        # Archive a note
-mem edit <slug> --source agent                           # Mark as agent-edited
-mem edit <slug>                                          # Open in $EDITOR
+granite edit <slug> --body $'## Section\n\nContent here.'   # Replace body
+granite edit <slug> --append $'- 2026-03-30: Met at conf'   # Append text
+granite edit <slug> --title "New Title"                      # Update title
+granite edit <slug> --tag "tag1,tag2"                        # Add tags
+granite edit <slug> --alias "short-name,abbreviation"        # Add aliases
+granite edit <slug> --status archived                        # Archive a note
+granite edit <slug> --source agent                           # Mark as agent-edited
+granite edit <slug>                                          # Open in $EDITOR
 ```
 
 ### Graph
 
 ```bash
-mem backlinks <slug>              # Who links to this note?
-mem backlinks <slug> --json       # JSON output
-mem suggest-links <slug>          # Find unlinked mentions
-mem suggest-links <slug> --json   # JSON output
+granite backlinks <slug>              # Who links to this note?
+granite backlinks <slug> --json       # JSON output
+granite suggest-links <slug>          # Find unlinked mentions
+granite suggest-links <slug> --json   # JSON output
 ```
 
 ### Manage
 
 ```bash
-mem init          # Initialize a new vault
-mem types         # List available note types
-mem doctor        # Validate vault health
-mem serve         # Start web UI at localhost:4321
+granite init          # Initialize a new vault
+granite types         # List available note types
+granite doctor        # Validate vault health
+granite serve         # Start web UI at localhost:4321
 ```
 
 All `--json` commands return `{"success": true, "data": ...}` or `{"success": false, "error": "..."}`.
@@ -114,10 +114,10 @@ All `--json` commands return `{"success": true, "data": ...}` or `{"success": fa
 One sentence. No formatting. Just the raw thought.
 
 ```bash
-mem new "Granite could auto-detect note type from content"
+granite new "Granite could auto-detect note type from content"
 ```
 
-Bad: `mem new "I was thinking about how it would be really cool if Granite could maybe analyze what you write and automatically suggest the type"`
+Bad: `granite new "I was thinking about how it would be really cool if Granite could maybe analyze what you write and automatically suggest the type"`
 
 ### Permanent
 Start with a one-line summary. Use `## Summary`, `## Details`, `## Links` sections.
@@ -163,9 +163,9 @@ This aligns with how [[Granite]] works. See also [[Local-First Software]].
 Lead with role and context. Add timestamped interaction notes with `--append`.
 
 ```bash
-mem new "Jane Smith" -t person --json
-mem edit jane-smith --body $'## Role\n\nCTO at Acme Corp\n\n## Context\n\nMet at ReactConf 2026. Working on similar infra.\n\n## Contact\n\nSlack: @jsmith\n\n## Notes\n\n## Links\n'
-mem edit jane-smith --append $'- 2026-03-30: Discussed [[project-x]] migration timeline'
+granite new "Jane Smith" -t person --json
+granite edit jane-smith --body $'## Role\n\nCTO at Acme Corp\n\n## Context\n\nMet at ReactConf 2026. Working on similar infra.\n\n## Contact\n\nSlack: @jsmith\n\n## Notes\n\n## Links\n'
+granite edit jane-smith --append $'- 2026-03-30: Discussed [[project-x]] migration timeline'
 ```
 
 ### Meeting
@@ -230,8 +230,8 @@ Active
 
 **Aliases**: set when a note has common abbreviations or alternate names.
 ```bash
-mem edit amazon-web-services --alias "AWS,aws"
-mem edit jane-smith --alias "Jane,jsmith"
+granite edit amazon-web-services --alias "AWS,aws"
+granite edit jane-smith --alias "Jane,jsmith"
 ```
 This makes wikilinks resolve correctly: `[[AWS]]` will find the `amazon-web-services` note.
 
@@ -260,7 +260,7 @@ Every note has `status` and `source` fields in frontmatter:
 
 **Agents must always use `--source agent`** when creating notes:
 ```bash
-mem new "Insight from conversation" -t permanent --source agent --json
+granite new "Insight from conversation" -t permanent --source agent --json
 ```
 
 ## Key Patterns
@@ -268,25 +268,25 @@ mem new "Insight from conversation" -t permanent --source agent --json
 ### Capturing a meeting
 
 ```bash
-mem search "sprint review" --json           # Check if note exists
-mem new "Sprint review 2026-03-30" -t meeting --source agent --json
+granite search "sprint review" --json           # Check if note exists
+granite new "Sprint review 2026-03-30" -t meeting --source agent --json
 # For each attendee:
-mem search "Jane Smith" --json              # Check if person note exists
-mem new "Jane Smith" -t person --source agent --json  # Create if missing
+granite search "Jane Smith" --json              # Check if person note exists
+granite new "Jane Smith" -t person --source agent --json  # Create if missing
 # Fill meeting body:
-mem edit sprint-review-2026-03-30 --body $'## Attendees\n\n- [[jane-smith]]\n...'
+granite edit sprint-review-2026-03-30 --body $'## Attendees\n\n- [[jane-smith]]\n...'
 # Update person notes:
-mem edit jane-smith --append $'- 2026-03-30: [[sprint-review-2026-03-30]]'
+granite edit jane-smith --append $'- 2026-03-30: [[sprint-review-2026-03-30]]'
 ```
 
 ### Recording a decision
 
 ```bash
-mem search "database choice" --json
-mem new "Analytics database choice" -t decision --source agent --json
-mem edit analytics-database-choice --body $'## Context\n\n...\n\n## Decision\n\n...\n\n## Status\n\nActive'
-mem edit analytics-database-choice --tag "area/infrastructure"
-mem edit analytics-service --append $'Key decision: [[analytics-database-choice]]'
+granite search "database choice" --json
+granite new "Analytics database choice" -t decision --source agent --json
+granite edit analytics-database-choice --body $'## Context\n\n...\n\n## Decision\n\n...\n\n## Status\n\nActive'
+granite edit analytics-database-choice --tag "area/infrastructure"
+granite edit analytics-service --append $'Key decision: [[analytics-database-choice]]'
 ```
 
 ### Retrieving knowledge
@@ -294,17 +294,17 @@ mem edit analytics-service --append $'Key decision: [[analytics-database-choice]
 When the user asks "what do I know about X?":
 
 ```bash
-mem search "X" --json                    # Find relevant notes
-mem show <slug> --json                   # Read each note's content
-mem backlinks <slug> --json              # Find what links to it
+granite search "X" --json                    # Find relevant notes
+granite show <slug> --json                   # Read each note's content
+granite backlinks <slug> --json              # Find what links to it
 # Synthesize across results and present to user
 ```
 
 ### Maintaining the knowledge graph
 
 ```bash
-mem suggest-links <slug> --json          # Find unlinked mentions → add links
-mem doctor                               # Check vault health
+granite suggest-links <slug> --json          # Find unlinked mentions → add links
+granite doctor                               # Check vault health
 # Build hub notes for major topics (permanent notes that are mostly links)
 ```
 

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -19,7 +19,7 @@ export function addNote(text?: string, options: { json?: boolean } = {}): void {
     // Read from stdin (pipe)
     content = fs.readFileSync(0, 'utf-8').trim();
   } else {
-    console.error('Usage: mem add "some text" or echo "text" | mem add');
+    console.error('Usage: granite add "some text" or echo "text" | granite add');
     process.exit(1);
   }
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -35,5 +35,5 @@ export function initVault(dir = getDefaultVaultRoot()): void {
     console.log(`  ${typeConfig.folder}/  (${name})`);
   }
   console.log('');
-  console.log('Next: mem new "My first note" --type fleeting');
+  console.log('Next: granite new "My first note" --type fleeting');
 }

--- a/src/commands/types.ts
+++ b/src/commands/types.ts
@@ -18,5 +18,5 @@ export function typesCommand(): void {
   }
 
   console.log(`Default type: ${config.defaults.note_type}`);
-  console.log(`\nUsage: mem new <type> <title>`);
+  console.log(`\nUsage: granite new <type> <title>`);
 }

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -108,7 +108,7 @@ export function writeDefaultConfig(dir: string): void {
 export function loadConfig(vaultRoot: string): GraniteConfig {
   const configPath = path.join(vaultRoot, CONFIG_FILENAME);
   if (!fs.existsSync(configPath)) {
-    throw new Error(`No ${CONFIG_FILENAME} found in ${vaultRoot}. Run "mem init" first.`);
+    throw new Error(`No ${CONFIG_FILENAME} found in ${vaultRoot}. Run "granite init" first.`);
   }
   const raw = fs.readFileSync(configPath, 'utf-8');
   const parsed = yaml.load(raw) as GraniteConfig;

--- a/src/core/vault.ts
+++ b/src/core/vault.ts
@@ -31,7 +31,7 @@ export function findVaultRoot(from?: string): string | null {
 export function requireVaultRoot(from?: string): string {
   const root = findVaultRoot(from);
   if (!root) {
-    throw new Error(`No Granite vault found. Run "mem init" to create ${getDefaultVaultRoot()}.`);
+    throw new Error(`No Granite vault found. Run "granite init" to create ${getDefaultVaultRoot()}.`);
   }
   return root;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ import { GRANITE_VERSION } from './version.js';
 const program = new Command();
 
 program
-  .name('mem')
+  .name('granite')
   .description('Granite — a local-first markdown memory system')
   .version(GRANITE_VERSION);
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -350,7 +350,7 @@ function registerTools(server: McpServer, runtime: GraniteMcpRuntime): void {
 
   server.registerTool('granite_capture_note', {
     title: 'Capture Granite Note',
-    description: 'Quick-capture a note from free-form text, similar to mem add.',
+    description: 'Quick-capture a note from free-form text, similar to granite add.',
     inputSchema: {
       text: z.string().describe('Raw capture text.'),
       type: z.string().optional().describe('Optional note type override. Defaults to the vault default type.'),

--- a/test/core/vault.test.ts
+++ b/test/core/vault.test.ts
@@ -61,7 +61,7 @@ describe('vault', () => {
 
   it('mentions the default vault path when no vault can be found', () => {
     expect(() => requireVaultRoot(path.join(tmpHome, 'nowhere'))).toThrow(
-      `No Granite vault found. Run "mem init" to create ${getDefaultVaultRoot()}.`,
+      `No Granite vault found. Run "granite init" to create ${getDefaultVaultRoot()}.`,
     );
   });
 });


### PR DESCRIPTION
## Summary
- rename the installed CLI binary from `mem` to `granite`
- align user-facing command strings and error/help text with the new CLI name
- update README, internal docs, worker auth/billing copy, and the local skill examples to use `granite`

## Why
The installed command should match the product name `Granite` instead of exposing `mem` at install time.

## Validation
- `npm run test`
- `npm run lint`
- `npm run build`

## Notes
- excluded unrelated local changes in `packages/worker/package.json`, `packages/worker/package-lock.json`, `.mcp.json`, and `packages/worker/.wrangler/`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the installed CLI from mem to granite and updated all user-facing strings, docs, examples, and tests to match. This aligns the CLI with the Granite product name; behavior is unchanged.

- **Migration**
  - Use `granite` instead of `mem` for all commands (e.g., `granite init`, `granite serve`, `granite mcp`).
  - Update MCP client configs to run `"granite" "mcp" ...` instead of `"mem"`.
  - Update scripts/aliases referencing `mem` (serve, search, suggest-links, etc.).
  - Cloud messages now reference `granite cloud login` and `granite cloud upgrade`.

<sup>Written for commit 086a1ae4a53eb78c1df1547859216a7b5f737e29. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a broad rename of the published CLI binary and user-facing help/error strings; main risk is breaking existing scripts that still invoke `mem`.
> 
> **Overview**
> **Renames the installed CLI binary from `mem` to `granite`.** Updates `package.json`/lockfile `bin` mapping and the Commander program name so installs expose `granite`.
> 
> Aligns user-facing documentation and copy to the new command name, including README/agent docs, CLI usage/error/help strings, MCP tool descriptions, cloud worker auth/billing messages, and the affected test expectation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 086a1ae4a53eb78c1df1547859216a7b5f737e29. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->