### PR TITLE
feat: add agent-friendly note protocol metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance to Codex (Codex.ai/code) when working with code in t
 
 ## What is Granite?
 
-Granite (`granite` CLI) is a local-first markdown memory system for humans and agents. Notes are plain markdown files with YAML frontmatter, organized by configurable note types (fleeting, permanent, reference, person, meeting, project, decision). Configuration lives in `granite.yml` at the vault root. A SQLite index (`.granite/index.db`) provides full-text search and wikilink resolution.
+Granite (`granite` CLI) is a local-first markdown memory system for humans and agents. Notes are plain markdown files with YAML frontmatter, organized by configurable note types. The default model is knowledge-first: `note`, `source`, `synthesis`, and `output`. Configuration lives in `granite.yml` at the vault root. A SQLite index (`.granite/index.db`) provides full-text search and wikilink resolution.
 
 ## Commands
 
@@ -42,7 +42,7 @@ npx tsx src/index.ts <command>
 
 - **Vault detection**: `findVaultRoot()` walks up from CWD looking for `granite.yml`. Most commands call `requireVaultRoot()` which throws if not found.
 - **Index rebuild**: `ensureIndex()` rebuilds the entire SQLite index on every command when `config.index.auto_rebuild` is true. The index is derived state — the markdown files are the source of truth.
-- **Slug formats**: Fleeting notes use date-based slugs (`2026-03-30-a1b2`), all other types use title-based slugs with collision counters.
+- **Slug formats**: Granite uses title-based slugs with collision counters by default. Custom note types may still opt into alternate slug formats in `granite.yml`.
 - **Note files**: Each note is `<folder>/<slug>.md` with YAML frontmatter (id, title, type, created, modified, tags, aliases).
 
 ## Testing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What is Granite?
 
-Granite (`granite` CLI) is a local-first markdown memory system for humans and agents. Notes are plain markdown files with YAML frontmatter, organized by configurable note types (fleeting, permanent, reference, person, meeting, project, decision). Configuration lives in `granite.yml` at the vault root. A SQLite index (`.granite/index.db`) provides full-text search and wikilink resolution.
+Granite (`granite` CLI) is a local-first markdown memory system for humans and agents. Notes are plain markdown files with YAML frontmatter, organized by configurable note types. The default model is knowledge-first: `note`, `source`, `synthesis`, and `output`. Configuration lives in `granite.yml` at the vault root. A SQLite index (`.granite/index.db`) provides full-text search and wikilink resolution.
 
 ## Commands
 
@@ -42,7 +42,7 @@ npx tsx src/index.ts <command>
 
 - **Vault detection**: `findVaultRoot()` walks up from CWD looking for `granite.yml`. Most commands call `requireVaultRoot()` which throws if not found.
 - **Index rebuild**: `ensureIndex()` rebuilds the entire SQLite index on every command when `config.index.auto_rebuild` is true. The index is derived state — the markdown files are the source of truth.
-- **Slug formats**: Fleeting notes use date-based slugs (`2026-03-30-a1b2`), all other types use title-based slugs with collision counters.
+- **Slug formats**: Granite uses title-based slugs with collision counters by default. Custom note types may still opt into alternate slug formats in `granite.yml`.
 - **Note files**: Each note is `<folder>/<slug>.md` with YAML frontmatter (id, title, type, created, modified, tags, aliases).
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Most PKM tools give you a blank canvas. Granite gives you a working system:
 
 - capture quickly
 - structure ideas without over-designing your workflow
-- link people, meetings, projects, and decisions
+- keep sources, durable notes, syntheses, and outputs connected
 - surface what to connect or write next
 - stay fully local, scriptable, and agent-friendly
 
@@ -39,13 +39,12 @@ Granite is opinionated where it matters and flexible where it should be.
 
 Granite ships with a small working model instead of an empty workspace:
 
-- `fleeting` for quick capture
-- `permanent` for durable ideas
-- `reference` for external sources
-- `person` for people and relationships
-- `meeting` for notes with attendees, decisions, and actions
-- `project` for active work
-- `decision` for durable decision records
+- `note` for durable ideas
+- `source` for imported or observed source material
+- `synthesis` for durable compiled knowledge
+- `output` for audience-specific deliverables
+
+`note -> synthesis -> output`
 
 This is enough structure to make your notes connect naturally, without forcing you into a heavyweight system.
 
@@ -83,7 +82,7 @@ Create the default vault in `~/.granite` and start capturing:
 ```bash
 granite init
 granite add "Talked to Alice about local-first sync tradeoffs"
-granite new "Local-first sync tradeoffs" --type permanent
+granite new "Local-first sync tradeoffs" --type note
 granite list
 granite search "sync"
 ```
@@ -108,7 +107,7 @@ granite add "Users want fewer note types, but stronger defaults."
 Turn it into a durable note:
 
 ```bash
-granite new "Strong defaults beat infinite flexibility" --type permanent
+granite new "Strong defaults beat infinite flexibility" --type note
 ```
 
 Find connections:
@@ -149,10 +148,28 @@ note_types:
     line_limit: 120
     warn_only: true
     slug_format: title
-    instructions: Capture the idea clearly, then link it to a project, person, or permanent note.
+    instructions: Capture the idea clearly, then link it to a source, note, or synthesis.
 ```
 
 The point is not to create 30 note types. The point is to add a type only when it makes your memory system sharper.
+
+## Protocol Fields
+
+Granite keeps the core schema small, but now includes a few shared fields that help both humans and agents work safely in the same vault:
+
+- `status`: `inbox | active | archived`
+- `source`: `human | agent | extraction`
+- `review_state`: `draft | reviewed | locked`
+- `durability`: `canonical | working | ephemeral`
+- `derived_from`: list of note IDs or slugs used as provenance
+
+These fields are intentionally lightweight:
+
+- `review_state` is the editorial state
+- `durability` distinguishes durable knowledge from working material or situational outputs
+- `derived_from` is the minimal provenance hook for syntheses and outputs
+
+Granite does not impose a full agent workflow in the core. Richer conventions such as agent traces or synthesis policies are better handled in templates, skills, and team protocol.
 
 ## Local-First Architecture
 
@@ -172,7 +189,7 @@ This keeps the system transparent, portable, and inspectable.
 Many commands support JSON output:
 
 ```bash
-granite new "Sync constraints" --type permanent --json
+granite new "Sync constraints" --type note --review-state reviewed --durability canonical --json
 granite list --json
 granite show sync-constraints --json
 granite search "constraints" --json
@@ -204,6 +221,8 @@ The server exposes:
 - resources for `granite.yml`, vault overview, note types, and individual notes via `granite://notes/{slug}`
 - prompts for refining notes and reviewing links/next steps
 
+The note payloads exposed through MCP include the shared protocol fields (`status`, `source`, `review_state`, `durability`, `derived_from`) so clients can make safer decisions without Granite embedding any model-specific logic.
+
 Example stdio client configuration:
 
 ```json
@@ -217,10 +236,10 @@ Example stdio client configuration:
 
 ```bash
 granite init
-granite new <title> [--type <type>] [--json]
+granite new <title> [--type <type>] [--source <source>] [--status <status>] [--review-state <state>] [--durability <durability>] [--derived-from <refs>] [--json]
 granite add [text] [--json]
 granite list [--type <type>] [--json]
-granite edit <slug>
+granite edit <slug> [--body <text>] [--append <text>] [--title <title>] [--tag <tags>] [--alias <aliases>] [--status <status>] [--source <source>] [--review-state <state>] [--durability <durability>] [--derived-from <refs>]
 granite open <slug>
 granite show <slug> [--json] [--body]
 granite search <query> [--json]
@@ -265,5 +284,6 @@ Granite is built on a few beliefs:
 - relationships between notes matter more than visual chrome
 - a good PKM should help you decide what to connect or write next
 - tools for humans should also be legible to agents
+- protocol belongs in the core, agent policy belongs outside it
 
 If that sounds right, Granite is the tool.

--- a/docs/GRANITE_OBJECT_STANDARD.md
+++ b/docs/GRANITE_OBJECT_STANDARD.md
@@ -1,8 +1,6 @@
 # Granite Object Standard (GOS)
 
-> A simple, powerful standard for agent-first note and object management.
-> Informed by: MCP resources/tools, gh CLI field selection, Mem0 agent memory,
-> Schema.org typed relationships, Logseq class-based schemas, CRDT identity patterns.
+> A small protocol for human-readable, agent-operable notes in Granite.
 
 ---
 
@@ -12,9 +10,8 @@
 Files on disk are the source of truth. The SQLite index, backlinks graph, and search
 results are materialized views — rebuilt anytime from the files.
 
-### 1.2 Agent-first, human-friendly
-Every command returns structured JSON by default when piped (`!isTTY`).
-Human-readable output is a presentation layer on top of the same data.
+### 1.2 Human-readable, agent-operable
+Granite stays readable in raw Markdown first. Structured JSON and MCP exposure are there to make the same vault easy for agents to inspect and modify safely.
 
 ### 1.3 Stable identity survives renames
 Notes are identified by UUID (`id` in frontmatter), not by slug or title.
@@ -24,13 +21,8 @@ Slugs are human-friendly aliases. Wikilinks resolve through: slug → title → 
 Each note type defines expected fields. The type system is the schema system.
 Types are constrained to ~10 max (Johnny Decimal principle: discoverable at a glance).
 
-### 1.5 Links are typed
-Not all connections are equal. `[[wikilinks]]` carry semantic meaning through
-frontmatter fields that define the relationship type.
-
-### 1.6 Agents operate via Extract → Compare → Decide
-Following the Mem0 pattern: extract facts from conversation, compare against existing
-notes via search, then ADD / UPDATE / NOOP. Never blindly append.
+### 1.5 Minimal protocol beats hidden policy
+The Granite core should define a small, explicit protocol: stable IDs, note types, lifecycle state, editorial state, durability, and provenance hooks. Richer agent behavior belongs in skills, templates, and team process.
 
 ---
 
@@ -42,145 +34,84 @@ notes via search, then ADD / UPDATE / NOOP. Never blindly append.
 ---
 id: "uuid-v4"                    # Stable identity (survives renames)
 title: "Note Title"              # Human-readable name
-type: "permanent"                # Schema selector
+type: "note"                     # Schema selector
 created: "2026-03-30T10:00:00Z"  # ISO 8601
 modified: "2026-03-30T10:00:00Z" # ISO 8601
 tags: [architecture, active]     # Flat taxonomy, lowercase
 aliases: [alt-name, abbrev]      # Resolve wikilinks by alias
 status: active                   # Lifecycle: inbox | active | archived
 source: human                    # Provenance: human | agent | extraction
+review_state: draft              # Editorial state: draft | reviewed | locked
+durability: canonical            # Knowledge lifecycle: canonical | working | ephemeral
+derived_from: []                 # Optional provenance chain for derived notes
 ---
 ```
 
-**New fields (vs current Granite):**
-- `status` — lifecycle state, orthogonal to type. Enables PARA-style workflow:
-  `inbox` (raw capture) → `active` (in use) → `archived` (done, kept for reference).
-- `source` — who created this note. Critical for trust: an agent reading a `human`
-  permanent note trusts it more than an `agent` fleeting note.
+**Current shared protocol fields:**
+- `status` — lifecycle state, orthogonal to type: `inbox | active | archived`
+- `source` — who created the note: `human | agent | extraction`
+- `review_state` — editorial state: `draft | reviewed | locked`
+- `durability` — whether a note is durable knowledge, working material, or situation-specific output
+- `derived_from` — minimal provenance hook for syntheses and outputs
 
 ### 2.2 Type-specific schemas (defined in granite.yml)
 
-Each note type declares expected fields and their types:
+Each note type declares expected fields and their types. Granite itself stays small; richer structured workflows are optional and can be added in `granite.yml` when needed.
 
 ```yaml
 note_types:
-  meeting:
-    folder: notes/meetings
-    description: Meeting notes with attendees, decisions, and actions
-    fields:
-      attendees:
-        type: list
-        of: wikilink
-        description: People present
-      date:
-        type: date
-        required: true
-      project:
-        type: wikilink
-        description: Related project
+  source:
+    folder: notes/sources
+    description: Imported or observed source material
     template: |
-      ## Attendees
+      ## Summary
 
-      ## Agenda
+      ## Key Facts
 
-      ## Notes
+      - 
 
-      ## Decisions
-
-      ## Actions
-    line_limit: 300
-
-  decision:
-    folder: notes/decisions
-    fields:
-      context_for:
-        type: wikilink
-        description: Project or area this decision belongs to
-      decision_status:
-        type: enum
-        options: [active, superseded, revisit]
-        default: active
-        description: Decision lifecycle (distinct from universal note status)
-      superseded_by:
-        type: wikilink
-        description: If superseded, link to replacement decision
-    template: |
-      ## Context
-
-      ## Options Considered
-
-      1.
-      2.
-
-      ## Decision
-
-      ## Rationale
-
-      ## Status
-
-      Active
-    line_limit: 200
-
-  person:
-    folder: notes/people
-    fields:
-      role:
-        type: text
-      org:
-        type: text
-      contact:
-        type: text
-    template: |
-      ## Role
-
-      ## Context
-
-      ## Contact
-
-      ## Notes
+      ## Raw Content
 
       ## Links
-    line_limit: 150
+    line_limit: 400
+
+  synthesis:
+    folder: notes/syntheses
+    description: Compiled knowledge across multiple notes or sources
+    template: |
+      ## Scope
+
+      ## Executive Summary
+
+      ## Main Themes
+
+      ## Open Questions
+
+      ## Links
+    line_limit: 300
 ```
 
 **Field types:** `text`, `date`, `number`, `boolean`, `wikilink`, `list`, `enum`.
 Type-specific fields appear in frontmatter and are indexed in SQLite for structured queries.
 
-### 2.3 Typed relationships via frontmatter
-
-Instead of all `[[wikilinks]]` being untyped, key relationships are declared in frontmatter:
+### 2.3 Structured relationships via frontmatter
 
 ```yaml
 ---
 id: "abc-123"
-title: "Sprint review 2026-03-30"
-type: meeting
-attendees: ["[[jane-smith]]", "[[bob-chen]]"]
-project: "[[project-granite]]"
+title: "State of transformer scaling"
+type: synthesis
+derived_from: ["attention-is-all-you-need", "scaling-laws"]
 ---
 ```
 
-The body still uses `[[wikilinks]]` for inline mentions, but frontmatter relationships
-are **structured, queryable, and carry semantic meaning**:
-- `attendees` links are of type "person attended meeting"
-- `project` links are of type "meeting about project"
-
-This enables queries like: `granite search --field attendees:jane-smith` or
-`granite list --type meeting --field project:project-granite`.
+The body still uses `[[wikilinks]]` for inline mentions, but frontmatter relationships are more structured and easier for agents to interpret consistently.
 
 ---
 
 ## 3. CLI Output Standard
 
-### 3.1 Format detection
-
-```
-TTY (human typing)  →  human-readable tables/text
-Piped / --json      →  structured JSON with envelope
---format ndjson     →  streaming, one JSON object per line
-```
-
-### 3.2 JSON envelope (every command)
+### 3.1 JSON envelope
 
 **Success:**
 ```json
@@ -206,46 +137,25 @@ Piped / --json      →  structured JSON with envelope
 }
 ```
 
-### 3.3 Field selection (gh CLI pattern)
+### 3.2 Field selection
 
 ```bash
 granite list --json slug,title,type,tags
 granite show note-slug --json title,body,backlinks
-granite search "query" --json slug,title,score
 ```
 
-`--json` without field names = list available fields (self-documenting):
+`granite list --json` without field names returns the default field set:
 ```
-$ granite list --json
-Available fields: slug, title, type, created, modified, tags, aliases, status, source, filepath
-```
-
-### 3.4 Structured filtering
-
-```bash
-granite list --type meeting --tag project-x --status active --since 2026-03-01
-granite list --field attendees:jane-smith          # Type-specific field query
-granite search "api design" --type decision        # Full-text + type filter
+slug, title, type, created, modified, tags, aliases, status, source, review_state, durability, derived_from, filepath
 ```
 
-### 3.5 Exit codes
+### 3.3 Exit codes
 
 | Code | Meaning |
 |------|---------|
 | 0 | Success |
 | 1 | General error |
 | 2 | Usage/argument error |
-| 4 | Not found (empty result, distinct from error) |
-
-### 3.6 NDJSON streaming (for large vaults)
-
-```bash
-granite list --format ndjson
-```
-```jsonl
-{"slug":"note-1","title":"First","type":"fleeting","status":"inbox"}
-{"slug":"note-2","title":"Second","type":"decision","status":"active"}
-```
 
 ---
 
@@ -269,8 +179,8 @@ Every agent interaction with the vault follows this pattern:
 
 **Step 2 — Compare:** Search the vault for existing notes about the same entities.
 ```bash
-granite search "Jane Smith" --json slug,title,type
-granite list --type person --json slug,title --field role:CTO
+granite search "transformer scaling" --json
+granite list --type synthesis --json slug,title,review_state
 ```
 
 **Step 3 — Decide:**
@@ -280,23 +190,9 @@ granite list --type person --json slug,title --field role:CTO
 
 **Step 4 — Act:**
 ```bash
-granite new "Jane Smith" -t person --json               # ADD
-granite edit jane-smith --append $'- 2026-03-30: ...'    # UPDATE
-# NOOP = do nothing
+granite new "State of transformer scaling" -t synthesis --review-state reviewed --derived-from attention-is-all-you-need,scaling-laws --json
+granite edit state-of-transformer-scaling --append $'\n## Links\n\n- [[scaling-laws]]'
 ```
-
-### 4.2 Trust levels by source and type
-
-When an agent reads notes to inform its responses, trust varies:
-
-| Source × Type | Trust | Use |
-|---|---|---|
-| human + permanent | Highest | Authoritative knowledge |
-| human + decision | High | Established choices |
-| human + reference | High | Verified external sources |
-| agent + permanent | Medium | Agent-refined insights (verify) |
-| human + fleeting | Low | Raw, unprocessed capture |
-| agent + fleeting | Lowest | Agent speculation (needs review) |
 
 ### 4.3 MCP resource/tool mapping
 
@@ -315,86 +211,57 @@ If Granite exposes an MCP server, the split is:
 
 ---
 
-## 5. Knowledge Graph Patterns
+## 5. Knowledge Patterns
 
 ### 5.1 Hub notes (Maps of Content)
 
-For major topics, create permanent notes that are mostly links:
+For major topics, create durable notes that are mostly links:
 
 ```yaml
 ---
 title: "Knowledge Map: Infrastructure"
-type: permanent
+type: note
 tags: [hub, area/infrastructure]
 ---
 
-## Active Projects
-- [[project-granite]] — Memory system for agents
-- [[project-api-v2]] — API redesign
+## Sources
+- [[attention-is-all-you-need]] — Foundational transformer paper
+- [[scaling-laws]] — Reference on scaling behavior
 
-## Key Decisions
-- [[decision-use-sqlite]] — Database choice
-- [[decision-markdown-first]] — File format
+## Durable Notes
+- [[transformer-architectures]]
+- [[training-compute-tradeoffs]]
 
-## People
-- [[jane-smith]] — Infrastructure lead
-- [[bob-chen]] — Backend engineer
-
-## Reference
-- [[local-first-software]] — Architecture pattern
+## Syntheses
+- [[state-of-transformer-scaling]]
+- [[attention-variants-overview]]
 ```
 
-### 5.2 Temporal chains
-
-Meeting and decision notes form temporal chains through wikilinks:
+### 5.2 The promotion flow
 
 ```
-[[sprint-review-2026-03-23]] → [[sprint-review-2026-03-30]] → [[sprint-review-2026-04-06]]
+note (canonical) ──compile──▶ synthesis (canonical)
+synthesis (canonical) ──render──▶ output (ephemeral)
 ```
 
-Each links to the previous and next. Agents can traverse the chain to build context.
-
-### 5.3 The promotion flow
-
-```
-fleeting (inbox)  ──refine──▶  permanent (active)  ──archive──▶  permanent (archived)
-     │                              ▲
-     └──────extract──────▶  reference (active)
-```
-
-Fleeting notes are raw captures. During review, atomic insights are extracted
-into permanent notes, and source material goes into reference notes.
-The fleeting note is then archived (not deleted — it's the provenance chain).
+This is the main distinction Granite now supports in the core:
+- durable knowledge
+- working material
+- situational output
 
 ---
 
 ## 6. Implementation Priorities for Granite
 
-### Phase 1 (shipped): Agent-readable CLI
-✅ `granite show` command
-✅ `--json` on all commands
-✅ Consistent JSON envelope
-✅ `--alias` on edit
-✅ Improved templates
+### Implemented
+- Shared frontmatter protocol: `status`, `source`, `review_state`, `durability`, `derived_from`
+- Default note types for `source`, `synthesis`, and `output`
+- CLI support for editing the shared protocol fields
+- MCP exposure of the same protocol fields
+- `doctor` warnings for invalid lifecycle/editorial metadata and missing provenance on `synthesis` / `output`
 
-### Phase 2 (next): Schema and filtering
-- Add `status` and `source` to universal frontmatter
-- Add `fields` definition to `granite.yml` note types
-- Index type-specific fields in SQLite
-- Add `--field` filter to `list` and `search`
-- Field selection on `--json` (gh-style)
-
-### Phase 3 (future): Advanced agent patterns
-- Auto-detect TTY for format switching
-- NDJSON streaming output
-- Exit code 4 for "not found" (distinct from error)
-- `granite --capabilities` for agent discovery
-- Fuzzy suggestions on "not found" errors
-- MCP server exposing resources + tools
-
-### Phase 4 (later): Knowledge graph intelligence
-- Typed relationship indexing (frontmatter wikilinks stored with relationship type)
-- `granite graph` command for traversing the link graph
-- `granite promote <slug> --to permanent` for lifecycle transitions
-- `granite orphans` to find unlinked notes
-- Hub note auto-generation from tag clusters
+### Intentionally out of core
+- Confidence scoring
+- Mandatory “agent trace” sections
+- Model-specific prompts or planner behavior
+- Rich agent policy embedded in Granite

--- a/packages/worker/src/handlers/sync.ts
+++ b/packages/worker/src/handlers/sync.ts
@@ -91,7 +91,7 @@ export async function handleSyncPush(c: Context<{ Bindings: Env }>) {
         slug: resolvedSlug,
         id: String(change.note_id),
         title: String(change.frontmatter.title ?? ''),
-        type: String(change.frontmatter.type ?? 'fleeting'),
+        type: String(change.frontmatter.type ?? 'note'),
         created: String(change.frontmatter.created ?? ''),
         modified: String(change.frontmatter.modified ?? ''),
         tags: JSON.stringify(change.frontmatter.tags ?? []),
@@ -229,6 +229,6 @@ export async function handleSyncDevices(c: Context<{ Bindings: Env }>) {
 }
 
 function getTypeFolder(frontmatter: Record<string, unknown>): string {
-  const type = String(frontmatter.type ?? 'fleeting');
+  const type = String(frontmatter.type ?? 'note');
   return resolveTypeFolder(type);
 }

--- a/packages/worker/src/lib/config.ts
+++ b/packages/worker/src/lib/config.ts
@@ -3,13 +3,10 @@
  * These match the defaults in the main Granite CLI config (src/core/config.ts).
  */
 export const DEFAULT_TYPE_FOLDERS: Record<string, string> = {
-  fleeting: 'notes/fleeting',
-  permanent: 'notes/permanent',
-  reference: 'notes/reference',
-  person: 'notes/people',
-  meeting: 'notes/meetings',
-  project: 'notes/projects',
-  decision: 'notes/decisions',
+  note: 'notes/notes',
+  source: 'notes/sources',
+  synthesis: 'notes/syntheses',
+  output: 'notes/outputs',
 };
 
 /**

--- a/packages/worker/src/runtime.ts
+++ b/packages/worker/src/runtime.ts
@@ -478,16 +478,17 @@ function getDefaultConfig(): GraniteConfig {
     note_types: Object.fromEntries(
       Object.entries(DEFAULT_TYPE_FOLDERS).map(([type, folder]) => {
         const descriptions: Record<string, string> = {
-          fleeting: 'Quick captures', permanent: 'Refined notes', reference: 'External sources',
-          person: 'People', meeting: 'Meetings', project: 'Projects', decision: 'Decisions',
+          note: 'Durable knowledge note',
+          source: 'Imported or observed source material',
+          synthesis: 'Compiled knowledge across notes or sources',
+          output: 'Situational deliverable derived from durable knowledge',
         };
         const extra: Partial<NoteTypeConfig> = {};
-        if (type === 'fleeting') { extra.slug_format = 'date'; extra.line_limit = 50; extra.warn_only = true; }
-        if (type === 'reference') { extra.line_limit = 300; extra.warn_only = true; }
+        if (type === 'source') { extra.line_limit = 300; extra.warn_only = true; }
         return [type, defaultType(folder, descriptions[type] ?? type, extra)];
       }),
     ),
-    defaults: { note_type: 'fleeting', editor: '$EDITOR' },
+    defaults: { note_type: 'note', editor: '$EDITOR' },
     index: { auto_rebuild: true },
   };
 }

--- a/skills/granite/SKILL.md
+++ b/skills/granite/SKILL.md
@@ -1,319 +1,222 @@
 ---
 name: granite
-description: Manage a local-first markdown memory system using the `granite` CLI. Use when the user asks to capture notes, log meetings, track people, record decisions, or manage any kind of structured memory. Enforces brevity and atomic note-taking.
+description: Work safely in a Granite vault using the `granite` CLI. Use when the user wants to capture, refine, link, or retrieve knowledge in a local-first markdown memory system that is readable by humans and operable by agents.
 user-invocable: true
 argument-hint: [action]
 allowed-tools: Bash
 ---
 
-You are an expert at managing a structured knowledge base using the `granite` CLI — a local-first markdown memory system built on Zettelkasten principles.
+You are operating a Granite vault.
 
-## Core Workflow (ECDA Loop)
+Granite is not an AI product. It is a local-first knowledge substrate:
 
-Every interaction follows this loop:
+- Markdown files are the source of truth
+- the SQLite index is derived state
+- the CLI and MCP layer expose the vault cleanly
+- agent policy lives in this skill, not in the Granite core
 
+Your job is to keep the vault readable for humans and safe for agents.
+
+## Core Rules
+
+1. Read before write.
+Always inspect the vault before creating or editing notes.
+
+2. Prefer the smallest useful change.
+Append, link, or update an existing note when that is clearly better than creating a duplicate.
+
+3. Mark agent work explicitly.
+When you create or edit notes as an agent, always set `--source agent`.
+
+4. Respect editorial state.
+If `review_state` is `locked`, do not silently rewrite the note. Create a new derived note instead unless the user explicitly asks to edit it.
+
+5. Preserve provenance.
+For `synthesis` and `output`, set `--derived-from` with the source note IDs or slugs you relied on.
+
+6. Separate durable knowledge from situational output.
+Use `--durability canonical` for notes meant to remain part of the durable knowledge base, `working` for intermediate material, and `ephemeral` for audience-specific outputs.
+
+## Preferred Type Model
+
+Prefer this model unless the user explicitly wants a more specific structured type:
+
+| Situation | Type | Durability |
+|-----------|------|------------|
+| Durable idea or concept | `note` | `canonical` |
+| Imported or observed source material | `source` | `canonical` |
+| Compiled knowledge across multiple notes/sources | `synthesis` | `canonical` |
+| Audience-specific deliverable | `output` | `ephemeral` |
+
+## Read Workflow
+
+Start with this loop:
+
+```bash
+granite types
+granite search "<query>" --json
+granite list --json slug,title,type,review_state,durability
+granite show <slug> --json
+granite backlinks <slug> --json
 ```
-1. Extract   →  identify facts, entities, relationships from conversation
-2. Compare   →  search vault for existing notes about the same entities
-3. Decide    →  ADD (new note), UPDATE (append/edit), or NOOP (skip)
-4. Act       →  create/update, link with [[wikilinks]], verify limits
-```
 
-**Always set `--source agent`** when creating or editing notes as an agent.
+Use `granite suggest-links <slug>` and `granite recommend <slug>` when you need help finding the next connection or note.
 
-## Note Type Decision Tree
+## Write Workflow
 
-| Situation | Type |
-|-----------|------|
-| Quick capture, raw thought | `fleeting` |
-| Refined idea, one concept | `permanent` |
-| External source (article, book, talk) | `reference` |
-| A person you interact with | `person` |
-| Meeting that happened or is planned | `meeting` |
-| Ongoing initiative with goals | `project` |
-| Choice made with rationale | `decision` |
+Use this decision order:
 
-## Line Limits (STRICT)
-
-| Type | Max lines | Enforced | Purpose |
-|------|-----------|----------|---------|
-| `fleeting` | 50 | warn | Raw thought. One sentence or short paragraph. |
-| `permanent` | 200 | hard | One atomic idea. Summary + details + links. |
-| `reference` | 300 | warn | External source. Key points in your own words. |
-| `person` | 150 | warn | Contact card. Role, context, interaction log. |
-| `meeting` | 300 | warn | Attendees, decisions, action items. No fluff. |
-| `project` | 300 | warn | Goal, status, people, key decisions. |
-| `decision` | 200 | hard | Context, options, outcome, rationale. |
-
-If a note exceeds its limit, **split it** into multiple linked notes.
-
-## CLI Reference
+1. Search for an existing note.
+2. If one clearly matches, update it.
+3. If the existing note is stable and your content is derived or contextual, create a new `synthesis` or `output` instead of overwriting it.
+4. If nothing matches, create a new note with the smallest appropriate type.
 
 ### Create
 
 ```bash
-granite new "Note title" -t permanent                      # Create typed note
-granite new "Quick thought"                                # Fleeting note (default)
-granite new "Sprint review" -t meeting --source agent --json  # Agent-created, JSON output
-granite add "Quick thought"                                # Quick-capture fleeting note
-echo "Piped content" | granite add --json                  # Stdin + JSON output
-```
-
-### Read
-
-```bash
-granite show <slug>                          # Display note with header
-granite show <slug> --json                   # Full note as JSON (agent-friendly)
-granite show <slug> --body                   # Raw body only (for piping)
-granite list                                 # All notes, sorted by modified
-granite list -t person                       # Filter by type
-granite list -s active                       # Filter by status
-granite list --source agent                  # Filter by source
-granite list --since 2026-03-01              # Filter by modified date
-granite list --json slug,title,type,status   # Field selection (gh-style)
-granite search "query"                       # Full-text search
-granite search "query" --json                # JSON output
+granite new "New source" --type source --source agent --review-state draft --durability canonical --json
+granite new "Transformer scaling" --type note --source agent --review-state draft --durability canonical --json
+granite new "State of transformer scaling" --type synthesis --source agent --review-state draft --durability canonical --derived-from paper-a,transformer-scaling --json
+granite new "Transformer team brief" --type output --source agent --review-state draft --durability ephemeral --derived-from state-of-transformer-scaling --json
 ```
 
 ### Update
 
 ```bash
-granite edit <slug> --body $'## Section\n\nContent here.'   # Replace body
-granite edit <slug> --append $'- 2026-03-30: Met at conf'   # Append text
-granite edit <slug> --title "New Title"                      # Update title
-granite edit <slug> --tag "tag1,tag2"                        # Add tags
-granite edit <slug> --alias "short-name,abbreviation"        # Add aliases
-granite edit <slug> --status archived                        # Archive a note
-granite edit <slug> --source agent                           # Mark as agent-edited
-granite edit <slug>                                          # Open in $EDITOR
+granite edit <slug> --append $'New paragraph or bullet'
+granite edit <slug> --status archived
+granite edit <slug> --review-state reviewed
+granite edit <slug> --durability canonical
+granite edit <slug> --derived-from note-a,note-b
 ```
 
-### Graph
+## Writing Guidance by Type
 
-```bash
-granite backlinks <slug>              # Who links to this note?
-granite backlinks <slug> --json       # JSON output
-granite suggest-links <slug>          # Find unlinked mentions
-granite suggest-links <slug> --json   # JSON output
-```
+### `note`
 
-### Manage
+- One durable idea per note.
+- Prefer `## Summary`, `## Details`, `## Links`.
+- Link to adjacent concepts instead of adding broad taxonomy.
 
-```bash
-granite init          # Initialize a new vault
-granite types         # List available note types
-granite doctor        # Validate vault health
-granite serve         # Start web UI at localhost:4321
-```
+### `source`
 
-All `--json` commands return `{"success": true, "data": ...}` or `{"success": false, "error": "..."}`.
+- Stay close to the source.
+- Capture a short summary and 2-3 key facts.
+- Do not smuggle a full synthesis into a source note.
 
-## Writing by Type
+Suggested body shape:
 
-### Fleeting
-One sentence. No formatting. Just the raw thought.
-
-```bash
-granite new "Granite could auto-detect note type from content"
-```
-
-Bad: `granite new "I was thinking about how it would be really cool if Granite could maybe analyze what you write and automatically suggest the type"`
-
-### Permanent
-Start with a one-line summary. Use `## Summary`, `## Details`, `## Links` sections.
-
-```
+```md
 ## Summary
 
-Atomic notes outperform long documents for knowledge retention.
+## Key Facts
 
-## Details
+- 
 
-When each note captures one idea, linking creates emergent structure.
-The key is [[wikilinks]] between concepts, not folder hierarchies.
+## Raw Content
 
 ## Links
-
-Related: [[Zettelkasten Method]], [[Knowledge Graphs]]
 ```
 
-### Reference
-Capture source, date, key points in your own words, and your reaction.
+### `synthesis`
 
-```
-## Source
+- Compile multiple notes or sources into durable knowledge.
+- Keep the scope explicit.
+- Use `derived_from` in frontmatter for provenance.
 
-https://example.com/local-first-article
+Suggested body shape:
 
-## Date
+```md
+## Scope
 
-2026-03-30
+## Executive Summary
 
-## Key Points
+## Main Themes
 
-- Data lives on device, not in the cloud
-- Sync is a feature, not a requirement
+## Open Questions
 
-## My Take
-
-This aligns with how [[Granite]] works. See also [[Local-First Software]].
+## Links
 ```
 
-### Person
-Lead with role and context. Add timestamped interaction notes with `--append`.
+### `output`
+
+- Outputs are contextual deliverables, not canonical knowledge.
+- Keep them readable and audience-aware.
+- Link them back to the durable knowledge they came from.
+
+Suggested body shape:
+
+```md
+## Goal
+
+## Audience
+
+## Output
+
+## References
+```
+
+## Field Usage
+
+### `source`
+
+- `human`: created by a person
+- `agent`: created or materially edited by an agent
+- `extraction`: mechanically imported from another source
+
+Always use `agent` when you are the one writing.
+
+### `review_state`
+
+- `draft`: still evolving
+- `reviewed`: checked and stable enough to rely on
+- `locked`: should not be silently rewritten
+
+### `durability`
+
+- `canonical`: durable knowledge
+- `working`: active scratch or intermediate material
+- `ephemeral`: context-specific deliverable
+
+### `derived_from`
+
+Use it when the note is derived from other notes or sources, especially for:
+
+- `synthesis`
+- `output`
+
+## Retrieval Pattern
+
+When the user asks “what do we know about X?”:
 
 ```bash
-granite new "Jane Smith" -t person --json
-granite edit jane-smith --body $'## Role\n\nCTO at Acme Corp\n\n## Context\n\nMet at ReactConf 2026. Working on similar infra.\n\n## Contact\n\nSlack: @jsmith\n\n## Notes\n\n## Links\n'
-granite edit jane-smith --append $'- 2026-03-30: Discussed [[project-x]] migration timeline'
+granite search "X" --json
+granite show <slug> --json
+granite backlinks <slug> --json
 ```
 
-### Meeting
-List attendees as `[[person]]` links. Capture only decisions and actions.
-
-```
-## Attendees
-
-- [[jane-smith]]
-- [[bob-chen]]
-
-## Agenda
-
-- Q2 roadmap review
-
-## Notes
-
-Agreed to focus on API v2 first.
-
-## Decisions
-
-- Prioritize API v2 over dashboard redesign
-
-## Actions
-
-- [ ] [[jane-smith]]: Draft API v2 spec by April 5
-- [ ] [[bob-chen]]: Set up staging environment
-```
-
-### Decision
-State context in one sentence. List options. State what was decided and why.
-
-```
-## Context
-
-Need to choose a database for the new analytics service.
-
-## Options Considered
-
-1. PostgreSQL — proven, team knows it well
-2. ClickHouse — optimized for analytics queries
-
-## Decision
-
-ClickHouse for analytics, PostgreSQL for metadata.
-
-## Rationale
-
-Analytics queries are 10x faster on ClickHouse. Keep PostgreSQL for CRUD.
-Linked to [[analytics-service]] project.
-
-## Status
-
-Active
-```
-
-## Tags and Aliases
-
-**Tags**: lowercase, hyphenated. Use sparingly — prefer `[[wikilinks]]` for relationships.
-- Good: `status/active`, `area/infrastructure`, `priority/high`
-- Bad: using tags to replicate what links already do
-
-**Aliases**: set when a note has common abbreviations or alternate names.
-```bash
-granite edit amazon-web-services --alias "AWS,aws"
-granite edit jane-smith --alias "Jane,jsmith"
-```
-This makes wikilinks resolve correctly: `[[AWS]]` will find the `amazon-web-services` note.
-
-## Status and Source (Provenance)
-
-Every note has `status` and `source` fields in frontmatter:
-
-**Status** — lifecycle state, orthogonal to type:
-- `inbox` — raw capture, needs processing
-- `active` — in use, current (default)
-- `archived` — done, kept for reference
-
-**Source** — who created it:
-- `human` — created by a person (default)
-- `agent` — created by an AI agent
-- `extraction` — extracted from another source
-
-**Trust levels** — when reading notes to inform responses:
-| Combo | Trust |
-|-------|-------|
-| human + permanent | Highest — authoritative knowledge |
-| human + decision | High — established choices |
-| agent + permanent | Medium — verify before citing |
-| human + fleeting | Low — raw, unprocessed |
-| agent + fleeting | Lowest — needs human review |
-
-**Agents must always use `--source agent`** when creating notes:
-```bash
-granite new "Insight from conversation" -t permanent --source agent --json
-```
-
-## Key Patterns
-
-### Capturing a meeting
-
-```bash
-granite search "sprint review" --json           # Check if note exists
-granite new "Sprint review 2026-03-30" -t meeting --source agent --json
-# For each attendee:
-granite search "Jane Smith" --json              # Check if person note exists
-granite new "Jane Smith" -t person --source agent --json  # Create if missing
-# Fill meeting body:
-granite edit sprint-review-2026-03-30 --body $'## Attendees\n\n- [[jane-smith]]\n...'
-# Update person notes:
-granite edit jane-smith --append $'- 2026-03-30: [[sprint-review-2026-03-30]]'
-```
-
-### Recording a decision
-
-```bash
-granite search "database choice" --json
-granite new "Analytics database choice" -t decision --source agent --json
-granite edit analytics-database-choice --body $'## Context\n\n...\n\n## Decision\n\n...\n\n## Status\n\nActive'
-granite edit analytics-database-choice --tag "area/infrastructure"
-granite edit analytics-service --append $'Key decision: [[analytics-database-choice]]'
-```
-
-### Retrieving knowledge
-
-When the user asks "what do I know about X?":
-
-```bash
-granite search "X" --json                    # Find relevant notes
-granite show <slug> --json                   # Read each note's content
-granite backlinks <slug> --json              # Find what links to it
-# Synthesize across results and present to user
-```
-
-### Maintaining the knowledge graph
-
-```bash
-granite suggest-links <slug> --json          # Find unlinked mentions → add links
-granite doctor                               # Check vault health
-# Build hub notes for major topics (permanent notes that are mostly links)
-```
+Then synthesize from the retrieved notes. Do not invent provenance that is not in the vault.
 
 ## Anti-patterns
 
-- **Essays in fleeting notes** — split into permanent notes
-- **Notes without links** — add `[[wikilinks]]` to at least one other note
-- **Vague titles** — be specific: "Auth migration decision" not "Decision"
-- **Duplicating information** — search first, use `--append` on existing notes
-- **Ignoring suggest-links** — if it detects a mention, link it
-- **Tags instead of links** — if it's a relationship, use a `[[wikilink]]`
-- **Creating without searching** — always check if a related note exists first
+- Creating a new note without searching first
+- Rewriting a `locked` note without explicit instruction
+- Using `output` as if it were canonical knowledge
+- Leaving `synthesis` or `output` notes without `derived_from`
+- Leaving a durable note too vague to stand on its own
+- Replacing links with tags when the relationship is explicit
+- Editing a human-authored durable note when a derived note would be safer
+
+## Final Check
+
+Before you finish substantial Granite work, run:
+
+```bash
+granite doctor
+```
+
+If the change is structural or the user asked for verification, also inspect the resulting note with:
+
+```bash
+granite show <slug> --json
+```

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -11,7 +11,7 @@ export function addNote(text?: string, options: { json?: boolean } = {}): void {
   const config = loadConfig(vaultRoot);
   const typeName = config.defaults.note_type;
 
-  let content: string;
+  let content = '';
 
   if (text) {
     content = text;

--- a/src/commands/edit.ts
+++ b/src/commands/edit.ts
@@ -4,7 +4,12 @@ import { loadConfig } from '../core/config.js';
 import { requireVaultRoot } from '../core/vault.js';
 import { findNoteBySlug, readNote } from '../core/note.js';
 import { parseFrontmatter, serializeFrontmatter } from '../core/frontmatter.js';
-import { validateStatus, validateSource } from '../core/json-output.js';
+import {
+  validateDurability,
+  validateReviewState,
+  validateStatus,
+  validateSource,
+} from '../core/json-output.js';
 import { recommendNote, formatRecommendations } from '../core/recommendations.js';
 import { getSyncManager } from '../core/sync/manager.js';
 
@@ -16,6 +21,9 @@ interface EditOptions {
   alias?: string;
   status?: string;
   source?: string;
+  reviewState?: string;
+  durability?: string;
+  derivedFrom?: string;
 }
 
 export function editCommand(slug: string, options: EditOptions): void {
@@ -28,7 +36,16 @@ export function editCommand(slug: string, options: EditOptions): void {
     process.exit(1);
   }
 
-  const hasFlags = options.body !== undefined || options.append !== undefined || options.title !== undefined || options.tag !== undefined || options.alias !== undefined || options.status !== undefined || options.source !== undefined;
+  const hasFlags = options.body !== undefined
+    || options.append !== undefined
+    || options.title !== undefined
+    || options.tag !== undefined
+    || options.alias !== undefined
+    || options.status !== undefined
+    || options.source !== undefined
+    || options.reviewState !== undefined
+    || options.durability !== undefined
+    || options.derivedFrom !== undefined;
 
   if (hasFlags) {
     // Programmatic edit (agent mode)
@@ -60,6 +77,20 @@ export function editCommand(slug: string, options: EditOptions): void {
     if (options.source) {
       validateSource(options.source);
       frontmatter.source = options.source;
+    }
+
+    if (options.reviewState) {
+      validateReviewState(options.reviewState);
+      frontmatter.review_state = options.reviewState;
+    }
+
+    if (options.durability) {
+      validateDurability(options.durability);
+      frontmatter.durability = options.durability;
+    }
+
+    if (options.derivedFrom !== undefined) {
+      frontmatter.derived_from = options.derivedFrom.split(',').map(value => value.trim()).filter(Boolean);
     }
 
     if (options.body !== undefined) {

--- a/src/commands/edit.ts
+++ b/src/commands/edit.ts
@@ -35,6 +35,7 @@ export function editCommand(slug: string, options: EditOptions): void {
     console.error(`Note not found: ${slug}`);
     process.exit(1);
   }
+  const existingNote = note;
 
   const hasFlags = options.body !== undefined
     || options.append !== undefined
@@ -49,7 +50,7 @@ export function editCommand(slug: string, options: EditOptions): void {
 
   if (hasFlags) {
     // Programmatic edit (agent mode)
-    let { frontmatter, body } = parseFrontmatter(fs.readFileSync(note.filepath, 'utf-8'));
+    let { frontmatter, body } = parseFrontmatter(fs.readFileSync(existingNote.filepath, 'utf-8'));
 
     if (options.title) {
       frontmatter.title = options.title;
@@ -102,42 +103,42 @@ export function editCommand(slug: string, options: EditOptions): void {
     }
 
     frontmatter.modified = new Date().toISOString();
-    fs.writeFileSync(note.filepath, serializeFrontmatter(frontmatter, body), 'utf-8');
+    fs.writeFileSync(existingNote.filepath, serializeFrontmatter(frontmatter, body), 'utf-8');
 
     // Transparent sync: track + push in background
     const sync = getSyncManager(vaultRoot, config);
-    const updatedForSync = readNote(note.filepath);
+    const updatedForSync = readNote(existingNote.filepath);
     sync?.trackAndPush(updatedForSync, 'update');
 
-    console.log(note.filepath);
+    console.log(existingNote.filepath);
     const recommendationStrategy = options.title !== undefined || options.alias !== undefined ? 'rebuild' : 'incremental';
-    printRecommendations(vaultRoot, config, note.filepath, recommendationStrategy);
+    printRecommendations(vaultRoot, config, existingNote.filepath, recommendationStrategy);
   } else {
     // Interactive edit (human mode) — open in $EDITOR
     const editor = process.env.EDITOR || 'vi';
-    const statBefore = fs.statSync(note.filepath).mtimeMs;
+    const statBefore = fs.statSync(existingNote.filepath).mtimeMs;
 
     try {
-      execSync(`${editor} "${note.filepath}"`, { stdio: 'inherit' });
+      execSync(`${editor} "${existingNote.filepath}"`, { stdio: 'inherit' });
     } catch {
       console.error(`Failed to open editor: ${editor}`);
       process.exit(1);
     }
 
     // If file was modified, update the modified timestamp in frontmatter
-    const statAfter = fs.statSync(note.filepath).mtimeMs;
+    const statAfter = fs.statSync(existingNote.filepath).mtimeMs;
     if (statAfter !== statBefore) {
-      const { frontmatter, body } = parseFrontmatter(fs.readFileSync(note.filepath, 'utf-8'));
+      const { frontmatter, body } = parseFrontmatter(fs.readFileSync(existingNote.filepath, 'utf-8'));
       frontmatter.modified = new Date().toISOString();
-      fs.writeFileSync(note.filepath, serializeFrontmatter(frontmatter, body), 'utf-8');
+      fs.writeFileSync(existingNote.filepath, serializeFrontmatter(frontmatter, body), 'utf-8');
 
       // Transparent sync: track + push in background
       const sync = getSyncManager(vaultRoot, config);
-      const updatedForSync = readNote(note.filepath);
+      const updatedForSync = readNote(existingNote.filepath);
       sync?.trackAndPush(updatedForSync, 'update');
 
-      console.log(`Updated: ${note.filepath}`);
-      printRecommendations(vaultRoot, config, note.filepath, 'rebuild');
+      console.log(`Updated: ${existingNote.filepath}`);
+      printRecommendations(vaultRoot, config, existingNote.filepath, 'rebuild');
     }
   }
 }

--- a/src/commands/edit.ts
+++ b/src/commands/edit.ts
@@ -70,22 +70,22 @@ export function editCommand(slug: string, options: EditOptions): void {
       frontmatter.aliases = [...existing];
     }
 
-    if (options.status) {
+    if (options.status !== undefined) {
       validateStatus(options.status);
       frontmatter.status = options.status;
     }
 
-    if (options.source) {
+    if (options.source !== undefined) {
       validateSource(options.source);
       frontmatter.source = options.source;
     }
 
-    if (options.reviewState) {
+    if (options.reviewState !== undefined) {
       validateReviewState(options.reviewState);
       frontmatter.review_state = options.reviewState;
     }
 
-    if (options.durability) {
+    if (options.durability !== undefined) {
       validateDurability(options.durability);
       frontmatter.durability = options.durability;
     }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -35,5 +35,5 @@ export function initVault(dir = getDefaultVaultRoot()): void {
     console.log(`  ${typeConfig.folder}/  (${name})`);
   }
   console.log('');
-  console.log('Next: granite new "My first note" --type fleeting');
+  console.log('Next: granite new "My first note" --type note');
 }

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -4,7 +4,7 @@ import { listNotes } from '../core/note.js';
 import { jsonSuccess } from '../core/json-output.js';
 import type { Note } from '../core/types.js';
 
-const AVAILABLE_FIELDS = ['slug', 'title', 'type', 'created', 'modified', 'tags', 'aliases', 'status', 'source', 'filepath'];
+const AVAILABLE_FIELDS = ['slug', 'title', 'type', 'created', 'modified', 'tags', 'aliases', 'status', 'source', 'review_state', 'durability', 'derived_from', 'filepath'];
 
 interface ListOptions {
   type?: string;
@@ -27,6 +27,9 @@ function pickFields(note: Note, fields: string[]): Record<string, unknown> {
       case 'aliases': out.aliases = note.frontmatter.aliases; break;
       case 'status': out.status = note.frontmatter.status; break;
       case 'source': out.source = note.frontmatter.source; break;
+      case 'review_state': out.review_state = note.frontmatter.review_state; break;
+      case 'durability': out.durability = note.frontmatter.durability; break;
+      case 'derived_from': out.derived_from = note.frontmatter.derived_from; break;
       case 'filepath': out.filepath = note.filepath; break;
     }
   }

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -30,7 +30,7 @@ export function newNote(
   const resolvedType = options.type || config.defaults.note_type;
   const typeConfig = config.note_types[resolvedType];
 
-  // For date-slug types (like fleeting), the title IS the content
+  // For date-slug types, the title doubles as the initial body content.
   const bodyOverride = typeConfig?.slug_format === 'date' ? title + '\n' : undefined;
   const note = createNote(vaultRoot, config, resolvedType, title, bodyOverride);
 

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -3,11 +3,28 @@ import { loadConfig } from '../core/config.js';
 import { requireVaultRoot } from '../core/vault.js';
 import { createNote } from '../core/note.js';
 import { parseFrontmatter, serializeFrontmatter } from '../core/frontmatter.js';
-import { jsonSuccess, validateStatus, validateSource } from '../core/json-output.js';
+import {
+  jsonSuccess,
+  validateDurability,
+  validateReviewState,
+  validateStatus,
+  validateSource,
+} from '../core/json-output.js';
 import { recommendNote, formatRecommendations } from '../core/recommendations.js';
 import { getSyncManager } from '../core/sync/manager.js';
 
-export function newNote(title: string, options: { type?: string; source?: string; status?: string; json?: boolean }): void {
+export function newNote(
+  title: string,
+  options: {
+    type?: string;
+    source?: string;
+    status?: string;
+    reviewState?: string;
+    durability?: string;
+    derivedFrom?: string;
+    json?: boolean;
+  },
+): void {
   const vaultRoot = requireVaultRoot();
   const config = loadConfig(vaultRoot);
   const resolvedType = options.type || config.defaults.note_type;
@@ -17,14 +34,21 @@ export function newNote(title: string, options: { type?: string; source?: string
   const bodyOverride = typeConfig?.slug_format === 'date' ? title + '\n' : undefined;
   const note = createNote(vaultRoot, config, resolvedType, title, bodyOverride);
 
-  // Apply source/status overrides
-  if (options.source || options.status) {
+  // Apply frontmatter overrides
+  if (options.source || options.status || options.reviewState || options.durability || options.derivedFrom) {
     if (options.source) validateSource(options.source);
     if (options.status) validateStatus(options.status);
+    if (options.reviewState) validateReviewState(options.reviewState);
+    if (options.durability) validateDurability(options.durability);
     const raw = fs.readFileSync(note.filepath, 'utf-8');
     const { frontmatter, body } = parseFrontmatter(raw);
     if (options.source) frontmatter.source = options.source as typeof frontmatter.source;
     if (options.status) frontmatter.status = options.status as typeof frontmatter.status;
+    if (options.reviewState) frontmatter.review_state = options.reviewState as typeof frontmatter.review_state;
+    if (options.durability) frontmatter.durability = options.durability as typeof frontmatter.durability;
+    if (options.derivedFrom) {
+      frontmatter.derived_from = options.derivedFrom.split(',').map(value => value.trim()).filter(Boolean);
+    }
     fs.writeFileSync(note.filepath, serializeFrontmatter(frontmatter, body), 'utf-8');
     note.frontmatter = frontmatter;
   }
@@ -46,6 +70,9 @@ export function newNote(title: string, options: { type?: string; source?: string
       type: resolvedType,
       status: note.frontmatter.status,
       source: note.frontmatter.source,
+      review_state: note.frontmatter.review_state,
+      durability: note.frontmatter.durability,
+      derived_from: note.frontmatter.derived_from,
       filepath: note.filepath,
       suggestions: recommendations.links.map(link => ({
         slug: link.slug,

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -35,18 +35,24 @@ export function newNote(
   const note = createNote(vaultRoot, config, resolvedType, title, bodyOverride);
 
   // Apply frontmatter overrides
-  if (options.source || options.status || options.reviewState || options.durability || options.derivedFrom) {
-    if (options.source) validateSource(options.source);
-    if (options.status) validateStatus(options.status);
-    if (options.reviewState) validateReviewState(options.reviewState);
-    if (options.durability) validateDurability(options.durability);
+  if (
+    options.source !== undefined ||
+    options.status !== undefined ||
+    options.reviewState !== undefined ||
+    options.durability !== undefined ||
+    options.derivedFrom !== undefined
+  ) {
+    if (options.source !== undefined) validateSource(options.source);
+    if (options.status !== undefined) validateStatus(options.status);
+    if (options.reviewState !== undefined) validateReviewState(options.reviewState);
+    if (options.durability !== undefined) validateDurability(options.durability);
     const raw = fs.readFileSync(note.filepath, 'utf-8');
     const { frontmatter, body } = parseFrontmatter(raw);
-    if (options.source) frontmatter.source = options.source as typeof frontmatter.source;
-    if (options.status) frontmatter.status = options.status as typeof frontmatter.status;
-    if (options.reviewState) frontmatter.review_state = options.reviewState as typeof frontmatter.review_state;
-    if (options.durability) frontmatter.durability = options.durability as typeof frontmatter.durability;
-    if (options.derivedFrom) {
+    if (options.source !== undefined) frontmatter.source = options.source as typeof frontmatter.source;
+    if (options.status !== undefined) frontmatter.status = options.status as typeof frontmatter.status;
+    if (options.reviewState !== undefined) frontmatter.review_state = options.reviewState as typeof frontmatter.review_state;
+    if (options.durability !== undefined) frontmatter.durability = options.durability as typeof frontmatter.durability;
+    if (options.derivedFrom !== undefined) {
       frontmatter.derived_from = options.derivedFrom.split(',').map(value => value.trim()).filter(Boolean);
     }
     fs.writeFileSync(note.filepath, serializeFrontmatter(frontmatter, body), 'utf-8');

--- a/src/commands/open.ts
+++ b/src/commands/open.ts
@@ -12,10 +12,11 @@ export function openNote(slug: string): void {
     console.error(`Note not found: "${slug}"`);
     process.exit(1);
   }
+  const existingNote = note;
 
   const editor = config.defaults.editor === '$EDITOR'
     ? process.env.EDITOR || 'vi'
     : config.defaults.editor;
 
-  execSync(`${editor} "${note.filepath}"`, { stdio: 'inherit' });
+  execSync(`${editor} "${existingNote.filepath}"`, { stdio: 'inherit' });
 }

--- a/src/commands/recommend.ts
+++ b/src/commands/recommend.ts
@@ -17,14 +17,15 @@ export function recommendCommand(slug: string, options: { json?: boolean }): voi
     }
     process.exit(1);
   }
+  const existingNote = note;
 
-  const recommendations = recommendNote(vaultRoot, config, note);
+  const recommendations = recommendNote(vaultRoot, config, existingNote);
 
   if (options.json) {
     console.log(jsonSuccess({
-      slug: note.slug,
-      title: note.frontmatter.title,
-      type: note.frontmatter.type,
+      slug: existingNote.slug,
+      title: existingNote.frontmatter.title,
+      type: existingNote.frontmatter.type,
       recommendations,
     }));
     return;
@@ -32,11 +33,11 @@ export function recommendCommand(slug: string, options: { json?: boolean }): voi
 
   const lines = formatRecommendations(recommendations);
   if (lines.length === 0) {
-    console.log(`No recommendations found for "${note.frontmatter.title}".`);
+    console.log(`No recommendations found for "${existingNote.frontmatter.title}".`);
     return;
   }
 
-  console.log(`Recommendations for "${note.frontmatter.title}":`);
+  console.log(`Recommendations for "${existingNote.frontmatter.title}":`);
   console.log('');
   for (const line of lines) {
     console.log(line);

--- a/src/commands/show.ts
+++ b/src/commands/show.ts
@@ -17,38 +17,39 @@ export function showCommand(slug: string, options: { json?: boolean; body?: bool
     }
     process.exit(1);
   }
+  const existingNote = note;
 
   if (options.json) {
     console.log(jsonSuccess({
-      slug: note.slug,
-      title: note.frontmatter.title,
-      type: note.frontmatter.type,
-      created: note.frontmatter.created,
-      modified: note.frontmatter.modified,
-      tags: note.frontmatter.tags,
-      aliases: note.frontmatter.aliases,
-      status: note.frontmatter.status,
-      source: note.frontmatter.source,
-      review_state: note.frontmatter.review_state,
-      durability: note.frontmatter.durability,
-      derived_from: note.frontmatter.derived_from,
-      body: note.body,
-      filepath: note.filepath,
+      slug: existingNote.slug,
+      title: existingNote.frontmatter.title,
+      type: existingNote.frontmatter.type,
+      created: existingNote.frontmatter.created,
+      modified: existingNote.frontmatter.modified,
+      tags: existingNote.frontmatter.tags,
+      aliases: existingNote.frontmatter.aliases,
+      status: existingNote.frontmatter.status,
+      source: existingNote.frontmatter.source,
+      review_state: existingNote.frontmatter.review_state,
+      durability: existingNote.frontmatter.durability,
+      derived_from: existingNote.frontmatter.derived_from,
+      body: existingNote.body,
+      filepath: existingNote.filepath,
     }));
     return;
   }
 
   if (options.body) {
-    process.stdout.write(note.body);
+    process.stdout.write(existingNote.body);
     return;
   }
 
   // Default: print full file content
-  console.log(`# ${note.frontmatter.title}  (${note.slug})`);
+  console.log(`# ${existingNote.frontmatter.title}  (${existingNote.slug})`);
   console.log(
-    `# type: ${note.frontmatter.type}  |  modified: ${note.frontmatter.modified.slice(0, 10)}  |  review: ${note.frontmatter.review_state}  |  durability: ${note.frontmatter.durability}`,
+    `# type: ${existingNote.frontmatter.type}  |  modified: ${existingNote.frontmatter.modified.slice(0, 10)}  |  review: ${existingNote.frontmatter.review_state}  |  durability: ${existingNote.frontmatter.durability}`,
   );
   console.log('');
-  const content = fs.readFileSync(note.filepath, 'utf-8');
+  const content = fs.readFileSync(existingNote.filepath, 'utf-8');
   console.log(content);
 }

--- a/src/commands/show.ts
+++ b/src/commands/show.ts
@@ -29,6 +29,9 @@ export function showCommand(slug: string, options: { json?: boolean; body?: bool
       aliases: note.frontmatter.aliases,
       status: note.frontmatter.status,
       source: note.frontmatter.source,
+      review_state: note.frontmatter.review_state,
+      durability: note.frontmatter.durability,
+      derived_from: note.frontmatter.derived_from,
       body: note.body,
       filepath: note.filepath,
     }));
@@ -42,7 +45,9 @@ export function showCommand(slug: string, options: { json?: boolean; body?: bool
 
   // Default: print full file content
   console.log(`# ${note.frontmatter.title}  (${note.slug})`);
-  console.log(`# type: ${note.frontmatter.type}  |  modified: ${note.frontmatter.modified.slice(0, 10)}`);
+  console.log(
+    `# type: ${note.frontmatter.type}  |  modified: ${note.frontmatter.modified.slice(0, 10)}  |  review: ${note.frontmatter.review_state}  |  durability: ${note.frontmatter.durability}`,
+  );
   console.log('');
   const content = fs.readFileSync(note.filepath, 'utf-8');
   console.log(content);

--- a/src/commands/suggest-links.ts
+++ b/src/commands/suggest-links.ts
@@ -18,9 +18,10 @@ export function suggestLinksCommand(slug: string, options: { json?: boolean }): 
     }
     process.exit(1);
   }
+  const existingNote = note;
 
   const db = ensureIndex(vaultRoot, config);
-  const suggestions = suggestLinks(db, note);
+  const suggestions = suggestLinks(db, existingNote);
   db.close();
 
   if (options.json) {
@@ -33,7 +34,7 @@ export function suggestLinksCommand(slug: string, options: { json?: boolean }): 
     return;
   }
 
-  console.log(`Suggested links for "${note.frontmatter.title}":`);
+  console.log(`Suggested links for "${existingNote.frontmatter.title}":`);
   console.log('');
   for (const s of suggestions) {
     console.log(`  → [[${s.target_title}]] — ${s.mentions} mention${s.mentions > 1 ? 's' : ''}`);

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -9,20 +9,8 @@ const DEFAULT_CONFIG: GraniteConfig = {
   vault_name: 'My Vault',
   version: 1,
   note_types: {
-    fleeting: {
-      folder: 'notes/fleeting',
-      description: 'Quick captures, inbox items',
-      template: '',
-      line_limit: 50,
-      warn_only: true,
-      slug_format: 'date',
-      instructions: 'Write a short thought, observation, or idea. Keep it raw — refine later into a permanent note.',
-      frontmatter_defaults: {
-        durability: 'working',
-      },
-    },
-    permanent: {
-      folder: 'notes/permanent',
+    note: {
+      folder: 'notes/notes',
       description: 'Refined, linked notes — one idea per note',
       template: '## Summary\n\n## Details\n\n## Links\n',
       line_limit: 200,
@@ -32,87 +20,13 @@ const DEFAULT_CONFIG: GraniteConfig = {
         durability: 'canonical',
       },
     },
-    reference: {
-      folder: 'notes/reference',
-      description: 'Notes on external sources (articles, books, talks)',
-      template: '## Source\n\nURL or citation here.\n\n## Date\n\n## Key Points\n\n- \n\n## My Take\n\n',
-      line_limit: 300,
-      warn_only: true,
-      instructions: 'Capture the source, the key points in your own words, and your reaction. Link to permanent notes that relate.',
-      frontmatter_defaults: {
-        durability: 'canonical',
-      },
-    },
     source: {
       folder: 'notes/sources',
       description: 'Imported or observed source material kept close to the original',
-      template: '## Summary\n\n## Key Facts\n\n- \n\n## Raw Content\n\n## Links\n\n## Agent Trace\n\n- Provenance: \n',
+      template: '## Summary\n\n## Key Facts\n\n- \n\n## Raw Content\n\n## Links\n',
       line_limit: 400,
       warn_only: true,
-      instructions: 'Keep the source close to the original. Capture provenance, key facts, and links to durable notes or syntheses.',
-      frontmatter_defaults: {
-        durability: 'canonical',
-      },
-    },
-    person: {
-      folder: 'notes/people',
-      description: 'Card for a person — contact, context, history',
-      template: '## Role\n\n## Context\n\nHow I know them, what we work on.\n\n## Contact\n\n## Notes\n\n- \n\n## Links\n\n',
-      line_limit: 150,
-      warn_only: true,
-      instructions: 'Fill in their role and context. Add timestamped notes as you interact (meetings, emails, calls). Link to projects, companies, or topics they relate to.',
-      fields: {
-        role: { type: 'text', description: 'Job title or role' },
-        org: { type: 'text', description: 'Organization or company' },
-        contact: { type: 'text', description: 'Email, Slack, phone' },
-      },
-      frontmatter_defaults: {
-        durability: 'canonical',
-      },
-    },
-    meeting: {
-      folder: 'notes/meetings',
-      description: 'Meeting notes with attendees, decisions, and actions',
-      template: '## Attendees\n\n- \n\n## Agenda\n\n- \n\n## Notes\n\n\n\n## Decisions\n\n- \n\n## Actions\n\n- [ ] \n',
-      line_limit: 300,
-      warn_only: true,
-      instructions: 'List attendees as [[person]] links. Capture decisions and action items clearly. Link to relevant projects or topics.',
-      fields: {
-        attendees: { type: 'list', of: 'wikilink', description: 'People present' },
-        date: { type: 'date', description: 'Meeting date' },
-        project: { type: 'wikilink', description: 'Related project' },
-      },
-      frontmatter_defaults: {
-        durability: 'working',
-      },
-    },
-    project: {
-      folder: 'notes/projects',
-      description: 'Project overview — goals, status, people, links',
-      template: '## Goal\n\n## Status\n\n## People\n\n- \n\n## Key Decisions\n\n- \n\n## Links\n\n',
-      line_limit: 300,
-      warn_only: true,
-      instructions: 'Define the goal clearly. Keep status updated. Link to people involved, meeting notes, and related permanent notes.',
-      fields: {
-        people: { type: 'list', of: 'wikilink', description: 'Team members involved' },
-        project_status: { type: 'enum', options: ['planning', 'active', 'paused', 'completed'], default: 'active', description: 'Project lifecycle' },
-      },
-      frontmatter_defaults: {
-        durability: 'canonical',
-      },
-    },
-    decision: {
-      folder: 'notes/decisions',
-      description: 'Record of a decision — context, options, outcome',
-      template: '## Context\n\nWhat prompted this decision.\n\n## Options Considered\n\n1. \n2. \n\n## Decision\n\n\n\n## Rationale\n\n## Status\n\nActive\n',
-      line_limit: 200,
-      warn_only: false,
-      instructions: 'Document the context, what options were considered, what was decided, and why. This is a permanent record — future-you will thank you. Link to the project or topic.',
-      fields: {
-        context_for: { type: 'wikilink', description: 'Project or area this decision belongs to' },
-        decision_status: { type: 'enum', options: ['active', 'superseded', 'revisit'], default: 'active', description: 'Decision lifecycle' },
-        superseded_by: { type: 'wikilink', description: 'Replacement decision if superseded' },
-      },
+      instructions: 'Keep the source close to the original. Capture provenance in frontmatter, summarize the essentials, and link to durable notes or syntheses.',
       frontmatter_defaults: {
         durability: 'canonical',
       },
@@ -120,10 +34,10 @@ const DEFAULT_CONFIG: GraniteConfig = {
     synthesis: {
       folder: 'notes/syntheses',
       description: 'Compiled knowledge that connects multiple notes or sources',
-      template: '## Scope\n\n## Executive Summary\n\n## Main Themes\n\n## Open Questions\n\n## Links\n\n## Agent Trace\n\n- Derived from: \n',
+      template: '## Scope\n\n## Executive Summary\n\n## Main Themes\n\n## Open Questions\n\n## Links\n',
       line_limit: 300,
       warn_only: true,
-      instructions: 'Use syntheses for durable compiled knowledge. Keep scope explicit, link to sources, and record agent trace separately from the main body.',
+      instructions: 'Use syntheses for durable compiled knowledge. Keep the scope explicit, summarize clearly, and point back to the notes or sources in derived_from.',
       frontmatter_defaults: {
         durability: 'canonical',
       },
@@ -131,17 +45,17 @@ const DEFAULT_CONFIG: GraniteConfig = {
     output: {
       folder: 'notes/outputs',
       description: 'Audience-specific outputs such as briefs, reports, or slides',
-      template: '## Goal\n\n## Audience\n\n## Output\n\n## References\n\n## Agent Trace\n\n- Derived from: \n',
+      template: '## Goal\n\n## Audience\n\n## Output\n\n## References\n',
       line_limit: 300,
       warn_only: true,
-      instructions: 'Outputs are situational deliverables. Keep them readable, point back to the durable knowledge they derive from, and make it easy to regenerate or archive them.',
+      instructions: 'Outputs are situational deliverables. Keep them readable, point back to the durable knowledge they derive from, and make them easy to regenerate or archive.',
       frontmatter_defaults: {
         durability: 'ephemeral',
       },
     },
   },
   defaults: {
-    note_type: 'fleeting',
+    note_type: 'note',
     editor: '$EDITOR',
   },
   index: {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -17,6 +17,9 @@ const DEFAULT_CONFIG: GraniteConfig = {
       warn_only: true,
       slug_format: 'date',
       instructions: 'Write a short thought, observation, or idea. Keep it raw — refine later into a permanent note.',
+      frontmatter_defaults: {
+        durability: 'working',
+      },
     },
     permanent: {
       folder: 'notes/permanent',
@@ -25,6 +28,9 @@ const DEFAULT_CONFIG: GraniteConfig = {
       line_limit: 200,
       warn_only: false,
       instructions: 'One atomic idea per note. Write a clear summary, then expand in details. Link to related notes with [[wikilinks]]. If the note grows too long, split it.',
+      frontmatter_defaults: {
+        durability: 'canonical',
+      },
     },
     reference: {
       folder: 'notes/reference',
@@ -33,6 +39,20 @@ const DEFAULT_CONFIG: GraniteConfig = {
       line_limit: 300,
       warn_only: true,
       instructions: 'Capture the source, the key points in your own words, and your reaction. Link to permanent notes that relate.',
+      frontmatter_defaults: {
+        durability: 'canonical',
+      },
+    },
+    source: {
+      folder: 'notes/sources',
+      description: 'Imported or observed source material kept close to the original',
+      template: '## Summary\n\n## Key Facts\n\n- \n\n## Raw Content\n\n## Links\n\n## Agent Trace\n\n- Provenance: \n',
+      line_limit: 400,
+      warn_only: true,
+      instructions: 'Keep the source close to the original. Capture provenance, key facts, and links to durable notes or syntheses.',
+      frontmatter_defaults: {
+        durability: 'canonical',
+      },
     },
     person: {
       folder: 'notes/people',
@@ -45,6 +65,9 @@ const DEFAULT_CONFIG: GraniteConfig = {
         role: { type: 'text', description: 'Job title or role' },
         org: { type: 'text', description: 'Organization or company' },
         contact: { type: 'text', description: 'Email, Slack, phone' },
+      },
+      frontmatter_defaults: {
+        durability: 'canonical',
       },
     },
     meeting: {
@@ -59,6 +82,9 @@ const DEFAULT_CONFIG: GraniteConfig = {
         date: { type: 'date', description: 'Meeting date' },
         project: { type: 'wikilink', description: 'Related project' },
       },
+      frontmatter_defaults: {
+        durability: 'working',
+      },
     },
     project: {
       folder: 'notes/projects',
@@ -70,6 +96,9 @@ const DEFAULT_CONFIG: GraniteConfig = {
       fields: {
         people: { type: 'list', of: 'wikilink', description: 'Team members involved' },
         project_status: { type: 'enum', options: ['planning', 'active', 'paused', 'completed'], default: 'active', description: 'Project lifecycle' },
+      },
+      frontmatter_defaults: {
+        durability: 'canonical',
       },
     },
     decision: {
@@ -83,6 +112,31 @@ const DEFAULT_CONFIG: GraniteConfig = {
         context_for: { type: 'wikilink', description: 'Project or area this decision belongs to' },
         decision_status: { type: 'enum', options: ['active', 'superseded', 'revisit'], default: 'active', description: 'Decision lifecycle' },
         superseded_by: { type: 'wikilink', description: 'Replacement decision if superseded' },
+      },
+      frontmatter_defaults: {
+        durability: 'canonical',
+      },
+    },
+    synthesis: {
+      folder: 'notes/syntheses',
+      description: 'Compiled knowledge that connects multiple notes or sources',
+      template: '## Scope\n\n## Executive Summary\n\n## Main Themes\n\n## Open Questions\n\n## Links\n\n## Agent Trace\n\n- Derived from: \n',
+      line_limit: 300,
+      warn_only: true,
+      instructions: 'Use syntheses for durable compiled knowledge. Keep scope explicit, link to sources, and record agent trace separately from the main body.',
+      frontmatter_defaults: {
+        durability: 'canonical',
+      },
+    },
+    output: {
+      folder: 'notes/outputs',
+      description: 'Audience-specific outputs such as briefs, reports, or slides',
+      template: '## Goal\n\n## Audience\n\n## Output\n\n## References\n\n## Agent Trace\n\n- Derived from: \n',
+      line_limit: 300,
+      warn_only: true,
+      instructions: 'Outputs are situational deliverables. Keep them readable, point back to the durable knowledge they derive from, and make it easy to regenerate or archive them.',
+      frontmatter_defaults: {
+        durability: 'ephemeral',
       },
     },
   },

--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import type Database from 'better-sqlite3';
 import type { GraniteConfig, DoctorIssue } from './types.js';
 import { listNotes } from './note.js';
+import { validateDurability, validateReviewState } from './json-output.js';
 import { parseWikilinks, resolveWikilinks } from './wikilinks.js';
 
 export function runDoctor(vaultRoot: string, config: GraniteConfig, db: Database.Database): DoctorIssue[] {
@@ -35,6 +36,26 @@ export function runDoctor(vaultRoot: string, config: GraniteConfig, db: Database
     }
     if (!fm.created) {
       issues.push({ level: 'warning', file: note.filepath, message: 'Missing frontmatter field: created' });
+    }
+    try {
+      validateReviewState(fm.review_state);
+    } catch (error) {
+      issues.push({ level: 'warning', file: note.filepath, message: (error as Error).message });
+    }
+    try {
+      validateDurability(fm.durability);
+    } catch (error) {
+      issues.push({ level: 'warning', file: note.filepath, message: (error as Error).message });
+    }
+    if (!Array.isArray(fm.derived_from)) {
+      issues.push({ level: 'warning', file: note.filepath, message: 'Invalid derived_from: expected a list of note IDs or slugs' });
+    }
+    if ((fm.type === 'synthesis' || fm.type === 'output') && (!Array.isArray(fm.derived_from) || fm.derived_from.length === 0)) {
+      issues.push({
+        level: 'warning',
+        file: note.filepath,
+        message: `Type "${fm.type}" should declare derived_from to preserve provenance`,
+      });
     }
   }
 

--- a/src/core/frontmatter.ts
+++ b/src/core/frontmatter.ts
@@ -13,6 +13,9 @@ export function parseFrontmatter(content: string): { frontmatter: NoteFrontmatte
     aliases: data.aliases ?? [],
     status: data.status ?? 'active',
     source: data.source ?? 'human',
+    review_state: data.review_state ?? 'draft',
+    durability: data.durability ?? 'working',
+    derived_from: data.derived_from ?? [],
   };
   // Preserve any extra type-specific fields
   for (const [key, value] of Object.entries(data)) {

--- a/src/core/frontmatter.ts
+++ b/src/core/frontmatter.ts
@@ -1,5 +1,12 @@
 import matter from 'gray-matter';
 import type { NoteFrontmatter } from './types.js';
+import {
+  normalizeDurability,
+  normalizeReviewState,
+  normalizeSource,
+  normalizeStatus,
+  normalizeStringArray,
+} from './json-output.js';
 
 export function parseFrontmatter(content: string): { frontmatter: NoteFrontmatter; body: string } {
   const { data, content: body } = matter(content);
@@ -9,13 +16,13 @@ export function parseFrontmatter(content: string): { frontmatter: NoteFrontmatte
     type: toFrontmatterString(data.type),
     created: toFrontmatterString(data.created),
     modified: toFrontmatterString(data.modified),
-    tags: data.tags ?? [],
-    aliases: data.aliases ?? [],
-    status: data.status ?? 'active',
-    source: data.source ?? 'human',
-    review_state: data.review_state ?? 'draft',
-    durability: data.durability ?? 'working',
-    derived_from: data.derived_from ?? [],
+    tags: normalizeStringArray(data.tags),
+    aliases: normalizeStringArray(data.aliases),
+    status: normalizeStatus(data.status),
+    source: normalizeSource(data.source),
+    review_state: normalizeReviewState(data.review_state),
+    durability: normalizeDurability(data.durability),
+    derived_from: normalizeStringArray(data.derived_from),
   };
   // Preserve any extra type-specific fields
   for (const [key, value] of Object.entries(data)) {

--- a/src/core/json-output.ts
+++ b/src/core/json-output.ts
@@ -6,10 +6,10 @@ export function jsonError(error: string): string {
   return JSON.stringify({ success: false, error }, null, 2);
 }
 
-const VALID_STATUSES = ['inbox', 'active', 'archived'] as const;
-const VALID_SOURCES = ['human', 'agent', 'extraction'] as const;
-const VALID_REVIEW_STATES = ['draft', 'reviewed', 'locked'] as const;
-const VALID_DURABILITY = ['canonical', 'working', 'ephemeral'] as const;
+export const VALID_STATUSES = ['inbox', 'active', 'archived'] as const;
+export const VALID_SOURCES = ['human', 'agent', 'extraction'] as const;
+export const VALID_REVIEW_STATES = ['draft', 'reviewed', 'locked'] as const;
+export const VALID_DURABILITY = ['canonical', 'working', 'ephemeral'] as const;
 
 export function validateStatus(value: string): asserts value is 'inbox' | 'active' | 'archived' {
   if (!(VALID_STATUSES as readonly string[]).includes(value)) {
@@ -33,4 +33,24 @@ export function validateDurability(value: string): asserts value is 'canonical' 
   if (!(VALID_DURABILITY as readonly string[]).includes(value)) {
     throw new Error(`Invalid durability: "${value}". Expected one of: ${VALID_DURABILITY.join(', ')}`);
   }
+}
+
+export function normalizeStatus(value: unknown, fallback: 'inbox' | 'active' | 'archived' = 'active'): 'inbox' | 'active' | 'archived' {
+  return typeof value === 'string' && (VALID_STATUSES as readonly string[]).includes(value) ? value as 'inbox' | 'active' | 'archived' : fallback;
+}
+
+export function normalizeSource(value: unknown, fallback: 'human' | 'agent' | 'extraction' = 'human'): 'human' | 'agent' | 'extraction' {
+  return typeof value === 'string' && (VALID_SOURCES as readonly string[]).includes(value) ? value as 'human' | 'agent' | 'extraction' : fallback;
+}
+
+export function normalizeReviewState(value: unknown, fallback: 'draft' | 'reviewed' | 'locked' = 'draft'): 'draft' | 'reviewed' | 'locked' {
+  return typeof value === 'string' && (VALID_REVIEW_STATES as readonly string[]).includes(value) ? value as 'draft' | 'reviewed' | 'locked' : fallback;
+}
+
+export function normalizeDurability(value: unknown, fallback: 'canonical' | 'working' | 'ephemeral' = 'working'): 'canonical' | 'working' | 'ephemeral' {
+  return typeof value === 'string' && (VALID_DURABILITY as readonly string[]).includes(value) ? value as 'canonical' | 'working' | 'ephemeral' : fallback;
+}
+
+export function normalizeStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.map(item => String(item)) : [];
 }

--- a/src/core/json-output.ts
+++ b/src/core/json-output.ts
@@ -8,6 +8,8 @@ export function jsonError(error: string): string {
 
 const VALID_STATUSES = ['inbox', 'active', 'archived'] as const;
 const VALID_SOURCES = ['human', 'agent', 'extraction'] as const;
+const VALID_REVIEW_STATES = ['draft', 'reviewed', 'locked'] as const;
+const VALID_DURABILITY = ['canonical', 'working', 'ephemeral'] as const;
 
 export function validateStatus(value: string): asserts value is 'inbox' | 'active' | 'archived' {
   if (!(VALID_STATUSES as readonly string[]).includes(value)) {
@@ -18,5 +20,17 @@ export function validateStatus(value: string): asserts value is 'inbox' | 'activ
 export function validateSource(value: string): asserts value is 'human' | 'agent' | 'extraction' {
   if (!(VALID_SOURCES as readonly string[]).includes(value)) {
     throw new Error(`Invalid source: "${value}". Expected one of: ${VALID_SOURCES.join(', ')}`);
+  }
+}
+
+export function validateReviewState(value: string): asserts value is 'draft' | 'reviewed' | 'locked' {
+  if (!(VALID_REVIEW_STATES as readonly string[]).includes(value)) {
+    throw new Error(`Invalid review_state: "${value}". Expected one of: ${VALID_REVIEW_STATES.join(', ')}`);
+  }
+}
+
+export function validateDurability(value: string): asserts value is 'canonical' | 'working' | 'ephemeral' {
+  if (!(VALID_DURABILITY as readonly string[]).includes(value)) {
+    throw new Error(`Invalid durability: "${value}". Expected one of: ${VALID_DURABILITY.join(', ')}`);
   }
 }

--- a/src/core/note.ts
+++ b/src/core/note.ts
@@ -42,6 +42,7 @@ export function createNote(
   }
 
   const now = new Date().toISOString();
+  const defaults = typeConfig.frontmatter_defaults ?? {};
   const frontmatter: NoteFrontmatter = {
     id: uuidv4(),
     title,
@@ -50,8 +51,11 @@ export function createNote(
     modified: now,
     tags: [],
     aliases: [],
-    status: 'active',
-    source: 'human',
+    status: defaults.status ?? 'active',
+    source: defaults.source ?? 'human',
+    review_state: defaults.review_state ?? 'draft',
+    durability: defaults.durability ?? 'working',
+    derived_from: defaults.derived_from ?? [],
   };
 
   const body = bodyOverride ?? typeConfig.template;

--- a/src/core/note.ts
+++ b/src/core/note.ts
@@ -3,6 +3,13 @@ import path from 'node:path';
 import { v4 as uuidv4 } from 'uuid';
 import { slugify } from './slugify.js';
 import { parseFrontmatter, serializeFrontmatter } from './frontmatter.js';
+import {
+  normalizeDurability,
+  normalizeReviewState,
+  normalizeSource,
+  normalizeStatus,
+  normalizeStringArray,
+} from './json-output.js';
 import type { GraniteConfig, Note, NoteFrontmatter } from './types.js';
 
 export function createNote(
@@ -51,11 +58,11 @@ export function createNote(
     modified: now,
     tags: [],
     aliases: [],
-    status: defaults.status ?? 'active',
-    source: defaults.source ?? 'human',
-    review_state: defaults.review_state ?? 'draft',
-    durability: defaults.durability ?? 'working',
-    derived_from: defaults.derived_from ?? [],
+    status: normalizeStatus(defaults.status),
+    source: normalizeSource(defaults.source),
+    review_state: normalizeReviewState(defaults.review_state),
+    durability: normalizeDurability(defaults.durability),
+    derived_from: normalizeStringArray(defaults.derived_from),
   };
 
   const body = bodyOverride ?? typeConfig.template;

--- a/src/core/recommendations.ts
+++ b/src/core/recommendations.ts
@@ -16,7 +16,7 @@ const STOP_WORDS = new Set([
   'write', 'notes', 'note', 'links', 'link', 'summary', 'details', 'source', 'date', 'role', 'context',
   'contact', 'attendees', 'agenda', 'decisions', 'actions', 'goal', 'status', 'people', 'rationale',
   'decision', 'options', 'considered', 'active', 'points', 'take', 'idea', 'ideas', 'project', 'meeting',
-  'person', 'reference', 'permanent', 'fleeting', 'how', 'know', 'work', 'works', 'what', 'prompted',
+  'person', 'reference', 'note', 'how', 'know', 'work', 'works', 'what', 'prompted',
   'them', 'what', 'plus', 'latest', 'recent', 'capture', 'record', 'refine', 'later', 'local', 'first',
   'short', 'clear', 'split', 'related', 'relevant', 'title', 'titles',
 ]);
@@ -283,57 +283,36 @@ function getTagRecommendations(note: Note, nearbyNotes: NearbyNote[]): TagRecomm
 }
 
 function getNextSteps(note: Note, nearbyNotes: NearbyNote[]): NextNoteRecommendation[] {
-  const projectLink = nearbyNotes.find(link => link.type === 'project');
-  const personLink = nearbyNotes.find(link => link.type === 'person');
+  const canonicalLink = nearbyNotes.find(link => link.type === 'note' || link.type === 'synthesis');
 
   switch (note.frontmatter.type) {
-    case 'fleeting':
+    case 'source':
       return [{
-        type: 'permanent',
-        title_hint: note.frontmatter.title,
-        reason: 'Promote this into a durable note if it keeps mattering.',
+        type: 'synthesis',
+        title_hint: `${note.frontmatter.title} synthesis`,
+        reason: 'Compile the main ideas from this source into a durable synthesis.',
       }];
-    case 'reference':
+    case 'note':
       return [{
-        type: 'permanent',
-        title_hint: `Idea from ${note.frontmatter.title}`,
-        reason: 'Distill one durable idea from this source.',
+        type: canonicalLink ? 'synthesis' : 'source',
+        title_hint: canonicalLink ? `${note.frontmatter.title} synthesis` : `${note.frontmatter.title} source`,
+        reason: canonicalLink
+          ? 'Compile this durable idea with adjacent notes into a reusable synthesis.'
+          : 'Attach this durable idea to an explicit source or source note.',
       }];
-    case 'person':
+    case 'synthesis':
       return [{
-        type: projectLink ? 'meeting' : 'project',
-        title_hint: projectLink ? `${note.frontmatter.title} + ${projectLink.title}` : `${note.frontmatter.title} collaboration`,
-        reason: projectLink
-          ? 'Capture the latest interaction connected to this person.'
-          : 'Anchor this person to a company, project, or collaboration note.',
+        type: 'output',
+        title_hint: `${note.frontmatter.title} brief`,
+        reason: 'Turn this durable synthesis into a situational output for a specific audience.',
       }];
-    case 'meeting':
+    case 'output':
       return [{
-        type: 'decision',
-        title_hint: `Decision from ${note.frontmatter.title}`,
-        reason: 'Extract the main decision so it can be linked independently.',
-      }];
-    case 'project':
-      return [{
-        type: personLink ? 'meeting' : 'decision',
-        title_hint: personLink ? `${note.frontmatter.title} sync` : `${note.frontmatter.title} decision`,
-        reason: personLink
-          ? 'Capture the next concrete conversation for this project.'
-          : 'Record the decision that drives this project forward.',
-      }];
-    case 'decision':
-      return [{
-        type: 'project',
-        title_hint: `${note.frontmatter.title} rollout`,
-        reason: 'Attach this decision to the project where it applies.',
-      }];
-    case 'permanent':
-      return [{
-        type: projectLink ? 'decision' : 'project',
-        title_hint: projectLink ? `Decision from ${note.frontmatter.title}` : `${note.frontmatter.title} in practice`,
-        reason: projectLink
-          ? 'Capture the concrete decision this idea supports.'
-          : 'Anchor this idea in a project, company, or active thread.',
+        type: canonicalLink ? canonicalLink.type : 'synthesis',
+        title_hint: canonicalLink ? canonicalLink.title : `${note.frontmatter.title} synthesis`,
+        reason: canonicalLink
+          ? 'Link this output back to the durable knowledge it should depend on.'
+          : 'Promote durable insights from this output into a reusable synthesis.',
       }];
     default:
       return [];
@@ -347,72 +326,45 @@ function getAdditionRecommendations(note: Note, config?: GraniteConfig): Additio
   const templateBody = config?.note_types[note.frontmatter.type]?.template ?? '';
 
   switch (note.frontmatter.type) {
-    case 'person':
-      if (isSectionSparse(body, 'Role', templateBody)) {
-        recommendations.push({ text: 'Add a one-line role, company, or why this person matters.' });
+    case 'source':
+      if (isSectionSparse(body, 'Summary', templateBody)) {
+        recommendations.push({ text: 'Write a short summary so this source is understandable without rereading the whole document.' });
       }
-      if (isSectionSparse(body, 'Context', templateBody)) {
-        recommendations.push({ text: 'Add how you know them or what you work on together.' });
-      }
-      if (existingLinks.length === 0) {
-        recommendations.push({ text: 'Link one project, company, or topic in the Links section.' });
-      }
-      break;
-    case 'reference':
-      if (!hasUrl(body) || body.includes('URL or citation here.')) {
-        recommendations.push({ text: 'Add the source URL or citation.' });
-      }
-      if (!hasMeaningfulBullets(body, 'Key Points')) {
-        recommendations.push({ text: 'Write 2-3 key points in your own words.' });
+      if (!hasMeaningfulBullets(body, 'Key Facts')) {
+        recommendations.push({ text: 'Capture 2-3 concrete facts worth preserving from the source.' });
       }
       if (existingLinks.length === 0) {
-        recommendations.push({ text: 'Link one permanent note, project, or topic this source relates to.' });
+        recommendations.push({ text: 'Link one note or synthesis that this source supports.' });
       }
       break;
-    case 'project':
-      if (isSectionSparse(body, 'Goal', templateBody)) {
-        recommendations.push({ text: 'Add a one-line goal so the project has a clear anchor.' });
-      }
-      if (isSectionSparse(body, 'People', templateBody)) {
-        recommendations.push({ text: 'Link the people involved in the project.' });
-      }
-      if (!hasMeaningfulBullets(body, 'Key Decisions')) {
-        recommendations.push({ text: 'Record one key decision or current status update.' });
-      }
-      break;
-    case 'meeting':
-      if (!hasAnyWikilinks(body)) {
-        recommendations.push({ text: 'Link the attendees directly in the note.' });
-      }
-      if (!hasMeaningfulBullets(body, 'Actions')) {
-        recommendations.push({ text: 'Capture at least one next action.' });
-      }
-      if (!hasMeaningfulBullets(body, 'Decisions')) {
-        recommendations.push({ text: 'Capture one decision or open question.' });
-      }
-      break;
-    case 'permanent':
+    case 'note':
       if (isSectionSparse(body, 'Summary', templateBody)) {
         recommendations.push({ text: 'Write a one-line summary before expanding the idea.' });
       }
       if (existingLinks.length === 0) {
-        recommendations.push({ text: 'Link one project, company, person, or adjacent idea.' });
+        recommendations.push({ text: 'Link one source, synthesis, or adjacent durable idea.' });
       }
       break;
-    case 'decision':
-      if (isSectionSparse(body, 'Context', templateBody)) {
-        recommendations.push({ text: 'Add the context that forced this decision.' });
+    case 'synthesis':
+      if (isSectionSparse(body, 'Scope', templateBody)) {
+        recommendations.push({ text: 'Define the scope so this synthesis has a clear boundary.' });
       }
-      if (isSectionSparse(body, 'Decision', templateBody)) {
-        recommendations.push({ text: 'State the decision in one sentence.' });
+      if (isSectionSparse(body, 'Executive Summary', templateBody)) {
+        recommendations.push({ text: 'Write a short executive summary before expanding the synthesis.' });
       }
       if (existingLinks.length === 0) {
-        recommendations.push({ text: 'Link the project, meeting, or note affected by this decision.' });
+        recommendations.push({ text: 'Link the notes or sources this synthesis pulls together.' });
       }
       break;
-    case 'fleeting':
-      if (tokenize(body).length < 8) {
-        recommendations.push({ text: 'Add one more sentence if this capture is worth keeping.' });
+    case 'output':
+      if (isSectionSparse(body, 'Goal', templateBody)) {
+        recommendations.push({ text: 'State the goal so the output is grounded in a concrete need.' });
+      }
+      if (isSectionSparse(body, 'Audience', templateBody)) {
+        recommendations.push({ text: 'Name the audience so the tone and content stay focused.' });
+      }
+      if (existingLinks.length === 0) {
+        recommendations.push({ text: 'Link the source note or synthesis this output derives from.' });
       }
       break;
     default:

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,3 +1,16 @@
+export type NoteStatus = 'inbox' | 'active' | 'archived';
+export type NoteSource = 'human' | 'agent' | 'extraction';
+export type ReviewState = 'draft' | 'reviewed' | 'locked';
+export type Durability = 'canonical' | 'working' | 'ephemeral';
+
+export interface NoteFrontmatterDefaults {
+  status?: NoteStatus;
+  source?: NoteSource;
+  review_state?: ReviewState;
+  durability?: Durability;
+  derived_from?: string[];
+}
+
 export interface NoteTypeConfig {
   folder: string;
   description: string;
@@ -7,6 +20,7 @@ export interface NoteTypeConfig {
   instructions?: string;
   slug_format?: 'title' | 'date';
   fields?: Record<string, FieldDefinition>;
+  frontmatter_defaults?: NoteFrontmatterDefaults;
 }
 
 export interface FieldDefinition {
@@ -49,8 +63,11 @@ export interface NoteFrontmatter {
   modified: string;
   tags: string[];
   aliases: string[];
-  status: 'inbox' | 'active' | 'archived';
-  source: 'human' | 'agent' | 'extraction';
+  status: NoteStatus;
+  source: NoteSource;
+  review_state: ReviewState;
+  durability: Durability;
+  derived_from: string[];
   [key: string]: unknown;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ program
   .command('new')
   .description('Create a new note')
   .argument('<title>', 'Note title')
-  .option('-t, --type <type>', 'Note type (e.g. fleeting, permanent, reference)')
+  .option('-t, --type <type>', 'Note type (e.g. note, source, synthesis, output)')
   .option('--source <source>', 'Set source (human, agent, extraction)')
   .option('--status <status>', 'Set status (inbox, active, archived)')
   .option('--review-state <state>', 'Set review state (draft, reviewed, locked)')
@@ -48,7 +48,7 @@ program
 
 program
   .command('add')
-  .description('Quick-capture a fleeting note (reads stdin if no text given)')
+  .description('Quick-capture a note using the default note type (reads stdin if no text given)')
   .argument('[text]', 'Note text (or pipe via stdin)')
   .option('--json', 'Output as JSON (agent-friendly)')
   .action((text: string | undefined, options: { json?: boolean }) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,8 +38,11 @@ program
   .option('-t, --type <type>', 'Note type (e.g. fleeting, permanent, reference)')
   .option('--source <source>', 'Set source (human, agent, extraction)')
   .option('--status <status>', 'Set status (inbox, active, archived)')
+  .option('--review-state <state>', 'Set review state (draft, reviewed, locked)')
+  .option('--durability <durability>', 'Set durability (canonical, working, ephemeral)')
+  .option('--derived-from <refs>', 'Set derived_from references (comma-separated note IDs or slugs)')
   .option('--json', 'Output as JSON (agent-friendly)')
-  .action((title: string, options: { type?: string; source?: string; status?: string; json?: boolean }) => {
+  .action((title: string, options: { type?: string; source?: string; status?: string; reviewState?: string; durability?: string; derivedFrom?: string; json?: boolean }) => {
     newNote(title, options);
   });
 
@@ -76,7 +79,10 @@ program
   .option('--alias <aliases>', 'Add aliases (comma-separated)')
   .option('--status <status>', 'Set status (inbox, active, archived)')
   .option('--source <source>', 'Set source (human, agent, extraction)')
-  .action((slug: string, options: { body?: string; append?: string; title?: string; tag?: string; alias?: string; status?: string; source?: string }) => {
+  .option('--review-state <state>', 'Set review state (draft, reviewed, locked)')
+  .option('--durability <durability>', 'Set durability (canonical, working, ephemeral)')
+  .option('--derived-from <refs>', 'Set derived_from references (comma-separated note IDs or slugs)')
+  .action((slug: string, options: { body?: string; append?: string; title?: string; tag?: string; alias?: string; status?: string; source?: string; reviewState?: string; durability?: string; derivedFrom?: string }) => {
     editCommand(slug, options);
   });
 

--- a/src/mcp/runtime.ts
+++ b/src/mcp/runtime.ts
@@ -12,18 +12,24 @@ import { suggestLinks } from '../core/suggest.js';
 import type {
   BacklinkEntry,
   DoctorIssue,
+  Durability,
   GraniteConfig,
   Note,
   NoteFrontmatter,
+  NoteSource,
+  NoteStatus,
+  ReviewState,
   SearchResult,
   WikiLink,
 } from '../core/types.js';
 import { parseWikilinks, resolveWikilinks } from '../core/wikilinks.js';
 import { getBacklinks } from '../core/backlinks.js';
-import { validateSource, validateStatus } from '../core/json-output.js';
-
-type NoteStatus = 'inbox' | 'active' | 'archived';
-type NoteSource = 'human' | 'agent' | 'extraction';
+import {
+  validateDurability,
+  validateReviewState,
+  validateSource,
+  validateStatus,
+} from '../core/json-output.js';
 
 interface VaultSignature {
   noteCount: number;
@@ -45,6 +51,9 @@ export interface NoteSummary {
   aliases: string[];
   status: NoteStatus;
   source: NoteSource;
+  review_state: ReviewState;
+  durability: Durability;
+  derived_from: string[];
   filepath: string;
   resource_uri: string;
 }
@@ -92,6 +101,9 @@ export interface CreateNoteInput {
   aliases?: string[];
   status?: NoteStatus;
   source?: NoteSource;
+  review_state?: ReviewState;
+  durability?: Durability;
+  derived_from?: string[];
 }
 
 export interface CaptureNoteInput {
@@ -101,6 +113,9 @@ export interface CaptureNoteInput {
   aliases?: string[];
   status?: NoteStatus;
   source?: NoteSource;
+  review_state?: ReviewState;
+  durability?: Durability;
+  derived_from?: string[];
 }
 
 export interface UpdateNoteInput {
@@ -111,6 +126,9 @@ export interface UpdateNoteInput {
   aliases?: string[];
   status?: NoteStatus;
   source?: NoteSource;
+  review_state?: ReviewState;
+  durability?: Durability;
+  derived_from?: string[];
 }
 
 export interface ListNotesInput {
@@ -280,6 +298,9 @@ export class GraniteMcpRuntime {
       aliases: input.aliases,
       status: input.status,
       source: input.source,
+      review_state: input.review_state,
+      durability: input.durability,
+      derived_from: input.derived_from,
     };
 
     if (hasMetadataMutations(metadataMutations)) {
@@ -306,6 +327,9 @@ export class GraniteMcpRuntime {
       aliases: input.aliases,
       status: input.status,
       source: input.source,
+      review_state: input.review_state,
+      durability: input.durability,
+      derived_from: input.derived_from,
     });
   }
 
@@ -424,6 +448,9 @@ export class GraniteMcpRuntime {
       aliases: note.frontmatter.aliases,
       status: note.frontmatter.status,
       source: note.frontmatter.source,
+      review_state: note.frontmatter.review_state,
+      durability: note.frontmatter.durability,
+      derived_from: note.frontmatter.derived_from,
       filepath: note.filepath,
       resource_uri: this.noteResourceUri(note.slug),
     };
@@ -454,6 +481,20 @@ export class GraniteMcpRuntime {
     if (input.source !== undefined) {
       validateSource(input.source);
       frontmatter.source = input.source;
+    }
+
+    if (input.review_state !== undefined) {
+      validateReviewState(input.review_state);
+      frontmatter.review_state = input.review_state;
+    }
+
+    if (input.durability !== undefined) {
+      validateDurability(input.durability);
+      frontmatter.durability = input.durability;
+    }
+
+    if (input.derived_from !== undefined) {
+      frontmatter.derived_from = [...input.derived_from];
     }
 
     if (input.body !== undefined) {
@@ -561,11 +602,16 @@ function mergeUnique(existing: string[], incoming: string[]): string[] {
   return [...merged];
 }
 
-function hasMetadataMutations(input: Pick<CreateNoteInput, 'tags' | 'aliases' | 'status' | 'source'>): boolean {
+function hasMetadataMutations(
+  input: Pick<CreateNoteInput, 'tags' | 'aliases' | 'status' | 'source' | 'review_state' | 'durability' | 'derived_from'>,
+): boolean {
   return (
     (input.tags?.length ?? 0) > 0 ||
     (input.aliases?.length ?? 0) > 0 ||
     input.status !== undefined ||
-    input.source !== undefined
+    input.source !== undefined ||
+    input.review_state !== undefined ||
+    input.durability !== undefined ||
+    (input.derived_from?.length ?? 0) > 0
   );
 }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -550,7 +550,7 @@ function registerResources(server: McpServer, runtime: GraniteMcpRuntime): void 
 function registerPrompts(server: McpServer, runtime: GraniteMcpRuntime): void {
   server.registerPrompt('granite_refine_note', {
     title: 'Refine Granite Note',
-    description: 'Create a prompt for turning a note into a cleaner permanent note draft.',
+    description: 'Create a prompt for turning a note into a cleaner durable note draft.',
     argsSchema: {
       slug: z.string().describe('Slug of the note to refine.'),
     },
@@ -565,7 +565,7 @@ function registerPrompts(server: McpServer, runtime: GraniteMcpRuntime): void {
           content: {
             type: 'text',
             text: [
-              'Refine the attached Granite note into a durable, well-structured permanent note.',
+              'Refine the attached Granite note into a durable, well-structured note.',
               'Keep the meaning intact, avoid inventing facts, preserve useful wikilinks, and use Granite-style headings when appropriate.',
             ].join(' '),
           },

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -51,6 +51,9 @@ const noteSummarySchema = z.object({
   aliases: z.array(z.string()),
   status: z.enum(['inbox', 'active', 'archived']),
   source: z.enum(['human', 'agent', 'extraction']),
+  review_state: z.enum(['draft', 'reviewed', 'locked']),
+  durability: z.enum(['canonical', 'working', 'ephemeral']),
+  derived_from: z.array(z.string()),
   filepath: z.string(),
   resource_uri: z.string(),
 });
@@ -337,6 +340,9 @@ function registerTools(server: McpServer, runtime: GraniteMcpRuntime): void {
       aliases: z.array(z.string()).optional().describe('Aliases to add immediately.'),
       status: z.enum(['inbox', 'active', 'archived']).optional().describe('Initial note status.'),
       source: z.enum(['human', 'agent', 'extraction']).optional().describe('Initial note source.'),
+      review_state: z.enum(['draft', 'reviewed', 'locked']).optional().describe('Initial review state.'),
+      durability: z.enum(['canonical', 'working', 'ephemeral']).optional().describe('Initial durability.'),
+      derived_from: z.array(z.string()).optional().describe('Source note IDs or slugs this note derives from.'),
     },
     outputSchema: z.object({
       note: noteDetailsSchema,
@@ -358,6 +364,9 @@ function registerTools(server: McpServer, runtime: GraniteMcpRuntime): void {
       aliases: z.array(z.string()).optional().describe('Aliases to add immediately.'),
       status: z.enum(['inbox', 'active', 'archived']).optional().describe('Initial note status.'),
       source: z.enum(['human', 'agent', 'extraction']).optional().describe('Initial note source.'),
+      review_state: z.enum(['draft', 'reviewed', 'locked']).optional().describe('Initial review state.'),
+      durability: z.enum(['canonical', 'working', 'ephemeral']).optional().describe('Initial durability.'),
+      derived_from: z.array(z.string()).optional().describe('Source note IDs or slugs this note derives from.'),
     },
     outputSchema: z.object({
       note: noteDetailsSchema,
@@ -381,6 +390,9 @@ function registerTools(server: McpServer, runtime: GraniteMcpRuntime): void {
       aliases: z.array(z.string()).optional().describe('Aliases to add.'),
       status: z.enum(['inbox', 'active', 'archived']).optional().describe('New note status.'),
       source: z.enum(['human', 'agent', 'extraction']).optional().describe('New note source.'),
+      review_state: z.enum(['draft', 'reviewed', 'locked']).optional().describe('New review state.'),
+      durability: z.enum(['canonical', 'working', 'ephemeral']).optional().describe('New durability.'),
+      derived_from: z.array(z.string()).optional().describe('Source note IDs or slugs this note derives from.'),
     },
     outputSchema: z.object({
       note: noteDetailsSchema,

--- a/src/web/public/graph.js
+++ b/src/web/public/graph.js
@@ -10,8 +10,7 @@ const GraphEngine = (() => {
 
   // ── Type colors ──
   const TYPE_COLORS = {
-    fleeting:   { fill: '#fbbf24', glow: 'rgba(251, 191, 36, 0.3)' },
-    permanent:  { fill: '#a5b4fc', glow: 'rgba(165, 180, 252, 0.3)' },
+    note:       { fill: '#a5b4fc', glow: 'rgba(165, 180, 252, 0.3)' },
     reference:  { fill: '#34d399', glow: 'rgba(52, 211, 153, 0.3)' },
     person:     { fill: '#f9a8d4', glow: 'rgba(249, 168, 212, 0.3)' },
     meeting:    { fill: '#93c5fd', glow: 'rgba(147, 197, 253, 0.3)' },

--- a/src/web/public/style.css
+++ b/src/web/public/style.css
@@ -274,8 +274,7 @@ html, body {
   text-transform: uppercase;
   color: var(--text-2);
 }
-.note-item-type.fleeting { color: #fbbf24; }
-.note-item-type.permanent { color: var(--accent-text); }
+.note-item-type.note { color: var(--accent-text); }
 .note-item-type.reference { color: var(--success); }
 .note-item-type.person { color: #f9a8d4; }
 .note-item-type.meeting { color: #93c5fd; }

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -112,6 +112,7 @@ export function createApp(vaultRoot: string, config: GraniteConfig) {
         created: note.frontmatter.created,
         review_state: note.frontmatter.review_state,
         durability: note.frontmatter.durability,
+        derived_from: note.frontmatter.derived_from,
       });
     } catch (err: any) {
       return c.json({ error: err.message }, 400);

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -54,6 +54,11 @@ export function createApp(vaultRoot: string, config: GraniteConfig) {
       modified: note.frontmatter.modified,
       tags: note.frontmatter.tags,
       aliases: note.frontmatter.aliases,
+      status: note.frontmatter.status,
+      source: note.frontmatter.source,
+      review_state: note.frontmatter.review_state,
+      durability: note.frontmatter.durability,
+      derived_from: note.frontmatter.derived_from,
       body: note.body,
       outgoing_links: resolvedLinks,
       backlinks,
@@ -104,6 +109,8 @@ export function createApp(vaultRoot: string, config: GraniteConfig) {
         title: note.frontmatter.title,
         type: note.frontmatter.type,
         created: note.frontmatter.created,
+        review_state: note.frontmatter.review_state,
+        durability: note.frontmatter.durability,
       });
     } catch (err: any) {
       return c.json({ error: err.message }, 400);

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -3,6 +3,7 @@ import { serveStatic } from '@hono/node-server/serve-static';
 import { serve } from '@hono/node-server';
 import path from 'node:path';
 import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import type { GraniteConfig } from '../core/types.js';
 import { ensureIndex } from '../core/index-db.js';
 import { createNote, findNoteBySlug, listNotes, readNote } from '../core/note.js';
@@ -128,7 +129,7 @@ export function createApp(vaultRoot: string, config: GraniteConfig) {
 
   // Static files — serve from the web/public directory
   // We need to resolve the path relative to where the source files are
-  const publicDir = path.join(import.meta.dirname, 'public');
+  const publicDir = path.join(path.dirname(fileURLToPath(import.meta.url)), 'public');
 
   app.get('/*', (c) => {
     const reqPath = c.req.path === '/' ? '/index.html' : c.req.path;

--- a/test/core/config.test.ts
+++ b/test/core/config.test.ts
@@ -26,10 +26,8 @@ describe('config', () => {
     const config = loadConfig(tmpDir);
     expect(config.vault_name).toBe('My Vault');
     expect(config.version).toBe(1);
-    expect(config.note_types).toHaveProperty('fleeting');
-    expect(config.note_types).toHaveProperty('permanent');
-    expect(config.note_types).toHaveProperty('reference');
-    expect(config.defaults.note_type).toBe('fleeting');
+    expect(Object.keys(config.note_types)).toEqual(['note', 'source', 'synthesis', 'output']);
+    expect(config.defaults.note_type).toBe('note');
   });
 
   it('throws when no config exists', () => {

--- a/test/core/doctor-edge-cases.test.ts
+++ b/test/core/doctor-edge-cases.test.ts
@@ -35,7 +35,7 @@ describe('doctor edge cases', () => {
   }
 
   it('reports missing note-type folders', () => {
-    fs.rmSync(path.join(tmpDir, config.note_types.reference.folder), { recursive: true, force: true });
+    fs.rmSync(path.join(tmpDir, config.note_types.source.folder), { recursive: true, force: true });
 
     const db = getDb(false);
     const issues = runDoctor(tmpDir, config, db);
@@ -45,13 +45,13 @@ describe('doctor edge cases', () => {
   });
 
   it('reports missing frontmatter fields, duplicate slugs, and duplicate ids', () => {
-    const first = createNote(tmpDir, config, 'permanent', 'Shared Title', 'Body.\n');
-    const second = createNote(tmpDir, config, 'reference', 'Another Title', 'Body.\n');
+    const first = createNote(tmpDir, config, 'note', 'Shared Title', 'Body.\n');
+    const second = createNote(tmpDir, config, 'source', 'Another Title', 'Body.\n');
 
     const firstContent = fs.readFileSync(first.filepath, 'utf-8');
     const { frontmatter } = parseFrontmatter(firstContent);
 
-    const duplicateSlugPath = path.join(tmpDir, config.note_types.reference.folder, `${first.slug}.md`);
+    const duplicateSlugPath = path.join(tmpDir, config.note_types.source.folder, `${first.slug}.md`);
     fs.writeFileSync(duplicateSlugPath, serializeFrontmatter(frontmatter, 'Duplicate slug.\n'), 'utf-8');
 
     const secondContent = fs.readFileSync(second.filepath, 'utf-8');

--- a/test/core/doctor.test.ts
+++ b/test/core/doctor.test.ts
@@ -74,4 +74,13 @@ describe('doctor', () => {
     // fleeting is warn_only, so it should be a warning
     expect(limitIssues[0].level).toBe('warning');
   });
+
+  it('warns when a synthesis has no provenance', () => {
+    createNote(tmpDir, config, 'synthesis', 'Synthesis Without Sources', '## Scope\n\nBody.\n');
+    const db = getDb();
+    const issues = runDoctor(tmpDir, config, db);
+    db.close();
+
+    expect(issues.some(issue => issue.message.includes('should declare derived_from'))).toBe(true);
+  });
 });

--- a/test/core/doctor.test.ts
+++ b/test/core/doctor.test.ts
@@ -33,8 +33,8 @@ describe('doctor', () => {
   }
 
   it('reports no issues for a healthy vault', () => {
-    createNote(tmpDir, config, 'permanent', 'A', 'Links to [[B]].\n');
-    createNote(tmpDir, config, 'permanent', 'B', 'Links to [[A]].\n');
+    createNote(tmpDir, config, 'note', 'A', 'Links to [[B]].\n');
+    createNote(tmpDir, config, 'note', 'B', 'Links to [[A]].\n');
     const db = getDb();
     const issues = runDoctor(tmpDir, config, db);
     db.close();
@@ -45,7 +45,7 @@ describe('doctor', () => {
   });
 
   it('detects broken wikilinks', () => {
-    createNote(tmpDir, config, 'permanent', 'Broken Links', 'See [[Ghost Note]] and [[Another Ghost]].\n');
+    createNote(tmpDir, config, 'note', 'Broken Links', 'See [[Ghost Note]] and [[Another Ghost]].\n');
     const db = getDb();
     const issues = runDoctor(tmpDir, config, db);
     db.close();
@@ -54,7 +54,7 @@ describe('doctor', () => {
   });
 
   it('detects orphan notes', () => {
-    createNote(tmpDir, config, 'fleeting', 'Lonely', 'No links here.\n');
+    createNote(tmpDir, config, 'note', 'Lonely', 'No links here.\n');
     const db = getDb();
     const issues = runDoctor(tmpDir, config, db);
     db.close();
@@ -63,16 +63,14 @@ describe('doctor', () => {
   });
 
   it('detects line limit violations', () => {
-    // Fleeting has line_limit: 50
-    const longBody = Array(60).fill('This is a line of text.').join('\n') + '\n';
-    createNote(tmpDir, config, 'fleeting', 'Too Long', longBody);
+    const longBody = Array(220).fill('This is a line of text.').join('\n') + '\n';
+    createNote(tmpDir, config, 'note', 'Too Long', longBody);
     const db = getDb();
     const issues = runDoctor(tmpDir, config, db);
     db.close();
     const limitIssues = issues.filter(i => i.message.includes('exceeds limit'));
     expect(limitIssues).toHaveLength(1);
-    // fleeting is warn_only, so it should be a warning
-    expect(limitIssues[0].level).toBe('warning');
+    expect(limitIssues[0].level).toBe('error');
   });
 
   it('warns when a synthesis has no provenance', () => {

--- a/test/core/doctor.test.ts
+++ b/test/core/doctor.test.ts
@@ -79,6 +79,8 @@ describe('doctor', () => {
     const issues = runDoctor(tmpDir, config, db);
     db.close();
 
-    expect(issues.some(issue => issue.message.includes('should declare derived_from'))).toBe(true);
+    const provenanceIssues = issues.filter(issue => issue.message.includes('should declare derived_from'));
+    expect(provenanceIssues).toHaveLength(1);
+    expect(provenanceIssues[0].level).toBe('warning');
   });
 });

--- a/test/core/frontmatter.test.ts
+++ b/test/core/frontmatter.test.ts
@@ -27,6 +27,8 @@ This is the body.
     expect(frontmatter.type).toBe('note');
     expect(frontmatter.tags).toEqual(['test', 'demo']);
     expect(frontmatter.aliases).toEqual(['my-test']);
+    expect(frontmatter.status).toBe('active');
+    expect(frontmatter.source).toBe('human');
     expect(frontmatter.review_state).toBe('draft');
     expect(frontmatter.durability).toBe('working');
     expect(frontmatter.derived_from).toEqual([]);
@@ -61,10 +63,38 @@ This is the body.
     expect(parsed.title).toBe(fm.title);
     expect(parsed.type).toBe(fm.type);
     expect(parsed.tags).toEqual(fm.tags);
+    expect(parsed.status).toBe('active');
+    expect(parsed.source).toBe('human');
     expect(parsed.review_state).toBe('reviewed');
     expect(parsed.durability).toBe('canonical');
     expect(parsed.derived_from).toEqual(['src-1']);
     expect(parsedBody).toContain('Some content here.');
+  });
+
+  it('normalizes invalid protocol metadata from yaml', () => {
+    const invalid = `---
+id: "bad"
+title: Bad Metadata
+type: note
+status: wrong
+source: false
+review_state: nope
+durability: 123
+derived_from: source-1
+tags: tag
+aliases: alias
+---
+
+Body.
+`;
+    const { frontmatter } = parseFrontmatter(invalid);
+    expect(frontmatter.status).toBe('active');
+    expect(frontmatter.source).toBe('human');
+    expect(frontmatter.review_state).toBe('draft');
+    expect(frontmatter.durability).toBe('working');
+    expect(frontmatter.derived_from).toEqual([]);
+    expect(frontmatter.tags).toEqual([]);
+    expect(frontmatter.aliases).toEqual([]);
   });
 
   it('handles missing optional fields gracefully', () => {

--- a/test/core/frontmatter.test.ts
+++ b/test/core/frontmatter.test.ts
@@ -6,7 +6,7 @@ describe('frontmatter', () => {
   const sampleContent = `---
 id: "abc-123"
 title: Test Note
-type: fleeting
+type: note
 created: "2026-03-30T10:00:00.000Z"
 modified: "2026-03-30T10:00:00.000Z"
 tags:
@@ -24,7 +24,7 @@ This is the body.
     const { frontmatter, body } = parseFrontmatter(sampleContent);
     expect(frontmatter.id).toBe('abc-123');
     expect(frontmatter.title).toBe('Test Note');
-    expect(frontmatter.type).toBe('fleeting');
+    expect(frontmatter.type).toBe('note');
     expect(frontmatter.tags).toEqual(['test', 'demo']);
     expect(frontmatter.aliases).toEqual(['my-test']);
     expect(frontmatter.review_state).toBe('draft');
@@ -42,7 +42,7 @@ This is the body.
     const fm: NoteFrontmatter = {
       id: 'xyz-456',
       title: 'Round Trip',
-      type: 'permanent',
+      type: 'note',
       created: '2026-01-01T00:00:00.000Z',
       modified: '2026-01-01T00:00:00.000Z',
       tags: ['a'],

--- a/test/core/frontmatter.test.ts
+++ b/test/core/frontmatter.test.ts
@@ -27,6 +27,9 @@ This is the body.
     expect(frontmatter.type).toBe('fleeting');
     expect(frontmatter.tags).toEqual(['test', 'demo']);
     expect(frontmatter.aliases).toEqual(['my-test']);
+    expect(frontmatter.review_state).toBe('draft');
+    expect(frontmatter.durability).toBe('working');
+    expect(frontmatter.derived_from).toEqual([]);
   });
 
   it('extracts body without frontmatter', () => {
@@ -44,6 +47,11 @@ This is the body.
       modified: '2026-01-01T00:00:00.000Z',
       tags: ['a'],
       aliases: [],
+      status: 'active',
+      source: 'human',
+      review_state: 'reviewed',
+      durability: 'canonical',
+      derived_from: ['src-1'],
     };
     const body = 'Some content here.\n';
     const serialized = serializeFrontmatter(fm, body);
@@ -53,6 +61,9 @@ This is the body.
     expect(parsed.title).toBe(fm.title);
     expect(parsed.type).toBe(fm.type);
     expect(parsed.tags).toEqual(fm.tags);
+    expect(parsed.review_state).toBe('reviewed');
+    expect(parsed.durability).toBe('canonical');
+    expect(parsed.derived_from).toEqual(['src-1']);
     expect(parsedBody).toContain('Some content here.');
   });
 
@@ -69,5 +80,8 @@ Body.
     expect(frontmatter.tags).toEqual([]);
     expect(frontmatter.aliases).toEqual([]);
     expect(frontmatter.type).toBe('');
+    expect(frontmatter.review_state).toBe('draft');
+    expect(frontmatter.durability).toBe('working');
+    expect(frontmatter.derived_from).toEqual([]);
   });
 });

--- a/test/core/index-db-incremental.test.ts
+++ b/test/core/index-db-incremental.test.ts
@@ -38,9 +38,9 @@ describe('index-db incremental flows', () => {
   });
 
   it('syncs a single note incrementally and resolves alias links', () => {
-    createNote(tmpDir, config, 'permanent', 'Target Note', 'Target.\n');
+    createNote(tmpDir, config, 'note', 'Target Note', 'Target.\n');
 
-    const targetPath = path.join(tmpDir, config.note_types.permanent.folder, 'target-note.md');
+    const targetPath = path.join(tmpDir, config.note_types.note.folder, 'target-note.md');
     const targetContent = fs.readFileSync(targetPath, 'utf-8');
     fs.writeFileSync(
       targetPath,
@@ -48,7 +48,7 @@ describe('index-db incremental flows', () => {
       'utf-8',
     );
 
-    const draft = createNote(tmpDir, config, 'permanent', 'Draft', 'Start.\n');
+    const draft = createNote(tmpDir, config, 'note', 'Draft', 'Start.\n');
 
     const db = createDatabase(path.join(tmpDir, '.granite', 'index.db'));
     rebuildIndex(tmpDir, config, db);
@@ -73,8 +73,8 @@ describe('index-db incremental flows', () => {
   });
 
   it('rebuilds the whole index when note counts drift from disk', () => {
-    const keep = createNote(tmpDir, config, 'permanent', 'Keep', 'Still here.\n');
-    const remove = createNote(tmpDir, config, 'permanent', 'Remove', 'Will be deleted.\n');
+    const keep = createNote(tmpDir, config, 'note', 'Keep', 'Still here.\n');
+    const remove = createNote(tmpDir, config, 'note', 'Remove', 'Will be deleted.\n');
 
     const db = createDatabase(path.join(tmpDir, '.granite', 'index.db'));
     rebuildIndex(tmpDir, config, db);
@@ -93,9 +93,9 @@ describe('index-db incremental flows', () => {
   });
 
   it('keeps malformed alias JSON from crashing link resolution', () => {
-    createNote(tmpDir, config, 'permanent', 'Target Note', 'Target.\n');
+    createNote(tmpDir, config, 'note', 'Target Note', 'Target.\n');
 
-    const targetPath = path.join(tmpDir, config.note_types.permanent.folder, 'target-note.md');
+    const targetPath = path.join(tmpDir, config.note_types.note.folder, 'target-note.md');
     const targetContent = fs.readFileSync(targetPath, 'utf-8');
     const parsed = parseFrontmatter(targetContent);
     parsed.frontmatter.aliases = [] as string[];
@@ -109,7 +109,7 @@ describe('index-db incremental flows', () => {
     rebuildIndex(tmpDir, config, db);
     db.prepare('UPDATE notes SET aliases = ? WHERE slug = ?').run('not-json', 'target-note');
 
-    const note = createNote(tmpDir, config, 'permanent', 'Draft', 'Link to [[Target Note]].\n');
+    const note = createNote(tmpDir, config, 'note', 'Draft', 'Link to [[Target Note]].\n');
     syncNoteInIndex(tmpDir, config, db, readNote(note.filepath));
 
     const link = db.prepare('SELECT target_slug FROM links WHERE source_slug = ?').get('draft') as { target_slug: string };

--- a/test/core/index-db.test.ts
+++ b/test/core/index-db.test.ts
@@ -38,8 +38,8 @@ describe('index-db', () => {
   });
 
   it('indexes notes and makes them searchable', () => {
-    createNote(tmpDir, config, 'permanent', 'Machine Learning', 'ML is about training models on data.\n');
-    createNote(tmpDir, config, 'permanent', 'Neural Networks', 'Neural nets are a type of [[Machine Learning]] model.\n');
+    createNote(tmpDir, config, 'note', 'Machine Learning', 'ML is about training models on data.\n');
+    createNote(tmpDir, config, 'note', 'Neural Networks', 'Neural nets are a type of [[Machine Learning]] model.\n');
 
     const dbPath = path.join(tmpDir, '.granite', 'index.db');
     const db = createDatabase(dbPath);
@@ -58,8 +58,8 @@ describe('index-db', () => {
   });
 
   it('indexes links between notes', () => {
-    createNote(tmpDir, config, 'permanent', 'Note A', 'Links to [[Note B]] here.\n');
-    createNote(tmpDir, config, 'permanent', 'Note B', 'This is note B.\n');
+    createNote(tmpDir, config, 'note', 'Note A', 'Links to [[Note B]] here.\n');
+    createNote(tmpDir, config, 'note', 'Note B', 'This is note B.\n');
 
     const dbPath = path.join(tmpDir, '.granite', 'index.db');
     const db = createDatabase(dbPath);
@@ -75,8 +75,8 @@ describe('index-db', () => {
   });
 
   it('backlinks query returns correct results', () => {
-    createNote(tmpDir, config, 'permanent', 'Source', 'See [[Target]] for details.\n');
-    createNote(tmpDir, config, 'permanent', 'Target', 'I am the target.\n');
+    createNote(tmpDir, config, 'note', 'Source', 'See [[Target]] for details.\n');
+    createNote(tmpDir, config, 'note', 'Target', 'I am the target.\n');
 
     const dbPath = path.join(tmpDir, '.granite', 'index.db');
     const db = createDatabase(dbPath);
@@ -91,7 +91,7 @@ describe('index-db', () => {
   });
 
   it('handles broken links gracefully', () => {
-    createNote(tmpDir, config, 'permanent', 'Broken', 'Links to [[Nonexistent]] page.\n');
+    createNote(tmpDir, config, 'note', 'Broken', 'Links to [[Nonexistent]] page.\n');
 
     const dbPath = path.join(tmpDir, '.granite', 'index.db');
     const db = createDatabase(dbPath);

--- a/test/core/note.test.ts
+++ b/test/core/note.test.ts
@@ -49,6 +49,23 @@ describe('note', () => {
     expect(note.body).toBe('Custom body text\n');
   });
 
+  it('normalizes invalid frontmatter defaults from config', () => {
+    config.note_types.note.frontmatter_defaults = {
+      status: 'bad-status' as any,
+      source: 'bad-source' as any,
+      review_state: 'bad-review' as any,
+      durability: 'bad-durability' as any,
+      derived_from: 'bad-derived' as any,
+    };
+
+    const note = createNote(tmpDir, config, 'note', 'Normalized Defaults');
+    expect(note.frontmatter.status).toBe('active');
+    expect(note.frontmatter.source).toBe('human');
+    expect(note.frontmatter.review_state).toBe('draft');
+    expect(note.frontmatter.durability).toBe('working');
+    expect(note.frontmatter.derived_from).toEqual([]);
+  });
+
   it('handles slug collision', () => {
     const note1 = createNote(tmpDir, config, 'note', 'Duplicate');
     const note2 = createNote(tmpDir, config, 'note', 'Duplicate');

--- a/test/core/note.test.ts
+++ b/test/core/note.test.ts
@@ -30,6 +30,9 @@ describe('note', () => {
     expect(note.frontmatter.title).toBe('My Test Note');
     expect(note.frontmatter.type).toBe('permanent');
     expect(note.frontmatter.id).toBeTruthy();
+    expect(note.frontmatter.review_state).toBe('draft');
+    expect(note.frontmatter.durability).toBe('canonical');
+    expect(note.frontmatter.derived_from).toEqual([]);
     expect(fs.existsSync(note.filepath)).toBe(true);
   });
 
@@ -38,6 +41,7 @@ describe('note', () => {
     expect(note.slug).toMatch(/^\d{4}-\d{2}-\d{2}-[a-z0-9]{4}$/);
     expect(note.frontmatter.title).toBe('Quick thought');
     expect(note.frontmatter.type).toBe('fleeting');
+    expect(note.frontmatter.durability).toBe('working');
   });
 
   it('creates a note with custom body', () => {

--- a/test/core/note.test.ts
+++ b/test/core/note.test.ts
@@ -25,10 +25,10 @@ describe('note', () => {
   });
 
   it('creates a note with correct frontmatter', () => {
-    const note = createNote(tmpDir, config, 'permanent', 'My Test Note');
+    const note = createNote(tmpDir, config, 'note', 'My Test Note');
     expect(note.slug).toBe('my-test-note');
     expect(note.frontmatter.title).toBe('My Test Note');
-    expect(note.frontmatter.type).toBe('permanent');
+    expect(note.frontmatter.type).toBe('note');
     expect(note.frontmatter.id).toBeTruthy();
     expect(note.frontmatter.review_state).toBe('draft');
     expect(note.frontmatter.durability).toBe('canonical');
@@ -36,22 +36,22 @@ describe('note', () => {
     expect(fs.existsSync(note.filepath)).toBe(true);
   });
 
-  it('creates a fleeting note with date-based slug', () => {
-    const note = createNote(tmpDir, config, 'fleeting', 'Quick thought');
-    expect(note.slug).toMatch(/^\d{4}-\d{2}-\d{2}-[a-z0-9]{4}$/);
+  it('creates a default note with title-based slug', () => {
+    const note = createNote(tmpDir, config, 'note', 'Quick thought');
+    expect(note.slug).toBe('quick-thought');
     expect(note.frontmatter.title).toBe('Quick thought');
-    expect(note.frontmatter.type).toBe('fleeting');
-    expect(note.frontmatter.durability).toBe('working');
+    expect(note.frontmatter.type).toBe('note');
+    expect(note.frontmatter.durability).toBe('canonical');
   });
 
   it('creates a note with custom body', () => {
-    const note = createNote(tmpDir, config, 'permanent', 'Quick', 'Custom body text\n');
+    const note = createNote(tmpDir, config, 'note', 'Quick', 'Custom body text\n');
     expect(note.body).toBe('Custom body text\n');
   });
 
   it('handles slug collision', () => {
-    const note1 = createNote(tmpDir, config, 'permanent', 'Duplicate');
-    const note2 = createNote(tmpDir, config, 'permanent', 'Duplicate');
+    const note1 = createNote(tmpDir, config, 'note', 'Duplicate');
+    const note2 = createNote(tmpDir, config, 'note', 'Duplicate');
     expect(note1.slug).toBe('duplicate');
     expect(note2.slug).toBe('duplicate-2');
   });
@@ -61,23 +61,23 @@ describe('note', () => {
   });
 
   it('reads a note back correctly', () => {
-    const created = createNote(tmpDir, config, 'permanent', 'Readable');
+    const created = createNote(tmpDir, config, 'note', 'Readable');
     const read = readNote(created.filepath);
     expect(read.slug).toBe('readable');
     expect(read.frontmatter.title).toBe('Readable');
-    expect(read.frontmatter.type).toBe('permanent');
+    expect(read.frontmatter.type).toBe('note');
   });
 
   it('lists all notes across types', () => {
-    createNote(tmpDir, config, 'fleeting', 'Note A');
-    createNote(tmpDir, config, 'permanent', 'Note B');
-    createNote(tmpDir, config, 'reference', 'Note C');
+    createNote(tmpDir, config, 'note', 'Note A');
+    createNote(tmpDir, config, 'note', 'Note B');
+    createNote(tmpDir, config, 'source', 'Note C');
     const notes = listNotes(tmpDir, config);
     expect(notes).toHaveLength(3);
   });
 
   it('finds a note by slug', () => {
-    createNote(tmpDir, config, 'permanent', 'Findable Note');
+    createNote(tmpDir, config, 'note', 'Findable Note');
     const found = findNoteBySlug(tmpDir, config, 'findable-note');
     expect(found).not.toBeNull();
     expect(found!.frontmatter.title).toBe('Findable Note');

--- a/test/core/querying.test.ts
+++ b/test/core/querying.test.ts
@@ -29,7 +29,7 @@ describe('querying helpers', () => {
   });
 
   it('returns normalized search results with snippet and score', () => {
-    createNote(tmpDir, config, 'permanent', 'Graph Memory', 'A graph memory stores linked ideas.\n');
+    createNote(tmpDir, config, 'note', 'Graph Memory', 'A graph memory stores linked ideas.\n');
 
     const db = createDatabase(path.join(tmpDir, '.granite', 'index.db'));
     rebuildIndex(tmpDir, config, db);
@@ -47,9 +47,9 @@ describe('querying helpers', () => {
   });
 
   it('returns backlinks sorted by source title', () => {
-    createNote(tmpDir, config, 'permanent', 'Zulu Source', 'Points to [[Target Note]].\n');
-    createNote(tmpDir, config, 'permanent', 'Alpha Source', 'Also points to [[Target Note]].\n');
-    createNote(tmpDir, config, 'permanent', 'Target Note', 'Referenced note.\n');
+    createNote(tmpDir, config, 'note', 'Zulu Source', 'Points to [[Target Note]].\n');
+    createNote(tmpDir, config, 'note', 'Alpha Source', 'Also points to [[Target Note]].\n');
+    createNote(tmpDir, config, 'note', 'Target Note', 'Referenced note.\n');
 
     const db = createDatabase(path.join(tmpDir, '.granite', 'index.db'));
     rebuildIndex(tmpDir, config, db);
@@ -61,10 +61,10 @@ describe('querying helpers', () => {
   });
 
   it('suggests notes mentioned in body and skips existing wikilinks', () => {
-    createNote(tmpDir, config, 'permanent', 'Machine Learning', 'Base concept.\n');
-    createNote(tmpDir, config, 'permanent', 'Large Language Model', 'Alias-heavy concept.\n');
+    createNote(tmpDir, config, 'note', 'Machine Learning', 'Base concept.\n');
+    createNote(tmpDir, config, 'note', 'Large Language Model', 'Alias-heavy concept.\n');
 
-    const llmNotePath = path.join(tmpDir, config.note_types.permanent.folder, 'large-language-model.md');
+    const llmNotePath = path.join(tmpDir, config.note_types.note.folder, 'large-language-model.md');
     const llmContent = fs.readFileSync(llmNotePath, 'utf-8');
     fs.writeFileSync(
       llmNotePath,
@@ -75,7 +75,7 @@ describe('querying helpers', () => {
     const current = createNote(
       tmpDir,
       config,
-      'permanent',
+      'note',
       'Draft Note',
       [
         'Machine learning appears twice.',

--- a/test/core/recommendations.test.ts
+++ b/test/core/recommendations.test.ts
@@ -28,21 +28,18 @@ describe('recommendations', () => {
   });
 
   it('recommends linked notes, tags, and a next step from local context', () => {
-    const granite = createNote(tmpDir, config, 'project', 'Granite', 'Granite is a local-first memory tool.\n');
-    setTags(granite.filepath, ['local-first', 'knowledge-base']);
+    const source = createNote(tmpDir, config, 'source', 'Attention Is All You Need', 'Transformer source note.\n');
+    setTags(source.filepath, ['transformers', 'attention']);
 
-    const githubSeo = createNote(tmpDir, config, 'reference', 'GitHub SEO', 'Repository discoverability on GitHub.\n');
-    setTags(githubSeo.filepath, ['github', 'seo']);
-
-    const stan = createNote(tmpDir, config, 'person', 'Stan Girard', 'Builder behind Granite and GitHub SEO.\n');
-    setTags(stan.filepath, ['founder', 'open-source']);
+    const synthesis = createNote(tmpDir, config, 'synthesis', 'Transformer Architecture', 'Compiled view of transformers.\n');
+    setTags(synthesis.filepath, ['transformers', 'architecture']);
 
     const note = createNote(
       tmpDir,
       config,
-      'reference',
-      'Launch notes',
-      'Granite should benefit from GitHub SEO. Stan Girard wrote about it.\n',
+      'source',
+      'Scaling source',
+      'Transformer architecture and attention patterns matter for scaling.\n',
     );
 
     const db = createDatabase(path.join(tmpDir, '.granite', 'index.db'));
@@ -52,47 +49,47 @@ describe('recommendations', () => {
     db.close();
 
     expect(recommendations.links.map(link => link.slug)).toEqual(
-      expect.arrayContaining(['granite', 'github-seo', 'stan-girard']),
+      expect.arrayContaining(['attention-is-all-you-need', 'transformer-architecture']),
     );
-    expect(recommendations.links.some(link => link.reason.includes('mentioned'))).toBe(true);
+    expect(recommendations.links.some(link => link.reason.includes('mentioned') || link.source === 'search')).toBe(true);
     expect(recommendations.additions.map(item => item.text)).toEqual(
       expect.arrayContaining([
-        'Add the source URL or citation.',
-        'Write 2-3 key points in your own words.',
+        'Write a short summary so this source is understandable without rereading the whole document.',
+        'Capture 2-3 concrete facts worth preserving from the source.',
       ]),
     );
     expect(recommendations.tags.map(tag => tag.tag)).toEqual(
-      expect.arrayContaining(['github', 'seo']),
+      expect.arrayContaining(['transformers', 'attention']),
     );
     expect(recommendations.next_steps[0]).toMatchObject({
-      type: 'permanent',
-      title_hint: 'Idea from Launch notes',
+      type: 'synthesis',
+      title_hint: 'Scaling source synthesis',
     });
   });
 
   it('recommends related notes through local search when no title is mentioned exactly', () => {
-    const semantic = createNote(
+    const source = createNote(
       tmpDir,
       config,
-      'permanent',
-      'Semantic Search',
+      'source',
+      'Semantic Search Source',
       'Semantic retrieval helps a note system find related ideas.\n',
     );
-    setTags(semantic.filepath, ['search']);
+    setTags(source.filepath, ['search']);
 
-    const vectors = createNote(
+    const synthesis = createNote(
       tmpDir,
       config,
-      'permanent',
+      'synthesis',
       'Embeddings for Notes',
       'Vector retrieval improves knowledge discovery in a note vault.\n',
     );
-    setTags(vectors.filepath, ['embeddings']);
+    setTags(synthesis.filepath, ['embeddings']);
 
     const target = createNote(
       tmpDir,
       config,
-      'permanent',
+      'note',
       'Semantic retrieval for a vault',
       'A local note system should surface related knowledge quickly.\n',
     );
@@ -105,19 +102,19 @@ describe('recommendations', () => {
 
     expect(recommendations.links.some(link => link.source === 'search')).toBe(true);
     expect(recommendations.links.map(link => link.slug)).toEqual(
-      expect.arrayContaining(['semantic-search', 'embeddings-for-notes']),
+      expect.arrayContaining(['semantic-search-source', 'embeddings-for-notes']),
     );
     expect(recommendations.tags.map(tag => tag.tag)).toContain('search');
   });
 
   it('does not re-suggest notes that are already linked', () => {
-    createNote(tmpDir, config, 'person', 'Stan Girard', 'Builder.\n');
+    createNote(tmpDir, config, 'source', 'Attention Source', 'Core source.\n');
     const launch = createNote(
       tmpDir,
       config,
-      'permanent',
+      'note',
       'Launch note',
-      'We worked with [[Stan Girard]] on Granite.\n',
+      'We should revisit [[Attention Source]] before publishing.\n',
     );
 
     const db = createDatabase(path.join(tmpDir, '.granite', 'index.db'));
@@ -126,47 +123,7 @@ describe('recommendations', () => {
     const recommendations = getRecommendations(db, readNote(launch.filepath), config);
     db.close();
 
-    expect(recommendations.links.map(link => link.slug)).not.toContain('stan-girard');
-  });
-
-  it('uses existing linked notes to improve next-step recommendations', () => {
-    createNote(tmpDir, config, 'project', 'Granite', 'Granite is a local-first memory system.\n');
-    const stan = createNote(
-      tmpDir,
-      config,
-      'person',
-      'Stan Girard',
-      '## Role\n\nBuilder behind Granite.\n\n## Context\n\nWorks on Granite.\n\n## Links\n\n- [[granite]]\n',
-    );
-
-    const db = createDatabase(path.join(tmpDir, '.granite', 'index.db'));
-    rebuildIndex(tmpDir, config, db);
-
-    const recommendations = getRecommendations(db, readNote(stan.filepath), config);
-    db.close();
-
-    expect(recommendations.next_steps[0]).toMatchObject({
-      type: 'meeting',
-      title_hint: 'Stan Girard + Granite',
-    });
-  });
-
-  it('gives add-now guidance for a newly created person card', () => {
-    const stan = createNote(tmpDir, config, 'person', 'Stan Girard');
-
-    const db = createDatabase(path.join(tmpDir, '.granite', 'index.db'));
-    rebuildIndex(tmpDir, config, db);
-
-    const recommendations = getRecommendations(db, readNote(stan.filepath), config);
-    db.close();
-
-    expect(recommendations.additions.map(item => item.text)).toEqual(
-      expect.arrayContaining([
-        'Add a one-line role, company, or why this person matters.',
-        'Add how you know them or what you work on together.',
-        'Link one project, company, or topic in the Links section.',
-      ]),
-    );
+    expect(recommendations.links.map(link => link.slug)).not.toContain('attention-source');
   });
 
   it('formats recommendation sections and returns nothing when empty', () => {
@@ -179,9 +136,9 @@ describe('recommendations', () => {
 
     expect(formatRecommendations({
       additions: [{ text: 'Add context.' }],
-      links: [{ slug: 'granite', title: 'Granite', type: 'project', reason: 'mentioned 2 times', source: 'mention' }],
+      links: [{ slug: 'granite', title: 'Granite', type: 'synthesis', reason: 'mentioned 2 times', source: 'mention' }],
       tags: [{ tag: 'search', weight: 3, source_slugs: ['granite', 'notes'] }],
-      next_steps: [{ type: 'decision', title_hint: 'Decision from Granite', reason: 'Capture the tradeoff.' }],
+      next_steps: [{ type: 'output', title_hint: 'Granite brief', reason: 'Create a situational deliverable.' }],
     })).toEqual([
       '  Add now:',
       '    Add context.',
@@ -190,74 +147,67 @@ describe('recommendations', () => {
       '  Tag now:',
       '    search — seen on 2 nearby notes',
       '  Next note:',
-      '    decision — Capture the tradeoff. Title hint: Decision from Granite.',
+      '    output — Create a situational deliverable. Title hint: Granite brief.',
     ]);
   });
 
-  it('covers next-step and add-now branches for remaining note types', () => {
-    const fleeting = createNote(tmpDir, config, 'fleeting', 'Quick capture', 'Tiny note.\n');
-    const meeting = createNote(tmpDir, config, 'meeting', 'Weekly sync');
-    const decision = createNote(tmpDir, config, 'decision', 'Choose SQLite');
-    const project = createNote(tmpDir, config, 'project', 'Granite');
-    const permanent = createNote(tmpDir, config, 'permanent', 'Memory Graph');
+  it('covers next-step and add-now branches for the default knowledge-oriented types', () => {
+    const note = createNote(tmpDir, config, 'note', 'Memory Graph');
+    const source = createNote(tmpDir, config, 'source', 'Attention Paper');
+    const synthesis = createNote(tmpDir, config, 'synthesis', 'Transformer State');
+    const output = createNote(tmpDir, config, 'output', 'Team Brief');
 
     const db = createDatabase(path.join(tmpDir, '.granite', 'index.db'));
     rebuildIndex(tmpDir, config, db);
 
-    const fleetingRecommendations = getRecommendations(db, readNote(fleeting.filepath), config);
-    expect(fleetingRecommendations.additions[0].text).toContain('Add one more sentence');
-    expect(fleetingRecommendations.next_steps[0]).toMatchObject({
-      type: 'permanent',
-      title_hint: 'Quick capture',
-    });
-
-    const meetingRecommendations = getRecommendations(db, readNote(meeting.filepath), config);
-    expect(meetingRecommendations.additions.map(item => item.text)).toEqual(
-      expect.arrayContaining([
-        'Link the attendees directly in the note.',
-        'Capture one decision or open question.',
-      ]),
-    );
-    expect(meetingRecommendations.next_steps[0].type).toBe('decision');
-
-    const decisionRecommendations = getRecommendations(db, readNote(decision.filepath), config);
-    expect(decisionRecommendations.additions.map(item => item.text)).toEqual(
-      expect.arrayContaining([
-        'Add the context that forced this decision.',
-        'State the decision in one sentence.',
-        'Link the project, meeting, or note affected by this decision.',
-      ]),
-    );
-    expect(decisionRecommendations.next_steps[0].type).toBe('project');
-
-    const projectRecommendations = getRecommendations(db, readNote(project.filepath), config);
-    expect(projectRecommendations.additions.map(item => item.text)).toEqual(
-      expect.arrayContaining([
-        'Add a one-line goal so the project has a clear anchor.',
-        'Link the people involved in the project.',
-        'Record one key decision or current status update.',
-      ]),
-    );
-    expect(projectRecommendations.next_steps[0].type).toBe('decision');
-
-    const permanentRecommendations = getRecommendations(db, readNote(permanent.filepath), config);
-    expect(permanentRecommendations.additions.map(item => item.text)).toEqual(
+    const noteRecommendations = getRecommendations(db, readNote(note.filepath), config);
+    expect(noteRecommendations.additions.map(item => item.text)).toEqual(
       expect.arrayContaining([
         'Write a one-line summary before expanding the idea.',
-        'Link one project, company, person, or adjacent idea.',
+        'Link one source, synthesis, or adjacent durable idea.',
       ]),
     );
-    expect(permanentRecommendations.next_steps[0].type).toBe('project');
+    expect(noteRecommendations.next_steps[0].type).toBe('source');
+
+    const sourceRecommendations = getRecommendations(db, readNote(source.filepath), config);
+    expect(sourceRecommendations.additions.map(item => item.text)).toEqual(
+      expect.arrayContaining([
+        'Write a short summary so this source is understandable without rereading the whole document.',
+        'Capture 2-3 concrete facts worth preserving from the source.',
+        'Link one note or synthesis that this source supports.',
+      ]),
+    );
+    expect(sourceRecommendations.next_steps[0].type).toBe('synthesis');
+
+    const synthesisRecommendations = getRecommendations(db, readNote(synthesis.filepath), config);
+    expect(synthesisRecommendations.additions.map(item => item.text)).toEqual(
+      expect.arrayContaining([
+        'Define the scope so this synthesis has a clear boundary.',
+        'Write a short executive summary before expanding the synthesis.',
+        'Link the notes or sources this synthesis pulls together.',
+      ]),
+    );
+    expect(synthesisRecommendations.next_steps[0].type).toBe('output');
+
+    const outputRecommendations = getRecommendations(db, readNote(output.filepath), config);
+    expect(outputRecommendations.additions.map(item => item.text)).toEqual(
+      expect.arrayContaining([
+        'State the goal so the output is grounded in a concrete need.',
+        'Name the audience so the tone and content stay focused.',
+        'Link the source note or synthesis this output derives from.',
+      ]),
+    );
+    expect(outputRecommendations.next_steps[0].type).toBe('synthesis');
 
     db.close();
   });
 
   it('supports incremental recommendation refreshes', () => {
-    createNote(tmpDir, config, 'project', 'Granite', 'Local-first system.\n');
+    createNote(tmpDir, config, 'synthesis', 'Granite', 'Local-first system.\n');
     const note = createNote(
       tmpDir,
       config,
-      'reference',
+      'source',
       'Fresh note',
       'Granite keeps markdown notes portable.\n',
     );

--- a/test/core/sync.test.ts
+++ b/test/core/sync.test.ts
@@ -151,7 +151,7 @@ describe('sync/conflict', () => {
   });
 
   it('detects a conflict when both local and remote are modified', () => {
-    const note = createNote(tmpDir, config, 'permanent', 'Conflict Test');
+    const note = createNote(tmpDir, config, 'note', 'Conflict Test');
     const remoteChange: SyncChange = {
       note_id: note.frontmatter.id,
       operation: 'update',
@@ -169,7 +169,7 @@ describe('sync/conflict', () => {
   });
 
   it('does not detect conflict for delete operations', () => {
-    const note = createNote(tmpDir, config, 'permanent', 'Delete Test');
+    const note = createNote(tmpDir, config, 'note', 'Delete Test');
     const remoteChange: SyncChange = {
       note_id: note.frontmatter.id,
       operation: 'delete',
@@ -182,7 +182,7 @@ describe('sync/conflict', () => {
   });
 
   it('resolves conflict with LWW and saves backup', () => {
-    const note = createNote(tmpDir, config, 'permanent', 'LWW Test');
+    const note = createNote(tmpDir, config, 'note', 'LWW Test');
     const remoteChange: SyncChange = {
       note_id: note.frontmatter.id,
       operation: 'update',
@@ -269,7 +269,7 @@ describe('sync/manager', () => {
       },
     };
     const manager = getSyncManager(tmpDir, syncConfig)!;
-    const note = createNote(tmpDir, config, 'permanent', 'Sync Track Test');
+    const note = createNote(tmpDir, config, 'note', 'Sync Track Test');
 
     // Should not throw even though server is unreachable
     expect(() => manager.trackAndPush(note, 'create')).not.toThrow();

--- a/test/core/vault-and-json-output.test.ts
+++ b/test/core/vault-and-json-output.test.ts
@@ -51,7 +51,7 @@ describe('vault helpers', () => {
   it('builds vault-relative file paths', () => {
     expect(getIndexDbPath('/vault')).toBe(path.join('/vault', '.granite', 'index.db'));
     expect(getIndexDbPath(path.join('/vault', '.granite'))).toBe(path.join('/vault', '.granite', 'index.db'));
-    expect(resolveNotePath('/vault', 'permanent', 'my-note')).toBe(path.join('/vault', 'permanent', 'my-note.md'));
+    expect(resolveNotePath('/vault', 'note', 'my-note')).toBe(path.join('/vault', 'note', 'my-note.md'));
   });
 });
 

--- a/test/core/wikilinks.test.ts
+++ b/test/core/wikilinks.test.ts
@@ -52,7 +52,7 @@ describe('resolveWikilinks', () => {
     frontmatter: {
       id: slug,
       title,
-      type: 'permanent',
+      type: 'note',
       created: '',
       modified: '',
       tags: [],

--- a/test/mcp/runtime.test.ts
+++ b/test/mcp/runtime.test.ts
@@ -26,8 +26,8 @@ describe('GraniteMcpRuntime', () => {
   });
 
   it('rebuilds a stale index on first refresh after a note deletion', () => {
-    createNote(tmpDir, config, 'permanent', 'Stable Note', 'Persistent note.\n');
-    const deleted = createNote(tmpDir, config, 'permanent', 'Deleted Note', 'Unique deleted content.\n');
+    createNote(tmpDir, config, 'note', 'Stable Note', 'Persistent note.\n');
+    const deleted = createNote(tmpDir, config, 'note', 'Deleted Note', 'Unique deleted content.\n');
 
     let runtime = new GraniteMcpRuntime(tmpDir, { indexCheckIntervalMs: 0 });
     expect(runtime.search('deleted')).toHaveLength(1);
@@ -44,7 +44,7 @@ describe('GraniteMcpRuntime', () => {
     const runtime = new GraniteMcpRuntime(tmpDir, { indexCheckIntervalMs: 0 });
     const result = runtime.createNote({
       title: 'Fresh Note',
-      type: 'permanent',
+      type: 'note',
       body: 'No extra metadata.\n',
     });
 

--- a/test/mcp/server.test.ts
+++ b/test/mcp/server.test.ts
@@ -26,7 +26,7 @@ describe('granite MCP server', () => {
       fs.mkdirSync(path.join(tmpDir, typeConfig.folder), { recursive: true });
     }
 
-    createNote(tmpDir, config, 'permanent', 'MCP Note', 'Granite MCP test note.\n');
+    createNote(tmpDir, config, 'note', 'MCP Note', 'Granite MCP test note.\n');
 
     runtime = new GraniteMcpRuntime(tmpDir, { indexCheckIntervalMs: 0 });
     server = createGraniteMcpServer(runtime);
@@ -75,7 +75,7 @@ describe('granite MCP server', () => {
       name: 'granite_create_note',
       arguments: {
         title: 'Linked Result',
-        type: 'permanent',
+        type: 'note',
         body: 'This note points to [[MCP Note]].\n',
         source: 'agent',
       },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
     "declaration": true,
     "sourceMap": true,
     "resolveJsonModule": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "test"]


### PR DESCRIPTION
## Summary
- add lightweight protocol metadata for human+agent note workflows
- introduce default source/synthesis/output note types and provenance fields
- expose the metadata across CLI, MCP, web, and doctor validations

## Validation
- npm run lint
- npm test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk due to a broad schema/default-model shift (new `note`/`source`/`synthesis`/`output` types and new shared frontmatter fields) that affects CLI, indexing, sync worker, MCP, and web responses, potentially impacting existing vault compatibility and downstream clients.
> 
> **Overview**
> **Introduces a shared “protocol” metadata layer in note frontmatter** by adding `review_state`, `durability`, and `derived_from` (plus normalization/validation) and surfacing these fields consistently in JSON outputs.
> 
> **Switches Granite’s default note model** from the prior type set to a knowledge-first set (`note`, `source`, `synthesis`, `output`), including new default folders/templates and per-type `frontmatter_defaults` (e.g., `note` canonical, `output` ephemeral).
> 
> **Extends all interfaces to read/write the protocol fields**: CLI `new`/`edit` flags and `list`/`show` JSON payloads, MCP tool schemas/runtime, web API note payloads, and worker sync defaults/type-folder mapping; `doctor` now validates these fields and warns when `synthesis`/`output` lack provenance. Documentation and tests are updated to match the new model, and the web server static path resolution is hardened for Node ESM.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4d45466b0b0bc4bb1a739a32a1915b98dc5953d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds agent-friendly note metadata and finalizes the new default model (`note`, `source`, `synthesis`, `output`). Validates and normalizes review state, durability, and provenance across the CLI, MCP, worker, and web APIs.

- **New Features**
  - Frontmatter: adds and normalizes `review_state`, `durability`, and `derived_from` with per-type `frontmatter_defaults` (`note` defaults `durability: canonical`).
  - CLI: `new`/`edit` accept `--review-state`, `--durability`, `--derived-from`; `list`/`show --json` return the fields; inputs validated.
  - MCP/Web: schemas and note summary/detail responses include the new metadata; web detail now returns them; `doctor` validates `review_state`/`durability` and provenance shape.

- **Refactors**
  - Default types simplified to `note`, `source`, `synthesis`, `output`; fallback is `note` across CLI, worker sync, and APIs.
  - Updated defaults, folders, README, GOS, and skill docs; graph/CSS reflect the new model; added Node typings in `tsconfig`.

<sup>Written for commit f4d45466b0b0bc4bb1a739a32a1915b98dc5953d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

