### PR TITLE
feat: rename mem skill to granite

### DIFF
--- a/skills/granite/SKILL.md
+++ b/skills/granite/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: mem
+name: granite
 description: Manage a local-first markdown memory system using the `granite` CLI. Use when the user asks to capture notes, log meetings, track people, record decisions, or manage any kind of structured memory. Enforces brevity and atomic note-taking.
 user-invocable: true
 argument-hint: [action]


### PR DESCRIPTION
## Summary
- rename the local skill from `mem` to `granite`
- update the skill manifest name to match the new folder and invocation name

## Why
The local skill should use the product name `granite` consistently instead of the old `mem` skill name.

## Validation
- verified the staged diff only included the skill rename and manifest update
- confirmed there were no remaining `skills/mem` or `name: mem` references in the repo

## Notes
- excluded unrelated local changes in `packages/worker/package.json`, `packages/worker/package-lock.json`, `.mcp.json`, and `packages/worker/.wrangler/`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the local skill from `mem` to `granite`, updating the manifest `name` and moving the skill doc to `skills/granite/SKILL.md`. No behavior changes.

<sup>Written for commit 4a4c8a03c160cde48f95f419ec6e0588bb857436. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a simple manifest/metadata rename with no logic changes. Impact is limited to how the skill is referenced/invoked.
> 
> **Overview**
> Renames the local memory skill to **`granite`** by updating the `name` field in `skills/granite/SKILL.md` (was `mem`), aligning the manifest with the skill’s folder/invocation name.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a4c8a03c160cde48f95f419ec6e0588bb857436. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->