### PR TITLE
feat: split granite skill into loop-phase skills

### DIFF
--- a/skills/granite-brief/SKILL.md
+++ b/skills/granite-brief/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: granite-brief
+description: Generate an audience-specific output (brief, report, email, talking points) from Granite vault knowledge. Use when the user needs to turn what the vault knows into a deliverable for a specific audience.
+user-invocable: true
+argument-hint: <what to produce and for whom>
+allowed-tools: Bash
+---
+
+You are an output generator for a Granite vault.
+
+Your job: turn durable knowledge (notes, sources, syntheses) into a **situational deliverable** — a brief, report, email draft, talking points, or any audience-specific output. This is the last mile of the knowledge loop.
+
+## Process
+
+### 1. Understand the Ask
+
+The user will say something like:
+- "Write a brief on X for the engineering team"
+- "Draft an email summarizing what we know about Y"
+- "Give me talking points for the board meeting about Z"
+
+Identify: **topic**, **audience**, **format**, **tone**.
+
+### 2. Research the Vault
+
+```bash
+granite search "<topic>" --json
+granite list --type synthesis --json slug,title
+granite list --type note --json slug,title,tags
+```
+
+Prioritize in this order:
+1. **Syntheses** — already compiled, most valuable
+2. **Notes** — durable atomic ideas
+3. **Sources** — raw material, use for citations
+
+Read the best matches:
+
+```bash
+granite show <slug> --json
+granite backlinks <slug> --json
+```
+
+### 3. Generate the Output
+
+Create an `output` note:
+
+```bash
+granite new "<Deliverable title>" --type output --source agent --durability ephemeral --derived-from synth-slug,note-slug --json
+```
+
+Write the body adapted to the audience:
+
+```bash
+granite edit <slug> --body $'## Goal
+
+<what this output achieves>
+
+## Audience
+
+<who reads this and what they care about>
+
+## Output
+
+<the actual deliverable content — adapted to format and tone>
+
+## References
+
+Derived from: [[synth-slug]], [[note-slug]], [[source-slug]]'
+```
+
+### 4. Adapt by Format
+
+**Brief / Executive summary:**
+- Lead with the conclusion
+- 3-5 bullet points max
+- Link to deeper notes for context
+
+**Report:**
+- Structured sections with headings
+- Evidence from sources
+- Explicit scope and limitations
+
+**Email draft:**
+- Subject line + body
+- Conversational tone adapted to recipient
+- Call to action
+
+**Talking points:**
+- Numbered points, one idea each
+- Anticipated questions with answers
+- Data points from sources
+
+**Slide outline:**
+- One key message per slide
+- Supporting points as sub-bullets
+- Speaker notes with source references
+
+### 5. Report
+
+Tell the user:
+- What output was created (slug)
+- Which vault notes it derives from
+- The output itself (formatted for copy-paste)
+- Suggest: "Run `/granite-lint` to verify vault health after this output"
+
+## Rules
+
+- **Always `--durability ephemeral`** — outputs are situational, not canonical knowledge.
+- **Always `--derived-from`** — trace back to the durable notes.
+- **Never fabricate** — if the vault doesn't have it, say so. Don't fill gaps with invention.
+- **Audience-first** — the same knowledge looks different for engineers vs. executives vs. customers.
+- **Outputs feed the loop** — if generating the output reveals a knowledge gap, tell the user what to capture next.
+- **Regenerable** — a good output can be regenerated from its sources. The durable knowledge matters more.

--- a/skills/granite-capture/SKILL.md
+++ b/skills/granite-capture/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: granite-capture
+description: Extract knowledge from a conversation and capture it into a Granite vault. Use when the user shares information worth preserving — facts, decisions, sources, people, ideas — and you need to turn it into structured notes.
+user-invocable: true
+argument-hint: [paste or describe what to capture]
+allowed-tools: Bash
+---
+
+You are a knowledge extractor for a Granite vault.
+
+Your job: take raw information from the conversation and turn it into well-structured Granite notes. You are the **data ingest** phase of the knowledge loop.
+
+## Process
+
+### 1. Extract
+
+Read the user's input and identify discrete knowledge units:
+
+| Signal | Note type | Example |
+|--------|-----------|---------|
+| A fact, concept, or idea worth keeping | `note` | "Transformers scale logarithmically with data" |
+| External material (article, paper, tweet, quote) | `source` | "Karpathy's tweet about LLM knowledge bases" |
+| Multiple related ideas that form a coherent picture | `synthesis` | "How our auth system evolved over 3 quarters" |
+| A person with context | `note` | "Jane Smith, CTO at Acme, met at ReactConf" |
+| A decision with rationale | `note` | "Chose ClickHouse over Postgres for analytics" |
+| A meeting with outcomes | `note` | "Sprint review 2026-04-04 — decided to ship v2 first" |
+
+One knowledge unit = one note. If you find 5 things, create 5 notes.
+
+### 2. Deduplicate
+
+Before creating anything:
+
+```bash
+granite search "<key terms>" --json
+```
+
+If an existing note covers the same ground:
+- **Append** new information with `granite edit <slug> --append`
+- **Don't** create a duplicate
+
+### 3. Create
+
+```bash
+granite new "Title" --type <type> --source agent --review-state draft --json
+granite edit <slug> --body $'<structured body>'
+```
+
+Always use `--source agent`. Always `--review-state draft` (the human reviews later).
+
+### 4. Link
+
+After creating, connect the new note to the vault:
+
+```bash
+granite suggest-links <slug> --json
+granite recommend <slug> --json
+```
+
+If suggest-links finds mentions, add the `[[wikilinks]]`. If recommend suggests a tag or link, apply it.
+
+### 5. Report
+
+Tell the user exactly what you captured:
+- What notes were created (slug, type)
+- What existing notes were updated
+- What links were formed
+- What the recommendation engine suggests next
+
+## Body Templates
+
+### note
+
+```markdown
+## Summary
+
+<one-line summary>
+
+## Details
+
+<expanded explanation with [[wikilinks]] to related concepts>
+
+## Links
+
+Related: [[slug-a]], [[slug-b]]
+```
+
+### source
+
+```markdown
+## Summary
+
+<what this source says in your own words>
+
+## Key Facts
+
+- <fact 1>
+- <fact 2>
+- <fact 3>
+
+## Raw Content
+
+<original text, quote, or URL>
+
+## Links
+
+Related: [[slug-a]]
+```
+
+### synthesis
+
+```markdown
+## Scope
+
+<what this synthesis covers>
+
+## Executive Summary
+
+<the compiled insight>
+
+## Main Themes
+
+<patterns across the source notes>
+
+## Open Questions
+
+<what's unresolved>
+
+## Links
+
+Sources: [[slug-a]], [[slug-b]], [[slug-c]]
+```
+
+## Rules
+
+- **Atomic notes** — one idea per note. If it's two ideas, make two notes.
+- **Specific titles** — "Auth migration decision" not "Decision". "Karpathy's LLM knowledge base tweet" not "Interesting tweet".
+- **Wikilinks over tags** — if it's a relationship, use `[[wikilink]]`. Tags are for cross-cutting categories only.
+- **Don't editorialize** — capture what was said, not your interpretation (especially for `source` type).
+- **Preserve provenance** — if the content derives from existing notes, set `--derived-from`.

--- a/skills/granite-compile/SKILL.md
+++ b/skills/granite-compile/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: granite-compile
+description: Synthesize scattered Granite notes into compiled knowledge. Use when the user wants to connect ideas, build a synthesis from multiple notes, or compile what the vault knows about a topic.
+user-invocable: true
+argument-hint: <topic to compile>
+allowed-tools: Bash
+---
+
+You are a knowledge compiler for a Granite vault.
+
+Your job: take scattered notes and sources and compile them into a **synthesis** — durable knowledge that is more valuable than any individual note. This is the most important operation in the knowledge loop.
+
+## Process
+
+### 1. Research the Topic
+
+```bash
+granite search "<topic>" --json
+granite list --type source --json slug,title,tags
+granite list --type note --json slug,title,tags
+```
+
+Read each relevant note:
+
+```bash
+granite show <slug> --json
+granite backlinks <slug> --json
+```
+
+Build a mental map of what the vault knows. Look for:
+- **Clusters** — notes that reference each other
+- **Tensions** — notes that disagree or present different angles
+- **Gaps** — things referenced but not yet captured
+- **Patterns** — recurring themes across sources
+
+### 2. Check for Existing Synthesis
+
+```bash
+granite search "<topic>" --json
+granite list --type synthesis --json slug,title
+```
+
+If a synthesis already exists on this topic:
+- Read it, then **update** it with new connections
+- Don't create a duplicate synthesis
+
+### 3. Compile
+
+Create the synthesis:
+
+```bash
+granite new "<Topic> synthesis" --type synthesis --source agent --review-state draft --derived-from slug-a,slug-b,slug-c --json
+```
+
+Write a body that:
+- **Connects** — draws explicit links between ideas from different notes
+- **Elevates** — says something the individual notes don't say alone
+- **Links back** — uses `[[wikilinks]]` to every source note
+- **Scopes** — states clearly what it covers and what it doesn't
+
+```bash
+granite edit <slug> --body $'## Scope
+
+<what this synthesis covers and doesn'\''t>
+
+## Executive Summary
+
+<the compiled insight — what you know NOW that no single note says>
+
+## Main Themes
+
+### <Theme 1>
+
+<pattern observed across [[source-a]], [[note-b]], [[note-c]]>
+
+### <Theme 2>
+
+<another pattern or tension>
+
+## Open Questions
+
+- <what'\''s missing or unresolved>
+- <what the next capture or research should target>
+
+## Links
+
+Sources: [[slug-a]], [[slug-b]], [[slug-c]]
+See also: [[related-synthesis]]'
+```
+
+### 4. Strengthen the Graph
+
+After creating the synthesis:
+
+```bash
+granite suggest-links <slug> --json
+granite recommend <slug> --json
+```
+
+Apply suggested links. Check if source notes should link back to the synthesis.
+
+### 5. Report
+
+Tell the user:
+- What synthesis was created (slug, scope)
+- Which notes it compiles (with count)
+- Key insight that emerged from compilation
+- Open questions and suggested next captures
+- What `granite recommend` suggests as next step
+
+## What Makes a Good Synthesis
+
+A synthesis is **not** a summary. It's compiled knowledge:
+
+| Bad synthesis | Good synthesis |
+|---------------|----------------|
+| Lists what each note says | Connects ideas across notes to reveal patterns |
+| Repeats information | Adds insight the notes don't contain individually |
+| Has no wikilinks | Links every claim back to its source note |
+| No scope statement | Clear boundary on what it covers |
+| No open questions | Identifies what's missing for the next iteration |
+
+## Rules
+
+- **Always set `derived_from`** — list every note slug the synthesis draws from.
+- **Scope explicitly** — a synthesis without scope is just a long note.
+- **One synthesis per topic** — update the existing one rather than creating overlapping syntheses.
+- **Link bidirectionally** — the synthesis links to sources, and sources should link back.
+- **Surface tensions** — if notes disagree, say so. Don't flatten nuance.
+- **Open questions drive the loop** — a good synthesis tells you what to capture next.

--- a/skills/granite-lint/SKILL.md
+++ b/skills/granite-lint/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: granite-lint
+description: Health-check a Granite vault and fix structural issues. Use when the user wants to clean up the vault, find broken links, detect orphans, strengthen the knowledge graph, or run a periodic review.
+user-invocable: true
+argument-hint: [focus area]
+allowed-tools: Bash
+---
+
+You are a vault maintainer for a Granite vault.
+
+Your job: find and fix structural problems, strengthen the knowledge graph, and surface what the vault needs next. This is the **lint** phase of the knowledge loop.
+
+## Process
+
+### 1. Run Doctor
+
+```bash
+granite doctor --json
+```
+
+Fix what you can immediately:
+- **Broken wikilinks** — find the correct slug and update the link
+- **Missing frontmatter** — add required fields
+- **Line limit violations** — split oversized notes or flag for user review
+
+### 2. Find Orphans
+
+List all notes and check for backlinks:
+
+```bash
+granite list --json slug,title,type,status
+```
+
+For each note (prioritize `note` and `synthesis` types):
+
+```bash
+granite backlinks <slug> --json
+```
+
+Orphans (zero backlinks) need attention:
+- If they should be linked from other notes, add wikilinks
+- If they're isolated ideas, run `suggest-links` to find connections
+- If they're stale, propose archiving
+
+### 3. Check Inbox
+
+```bash
+granite list --status inbox --json slug,title,type,created
+```
+
+Inbox notes older than a few days are rotting. For each:
+- Refine into a durable note, or
+- Merge into an existing note, or
+- Archive if no longer relevant
+
+### 4. Strengthen Connections
+
+For notes with few links:
+
+```bash
+granite suggest-links <slug> --json
+granite recommend <slug> --json
+```
+
+Apply what makes sense:
+- Add wikilinks for unlinked mentions
+- Apply recommended tags
+- Create follow-up notes if recommend suggests them
+
+### 5. Detect Compilation Opportunities
+
+Look for clusters of 3+ related `note` or `source` type notes that lack a unifying `synthesis`:
+
+```bash
+granite list --type note --json slug,title,tags
+granite list --type source --json slug,title,tags
+granite list --type synthesis --json slug,title
+```
+
+If you see a cluster that should be compiled, suggest `/granite-compile <topic>`.
+
+### 6. Report
+
+Present a structured health report:
+
+```
+## Vault Health Report
+
+### Fixed
+- <what you fixed>
+
+### Needs Attention
+- <issues that need user decision>
+
+### Orphans
+- <notes with no connections>
+
+### Inbox Status
+- <inbox notes and their age>
+
+### Compilation Opportunities
+- <clusters that could become syntheses>
+
+### Stats
+- Total notes: X
+- By type: Y notes, Z sources, W syntheses, V outputs
+- Orphans: N
+- Inbox items: M
+```
+
+## Rules
+
+- **Fix before flagging** — if you can fix it (broken link, missing tag), do it. Only flag issues that need human judgment.
+- **Don't delete** — archive instead. `granite edit <slug> --status archived`
+- **Don't edit locked notes** — flag them for the user.
+- **Explain why** — for each suggestion, say what it improves (graph density, discoverability, compilation readiness).
+- **End with next action** — always tell the user the single most valuable thing to do next (usually `/granite-capture` or `/granite-compile`).

--- a/skills/granite/SKILL.md
+++ b/skills/granite/SKILL.md
@@ -1,222 +1,96 @@
 ---
 name: granite
-description: Work safely in a Granite vault using the `granite` CLI. Use when the user wants to capture, refine, link, or retrieve knowledge in a local-first markdown memory system that is readable by humans and operable by agents.
+description: Work safely in a Granite vault using the `granite` CLI. Use when the user wants to capture, search, read, update, or navigate knowledge in a local-first markdown memory system.
 user-invocable: true
-argument-hint: [action]
+argument-hint: [query or action]
 allowed-tools: Bash
 ---
 
-You are operating a Granite vault.
+You are operating a Granite vault — a local-first knowledge compiler inspired by Karpathy's vision of LLM-operated knowledge bases.
 
-Granite is not an AI product. It is a local-first knowledge substrate:
+The core loop is: **capture → compile → query → output → lint**.
 
-- Markdown files are the source of truth
-- the SQLite index is derived state
-- the CLI and MCP layer expose the vault cleanly
-- agent policy lives in this skill, not in the Granite core
+This skill covers **query and CRUD** — the foundation. Use the specialized skills for the other phases:
+- `/granite-capture` — extract and capture knowledge from conversations
+- `/granite-compile` — synthesize scattered notes into compiled knowledge
+- `/granite-brief` — generate audience-specific outputs from the vault
+- `/granite-lint` — health-check and strengthen the vault
 
-Your job is to keep the vault readable for humans and safe for agents.
+## Safety Rules
 
-## Core Rules
+1. **Read before write.** Always search before creating. Never create a duplicate.
+2. **`--source agent`** on every create and edit you perform.
+3. **Respect `locked`** — if `review_state: locked`, create a derived note instead of editing.
+4. **Provenance** — set `--derived-from` on every `synthesis` and `output` note.
+5. **Smallest useful change** — append or link when that's clearly better than creating.
 
-1. Read before write.
-Always inspect the vault before creating or editing notes.
+## Note Types
 
-2. Prefer the smallest useful change.
-Append, link, or update an existing note when that is clearly better than creating a duplicate.
+| Type | Purpose | Durability |
+|------|---------|------------|
+| `note` | Atomic durable idea | canonical |
+| `source` | Imported/observed material | canonical |
+| `synthesis` | Compiled knowledge across notes | canonical |
+| `output` | Audience-specific deliverable | ephemeral |
 
-3. Mark agent work explicitly.
-When you create or edit notes as an agent, always set `--source agent`.
+Natural flow: `source → note → synthesis → output`
 
-4. Respect editorial state.
-If `review_state` is `locked`, do not silently rewrite the note. Create a new derived note instead unless the user explicitly asks to edit it.
+## CLI Quick Reference
 
-5. Preserve provenance.
-For `synthesis` and `output`, set `--derived-from` with the source note IDs or slugs you relied on.
-
-6. Separate durable knowledge from situational output.
-Use `--durability canonical` for notes meant to remain part of the durable knowledge base, `working` for intermediate material, and `ephemeral` for audience-specific outputs.
-
-## Preferred Type Model
-
-Prefer this model unless the user explicitly wants a more specific structured type:
-
-| Situation | Type | Durability |
-|-----------|------|------------|
-| Durable idea or concept | `note` | `canonical` |
-| Imported or observed source material | `source` | `canonical` |
-| Compiled knowledge across multiple notes/sources | `synthesis` | `canonical` |
-| Audience-specific deliverable | `output` | `ephemeral` |
-
-## Read Workflow
-
-Start with this loop:
+### Search & Read
 
 ```bash
-granite types
 granite search "<query>" --json
-granite list --json slug,title,type,review_state,durability
+granite list --json slug,title,type,status
+granite list --type source --since 2026-04-01 --json slug,title
 granite show <slug> --json
 granite backlinks <slug> --json
+granite suggest-links <slug> --json
+granite recommend <slug> --json
 ```
-
-Use `granite suggest-links <slug>` and `granite recommend <slug>` when you need help finding the next connection or note.
-
-## Write Workflow
-
-Use this decision order:
-
-1. Search for an existing note.
-2. If one clearly matches, update it.
-3. If the existing note is stable and your content is derived or contextual, create a new `synthesis` or `output` instead of overwriting it.
-4. If nothing matches, create a new note with the smallest appropriate type.
 
 ### Create
 
 ```bash
-granite new "New source" --type source --source agent --review-state draft --durability canonical --json
-granite new "Transformer scaling" --type note --source agent --review-state draft --durability canonical --json
-granite new "State of transformer scaling" --type synthesis --source agent --review-state draft --durability canonical --derived-from paper-a,transformer-scaling --json
-granite new "Transformer team brief" --type output --source agent --review-state draft --durability ephemeral --derived-from state-of-transformer-scaling --json
+granite new "Title" --type note --source agent --json
+granite new "Title" --type source --source agent --durability canonical --json
+granite new "Title" --type synthesis --source agent --derived-from slug-a,slug-b --json
+granite new "Title" --type output --source agent --durability ephemeral --derived-from slug-a --json
+granite add "Quick thought" --source agent --json
 ```
 
 ### Update
 
 ```bash
-granite edit <slug> --append $'New paragraph or bullet'
+granite edit <slug> --append $'New content'
+granite edit <slug> --body $'Full replacement'
+granite edit <slug> --tag "tag1,tag2"
 granite edit <slug> --status archived
 granite edit <slug> --review-state reviewed
-granite edit <slug> --durability canonical
 granite edit <slug> --derived-from note-a,note-b
 ```
 
-## Writing Guidance by Type
-
-### `note`
-
-- One durable idea per note.
-- Prefer `## Summary`, `## Details`, `## Links`.
-- Link to adjacent concepts instead of adding broad taxonomy.
-
-### `source`
-
-- Stay close to the source.
-- Capture a short summary and 2-3 key facts.
-- Do not smuggle a full synthesis into a source note.
-
-Suggested body shape:
-
-```md
-## Summary
-
-## Key Facts
-
-- 
-
-## Raw Content
-
-## Links
-```
-
-### `synthesis`
-
-- Compile multiple notes or sources into durable knowledge.
-- Keep the scope explicit.
-- Use `derived_from` in frontmatter for provenance.
-
-Suggested body shape:
-
-```md
-## Scope
-
-## Executive Summary
-
-## Main Themes
-
-## Open Questions
-
-## Links
-```
-
-### `output`
-
-- Outputs are contextual deliverables, not canonical knowledge.
-- Keep them readable and audience-aware.
-- Link them back to the durable knowledge they came from.
-
-Suggested body shape:
-
-```md
-## Goal
-
-## Audience
-
-## Output
-
-## References
-```
-
-## Field Usage
-
-### `source`
-
-- `human`: created by a person
-- `agent`: created or materially edited by an agent
-- `extraction`: mechanically imported from another source
-
-Always use `agent` when you are the one writing.
-
-### `review_state`
-
-- `draft`: still evolving
-- `reviewed`: checked and stable enough to rely on
-- `locked`: should not be silently rewritten
-
-### `durability`
-
-- `canonical`: durable knowledge
-- `working`: active scratch or intermediate material
-- `ephemeral`: context-specific deliverable
-
-### `derived_from`
-
-Use it when the note is derived from other notes or sources, especially for:
-
-- `synthesis`
-- `output`
-
-## Retrieval Pattern
-
-When the user asks “what do we know about X?”:
+### Inspect
 
 ```bash
-granite search "X" --json
-granite show <slug> --json
-granite backlinks <slug> --json
-```
-
-Then synthesize from the retrieved notes. Do not invent provenance that is not in the vault.
-
-## Anti-patterns
-
-- Creating a new note without searching first
-- Rewriting a `locked` note without explicit instruction
-- Using `output` as if it were canonical knowledge
-- Leaving `synthesis` or `output` notes without `derived_from`
-- Leaving a durable note too vague to stand on its own
-- Replacing links with tags when the relationship is explicit
-- Editing a human-authored durable note when a derived note would be safer
-
-## Final Check
-
-Before you finish substantial Granite work, run:
-
-```bash
+granite types
 granite doctor
 ```
 
-If the change is structural or the user asked for verification, also inspect the resulting note with:
+## When the User Asks "What Do We Know About X?"
 
 ```bash
-granite show <slug> --json
+granite search "X" --json
+granite show <best-slug> --json
+granite backlinks <best-slug> --json
 ```
+
+Synthesize from retrieved notes. Never invent provenance not in the vault.
+
+## Anti-patterns
+
+- Creating without searching first
+- Editing a `locked` note without explicit permission
+- `output` without `derived_from`
+- Replacing wikilinks with tags
+- Overwriting a human note when a derived note would be safer

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -55,4 +55,8 @@ export function addNote(text?: string, options: { json?: boolean } = {}): void {
       console.log(line);
     }
   }
+
+  console.log('');
+  console.log(`Captured as "${note.frontmatter.title}" (${note.slug})`);
+  console.log(`Next: Refine → granite edit ${note.slug} | Find links → granite suggest-links ${note.slug}`);
 }

--- a/src/commands/backlinks.ts
+++ b/src/commands/backlinks.ts
@@ -19,6 +19,9 @@ export function backlinksCommand(slug: string, options: { json?: boolean }): voi
 
   if (backlinks.length === 0) {
     console.log(`No backlinks found for "${slug}".`);
+    console.log('');
+    console.log('This note is an orphan — nothing links to it.');
+    console.log(`Connect it: granite suggest-links ${slug} | granite recommend ${slug}`);
     return;
   }
 
@@ -31,4 +34,6 @@ export function backlinksCommand(slug: string, options: { json?: boolean }): voi
     }
     console.log('');
   }
+
+  console.log(`${backlinks.length} note(s) link here. Strengthen: granite suggest-links ${slug}`);
 }

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -2,8 +2,9 @@ import { loadConfig } from '../core/config.js';
 import { requireVaultRoot } from '../core/vault.js';
 import { ensureIndex } from '../core/index-db.js';
 import { runDoctor } from '../core/doctor.js';
+import { jsonSuccess } from '../core/json-output.js';
 
-export function doctorCommand(): void {
+export function doctorCommand(options: { json?: boolean } = {}): void {
   const vaultRoot = requireVaultRoot();
   const config = loadConfig(vaultRoot);
   const db = ensureIndex(vaultRoot, config);
@@ -11,14 +12,29 @@ export function doctorCommand(): void {
   const issues = runDoctor(vaultRoot, config, db);
   db.close();
 
-  if (issues.length === 0) {
-    console.log('No issues found. Vault is healthy.');
-    return;
-  }
-
   const errors = issues.filter(i => i.level === 'error');
   const warnings = issues.filter(i => i.level === 'warning');
   const infos = issues.filter(i => i.level === 'info');
+
+  if (options.json) {
+    console.log(jsonSuccess({
+      healthy: errors.length === 0,
+      issues,
+      counts: {
+        errors: errors.length,
+        warnings: warnings.length,
+        infos: infos.length,
+      },
+    }));
+    return;
+  }
+
+  if (issues.length === 0) {
+    console.log('Vault is healthy. No issues found.');
+    console.log('');
+    console.log('Keep the loop going: granite status');
+    return;
+  }
 
   const print = (label: string, items: typeof issues) => {
     if (items.length === 0) return;
@@ -34,6 +50,20 @@ export function doctorCommand(): void {
   print('Info', infos);
 
   console.log(`\n${errors.length} error(s), ${warnings.length} warning(s), ${infos.length} info(s)`);
+
+  // Actionable guidance
+  console.log('');
+  const brokenLinks = issues.filter(i => i.message.includes('Broken wikilink') || i.message.includes('broken'));
+  const overLimit = issues.filter(i => i.message.includes('line limit') || i.message.includes('exceeds'));
+
+  if (brokenLinks.length > 0) {
+    console.log(`Fix broken links: ${brokenLinks.length} wikilink(s) point to notes that don't exist.`);
+    console.log('  → Create the missing notes or fix the [[wikilinks]].');
+  }
+  if (overLimit.length > 0) {
+    console.log(`Split oversized notes: ${overLimit.length} note(s) exceed their line limit.`);
+    console.log('  → Break them into smaller, linked notes. One idea per note.');
+  }
 
   if (errors.length > 0) process.exit(1);
 }

--- a/src/commands/edit.ts
+++ b/src/commands/edit.ts
@@ -142,11 +142,14 @@ function printRecommendations(
   const recommendations = recommendNote(vaultRoot, config, updatedNote, { strategy });
   const lines = formatRecommendations(recommendations);
 
-  if (lines.length === 0) return;
+  if (lines.length > 0) {
+    console.log('');
+    console.log('Recommendations:');
+    for (const line of lines) {
+      console.log(line);
+    }
+  }
 
   console.log('');
-  console.log('Recommendations:');
-  for (const line of lines) {
-    console.log(line);
-  }
+  console.log(`Next: Check connections → granite suggest-links ${updatedNote.slug} | Compile → granite recommend ${updatedNote.slug}`);
 }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -34,6 +34,14 @@ export function initVault(dir = getDefaultVaultRoot()): void {
   for (const [name, typeConfig] of Object.entries(config.note_types)) {
     console.log(`  ${typeConfig.folder}/  (${name})`);
   }
+
   console.log('');
-  console.log('Next: granite new "My first note" --type note');
+  console.log('The knowledge loop: capture → compile → query → output → lint');
+  console.log('');
+  console.log('  source → note → synthesis → output');
+  console.log('');
+  console.log('Get started:');
+  console.log('  granite add "Your first thought"          # Capture something');
+  console.log('  granite new "Topic" --type source          # Import source material');
+  console.log('  granite status                             # See what to do next');
 }

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -81,6 +81,11 @@ export function listCommand(options: ListOptions): void {
 
   if (notes.length === 0) {
     console.log('No notes found.');
+    if (options.type) {
+      console.log(`\nNo ${options.type} notes yet. Create one: granite new "Title" --type ${options.type}`);
+    } else {
+      console.log('\nVault is empty. Start: granite add "Your first thought"');
+    }
     return;
   }
 
@@ -92,4 +97,9 @@ export function listCommand(options: ListOptions): void {
   }
 
   console.log(`\n${notes.length} note(s)`);
+
+  // Contextual tip based on filter
+  if (options.status === 'inbox') {
+    console.log('\nProcess inbox: granite show <slug> → granite edit <slug> --status active');
+  }
 }

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -106,4 +106,23 @@ export function newNote(
       console.log(line);
     }
   }
+
+  // Contextual next step based on type
+  console.log('');
+  switch (resolvedType) {
+    case 'source':
+      console.log(`Next: Fill the note, then compile → granite recommend ${note.slug}`);
+      break;
+    case 'note':
+      console.log(`Next: Link to related notes → granite suggest-links ${note.slug}`);
+      break;
+    case 'synthesis':
+      console.log(`Next: Review connections → granite backlinks ${note.slug}`);
+      break;
+    case 'output':
+      console.log(`Next: Verify provenance → granite show ${note.slug}`);
+      break;
+    default:
+      console.log(`Next: granite recommend ${note.slug}`);
+  }
 }

--- a/src/commands/recommend.ts
+++ b/src/commands/recommend.ts
@@ -33,13 +33,25 @@ export function recommendCommand(slug: string, options: { json?: boolean }): voi
 
   const lines = formatRecommendations(recommendations);
   if (lines.length === 0) {
-    console.log(`No recommendations found for "${existingNote.frontmatter.title}".`);
+    console.log(`"${existingNote.frontmatter.title}" is well-connected. No actions needed.`);
+    console.log('');
+    console.log('Keep the loop going: granite status');
     return;
   }
 
-  console.log(`Recommendations for "${existingNote.frontmatter.title}":`);
+  console.log(`Recommendations for "${existingNote.frontmatter.title}" (${existingNote.frontmatter.type}):`);
   console.log('');
   for (const line of lines) {
     console.log(line);
+  }
+
+  // Contextual guidance based on what's recommended
+  console.log('');
+  if (recommendations.next_steps.length > 0) {
+    const step = recommendations.next_steps[0];
+    const hint = step.title_hint ? ` "${step.title_hint}"` : '';
+    console.log(`The vault is asking for: granite new${hint} --type ${step.type}`);
+  } else if (recommendations.links.length > 0) {
+    console.log(`Strengthen this note: granite edit ${slug} --append $'See also: [[${recommendations.links[0].slug}]]'`);
   }
 }

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -19,6 +19,8 @@ export function searchCommand(query: string, options: { json?: boolean }): void 
 
   if (results.length === 0) {
     console.log('No results found.');
+    console.log('');
+    console.log(`Nothing in the vault matches "${query}". Capture it: granite add "${query}"`);
     return;
   }
 
@@ -27,4 +29,8 @@ export function searchCommand(query: string, options: { json?: boolean }): void 
     console.log(`    ${r.snippet}`);
     console.log('');
   }
+
+  console.log(`${results.length} result(s) for "${query}"`);
+  console.log('');
+  console.log(`Dive deeper: granite show ${results[0].slug} | granite backlinks ${results[0].slug}`);
 }

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,0 +1,108 @@
+import { loadConfig } from '../core/config.js';
+import { requireVaultRoot } from '../core/vault.js';
+import { listNotes } from '../core/note.js';
+import { ensureIndex } from '../core/index-db.js';
+import { runDoctor } from '../core/doctor.js';
+import { getBacklinks } from '../core/backlinks.js';
+import { jsonSuccess } from '../core/json-output.js';
+
+export function statusCommand(options: { json?: boolean } = {}): void {
+  const vaultRoot = requireVaultRoot();
+  const config = loadConfig(vaultRoot);
+  const notes = listNotes(vaultRoot, config);
+
+  // Count by type
+  const byType: Record<string, number> = {};
+  for (const note of notes) {
+    byType[note.frontmatter.type] = (byType[note.frontmatter.type] ?? 0) + 1;
+  }
+
+  // Count by status
+  const inbox = notes.filter(n => n.frontmatter.status === 'inbox');
+  const drafts = notes.filter(n => n.frontmatter.review_state === 'draft' && n.frontmatter.status === 'active');
+  const orphans: string[] = [];
+
+  // Find orphans (notes with no backlinks)
+  const db = ensureIndex(vaultRoot, config);
+  const issues = runDoctor(vaultRoot, config, db);
+
+  for (const note of notes.slice(0, 50)) {
+    const bl = getBacklinks(db, note.slug);
+    if (bl.length === 0 && note.outgoing_links.length === 0) {
+      orphans.push(note.slug);
+    }
+  }
+  db.close();
+
+  const errors = issues.filter(i => i.level === 'error');
+
+  // Determine next actions
+  const nextActions: string[] = [];
+
+  if (notes.length === 0) {
+    nextActions.push('Your vault is empty. Start capturing: granite add "Your first thought"');
+  } else {
+    if (inbox.length > 0) {
+      nextActions.push(`Process your inbox: ${inbox.length} note(s) waiting → granite show ${inbox[0].slug}`);
+    }
+    if (drafts.length > 0) {
+      nextActions.push(`Review drafts: ${drafts.length} active draft(s) → granite show ${drafts[0].slug}`);
+    }
+    if (errors.length > 0) {
+      nextActions.push(`Fix ${errors.length} error(s) found by doctor → granite doctor`);
+    }
+    if (orphans.length > 0) {
+      nextActions.push(`Connect ${orphans.length} orphan note(s) → granite suggest-links ${orphans[0]}`);
+    }
+    const syntheses = byType['synthesis'] ?? 0;
+    const notesAndSources = (byType['note'] ?? 0) + (byType['source'] ?? 0);
+    if (notesAndSources >= 5 && syntheses === 0) {
+      nextActions.push('You have enough notes to compile a synthesis → granite recommend <slug>');
+    }
+    if (nextActions.length === 0) {
+      nextActions.push('Vault is healthy. Keep capturing or run: granite doctor');
+    }
+  }
+
+  if (options.json) {
+    console.log(jsonSuccess({
+      vault_name: config.vault_name,
+      note_count: notes.length,
+      notes_by_type: byType,
+      inbox_count: inbox.length,
+      draft_count: drafts.length,
+      orphan_count: orphans.length,
+      error_count: errors.length,
+      next_actions: nextActions,
+    }));
+    return;
+  }
+
+  console.log(`${config.vault_name}`);
+  console.log('');
+
+  // Stats
+  const typeLine = Object.entries(byType)
+    .map(([type, count]) => `${count} ${type}${count > 1 ? 's' : ''}`)
+    .join(', ');
+  console.log(`  ${notes.length} notes: ${typeLine || 'none'}`);
+
+  if (inbox.length > 0 || drafts.length > 0 || orphans.length > 0) {
+    const parts: string[] = [];
+    if (inbox.length > 0) parts.push(`${inbox.length} inbox`);
+    if (drafts.length > 0) parts.push(`${drafts.length} drafts`);
+    if (orphans.length > 0) parts.push(`${orphans.length} orphans`);
+    console.log(`  Attention: ${parts.join(', ')}`);
+  }
+
+  if (errors.length > 0) {
+    console.log(`  Health: ${errors.length} error(s) — run granite doctor`);
+  }
+
+  // Next actions
+  console.log('');
+  console.log('Next:');
+  for (const action of nextActions) {
+    console.log(`  → ${action}`);
+  }
+}

--- a/src/commands/suggest-links.ts
+++ b/src/commands/suggest-links.ts
@@ -30,13 +30,18 @@ export function suggestLinksCommand(slug: string, options: { json?: boolean }): 
   }
 
   if (suggestions.length === 0) {
-    console.log('No link suggestions found.');
+    console.log(`No unlinked mentions found for "${existingNote.frontmatter.title}".`);
+    console.log('');
+    console.log(`All mentions are linked. See what else to do: granite recommend ${slug}`);
     return;
   }
 
-  console.log(`Suggested links for "${existingNote.frontmatter.title}":`);
+  console.log(`Unlinked mentions in "${existingNote.frontmatter.title}":`);
   console.log('');
   for (const s of suggestions) {
     console.log(`  → [[${s.target_title}]] — ${s.mentions} mention${s.mentions > 1 ? 's' : ''}`);
   }
+
+  console.log('');
+  console.log(`Add [[wikilinks]] to strengthen the graph. Then: granite recommend ${slug}`);
 }

--- a/src/commands/types.ts
+++ b/src/commands/types.ts
@@ -5,7 +5,7 @@ export function typesCommand(): void {
   const vaultRoot = requireVaultRoot();
   const config = loadConfig(vaultRoot);
 
-  console.log('Available note types:\n');
+  console.log('Note types — the natural flow is: source → note → synthesis → output\n');
 
   for (const [name, tc] of Object.entries(config.note_types)) {
     console.log(`  ${name}`);
@@ -14,9 +14,22 @@ export function typesCommand(): void {
     if (tc.instructions) {
       console.log(`    guide: ${tc.instructions}`);
     }
+    if (tc.frontmatter_defaults) {
+      const defaults = Object.entries(tc.frontmatter_defaults)
+        .map(([k, v]) => `${k}: ${v}`)
+        .join(', ');
+      console.log(`    defaults: ${defaults}`);
+    }
     console.log('');
   }
 
   console.log(`Default type: ${config.defaults.note_type}`);
-  console.log(`\nUsage: granite new <type> <title>`);
+  console.log('');
+  console.log('When to use what:');
+  console.log('  source     Raw material — articles, tweets, papers. Keep it close to the original.');
+  console.log('  note       One durable idea. If it\'s two ideas, make two notes.');
+  console.log('  synthesis  Compile multiple notes into new understanding. The most valuable type.');
+  console.log('  output     Audience-specific deliverable. Ephemeral — always derived_from something durable.');
+  console.log('');
+  console.log('Usage: granite new "Title" --type <type>');
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { serveCommand } from './commands/serve.js';
 import { typesCommand } from './commands/types.js';
 import { listCommand } from './commands/list.js';
 import { editCommand } from './commands/edit.js';
+import { statusCommand } from './commands/status.js';
 import { mcpCommand, mcpStopCommand, mcpStatusCommand, parseTransport } from './commands/mcp.js';
 import { GRANITE_VERSION } from './version.js';
 
@@ -20,26 +21,38 @@ const program = new Command();
 
 program
   .name('granite')
-  .description('Granite — a local-first markdown memory system')
+  .description('Granite — a local-first knowledge compiler. capture → compile → query → output → lint')
   .version(GRANITE_VERSION);
+
+// ─── Setup ────────────────────────────────────────────────────────────
 
 program
   .command('init')
-  .description('Initialize the default vault in ~/.granite')
+  .description('Create a new vault and start the knowledge loop')
   .action(() => {
     initVault();
   });
 
 program
+  .command('status')
+  .description('See where your vault stands and what to do next')
+  .option('--json', 'Output as JSON')
+  .action((options: { json?: boolean }) => {
+    statusCommand(options);
+  });
+
+// ─── Capture ──────────────────────────────────────────────────────────
+
+program
   .command('new')
-  .description('Create a new note')
+  .description('Create a structured note — search first to avoid duplicates')
   .argument('<title>', 'Note title')
-  .option('-t, --type <type>', 'Note type (e.g. note, source, synthesis, output)')
-  .option('--source <source>', 'Set source (human, agent, extraction)')
-  .option('--status <status>', 'Set status (inbox, active, archived)')
-  .option('--review-state <state>', 'Set review state (draft, reviewed, locked)')
-  .option('--durability <durability>', 'Set durability (canonical, working, ephemeral)')
-  .option('--derived-from <refs>', 'Set derived_from references (comma-separated note IDs or slugs)')
+  .option('-t, --type <type>', 'Note type (note, source, synthesis, output)')
+  .option('--source <source>', 'Who created it (human, agent, extraction)')
+  .option('--status <status>', 'Lifecycle state (inbox, active, archived)')
+  .option('--review-state <state>', 'Editorial state (draft, reviewed, locked)')
+  .option('--durability <durability>', 'Knowledge permanence (canonical, working, ephemeral)')
+  .option('--derived-from <refs>', 'Provenance: slugs this note derives from (comma-separated)')
   .option('--json', 'Output as JSON (agent-friendly)')
   .action((title: string, options: { type?: string; source?: string; status?: string; reviewState?: string; durability?: string; derivedFrom?: string; json?: boolean }) => {
     newNote(title, options);
@@ -47,29 +60,53 @@ program
 
 program
   .command('add')
-  .description('Quick-capture a note using the default note type (reads stdin if no text given)')
+  .description('Quick-capture raw text into the vault — the fastest way to get something in')
   .argument('[text]', 'Note text (or pipe via stdin)')
   .option('--json', 'Output as JSON (agent-friendly)')
   .action((text: string | undefined, options: { json?: boolean }) => {
     addNote(text, options);
   });
 
+// ─── Query ────────────────────────────────────────────────────────────
+
 program
   .command('list')
   .alias('ls')
-  .description('List notes')
+  .description('Browse the vault — filter by type, status, source, or date')
   .option('-t, --type <type>', 'Filter by note type')
   .option('-s, --status <status>', 'Filter by status (inbox, active, archived)')
   .option('--source <source>', 'Filter by source (human, agent, extraction)')
-  .option('--since <date>', 'Filter notes modified since date (YYYY-MM-DD)')
-  .option('--json [fields]', 'Output as JSON; optionally specify fields (e.g. --json slug,title,type)')
+  .option('--since <date>', 'Only notes modified since (YYYY-MM-DD)')
+  .option('--json [fields]', 'Output as JSON; optionally select fields (e.g. --json slug,title,type)')
   .action((options: { type?: string; status?: string; source?: string; since?: string; json?: boolean | string }) => {
     listCommand(options);
   });
 
 program
+  .command('show')
+  .alias('cat')
+  .description('Read a note in full — frontmatter, body, and metadata')
+  .argument('<slug>', 'Note slug')
+  .option('--json', 'Output as JSON (agent-friendly)')
+  .option('--body', 'Output body only (for piping)')
+  .action((slug: string, options: { json?: boolean; body?: boolean }) => {
+    showCommand(slug, options);
+  });
+
+program
+  .command('search')
+  .description('Research a topic across the vault — use before creating to avoid duplicates')
+  .argument('<query>', 'Search query')
+  .option('--json', 'Output as JSON (agent-friendly)')
+  .action((query: string, options: { json?: boolean }) => {
+    searchCommand(query, options);
+  });
+
+// ─── Compile ──────────────────────────────────────────────────────────
+
+program
   .command('edit')
-  .description('Edit a note (opens $EDITOR, or use flags for programmatic edits)')
+  .description('Refine a note — append, rewrite, promote status, add tags and links')
   .argument('<slug>', 'Note slug')
   .option('--body <text>', 'Replace the note body')
   .option('--append <text>', 'Append text to the note body')
@@ -80,42 +117,22 @@ program
   .option('--source <source>', 'Set source (human, agent, extraction)')
   .option('--review-state <state>', 'Set review state (draft, reviewed, locked)')
   .option('--durability <durability>', 'Set durability (canonical, working, ephemeral)')
-  .option('--derived-from <refs>', 'Set derived_from references (comma-separated note IDs or slugs)')
+  .option('--derived-from <refs>', 'Set derived_from references (comma-separated slugs)')
   .action((slug: string, options: { body?: string; append?: string; title?: string; tag?: string; alias?: string; status?: string; source?: string; reviewState?: string; durability?: string; derivedFrom?: string }) => {
     editCommand(slug, options);
   });
 
 program
   .command('open')
-  .description('Open a note in your editor (alias for edit)')
+  .description('Open a note in your editor')
   .argument('<slug>', 'Note slug')
   .action((slug: string) => {
     openNote(slug);
   });
 
 program
-  .command('show')
-  .alias('cat')
-  .description('Display a note by slug')
-  .argument('<slug>', 'Note slug')
-  .option('--json', 'Output as JSON (agent-friendly)')
-  .option('--body', 'Output body only (no frontmatter)')
-  .action((slug: string, options: { json?: boolean; body?: boolean }) => {
-    showCommand(slug, options);
-  });
-
-program
-  .command('search')
-  .description('Full-text search across notes')
-  .argument('<query>', 'Search query')
-  .option('--json', 'Output as JSON (agent-friendly)')
-  .action((query: string, options: { json?: boolean }) => {
-    searchCommand(query, options);
-  });
-
-program
   .command('backlinks')
-  .description('Show notes that link to a given note')
+  .description("See a note's role in the graph — who links here and why")
   .argument('<slug>', 'Note slug')
   .option('--json', 'Output as JSON (agent-friendly)')
   .action((slug: string, options: { json?: boolean }) => {
@@ -124,7 +141,7 @@ program
 
 program
   .command('suggest-links')
-  .description('Suggest wikilinks based on unlinked mentions')
+  .description('Find unlinked mentions — strengthen the graph by adding missed [[wikilinks]]')
   .argument('<slug>', 'Note slug')
   .option('--json', 'Output as JSON (agent-friendly)')
   .action((slug: string, options: { json?: boolean }) => {
@@ -133,30 +150,35 @@ program
 
 program
   .command('recommend')
-  .description('Suggest links, tags, and the next note to create')
+  .description('The heart of the compile loop — what to link, tag, and write next')
   .argument('<slug>', 'Note slug')
   .option('--json', 'Output as JSON (agent-friendly)')
   .action((slug: string, options: { json?: boolean }) => {
     recommendCommand(slug, options);
   });
 
+// ─── Lint ─────────────────────────────────────────────────────────────
+
+program
+  .command('doctor')
+  .description('Health-check the vault — broken links, missing fields, line limit violations')
+  .option('--json', 'Output as JSON')
+  .action((options: { json?: boolean }) => {
+    doctorCommand(options);
+  });
+
 program
   .command('types')
-  .description('List available note types')
+  .description('See the note types and the natural flow: source → note → synthesis → output')
   .action(() => {
     typesCommand();
   });
 
-program
-  .command('doctor')
-  .description('Validate vault health')
-  .action(() => {
-    doctorCommand();
-  });
+// ─── Serve ────────────────────────────────────────────────────────────
 
 program
   .command('serve')
-  .description('Start the local web UI')
+  .description('Start the local web UI — browse, search, and visualize the knowledge graph')
   .option('-p, --port <port>', 'Port number', '4321')
   .action((options: { port: string }) => {
     serveCommand(options);


### PR DESCRIPTION
## Summary

- Refactored the monolithic `/granite` skill into 5 focused skills, each mapping to a phase of Karpathy's knowledge loop (`capture → compile → query → output → lint`)
- `/granite` — refocused on query + CRUD + safety rules (220 → 90 lines)
- `/granite-capture` — extract knowledge from conversations into structured notes
- `/granite-compile` — synthesize scattered notes into durable compiled knowledge
- `/granite-brief` — generate audience-specific outputs from vault knowledge
- `/granite-lint` — health-check, fix structural issues, strengthen the graph

## Test plan

- [ ] Install the skills and verify each is invocable: `/granite`, `/granite-capture`, `/granite-compile`, `/granite-brief`, `/granite-lint`
- [ ] Test `/granite-capture` with a paste of raw information — should create typed notes with wikilinks
- [ ] Test `/granite-compile` with a topic — should research vault, produce a synthesis note with `derived_from`
- [ ] Test `/granite-brief` with a deliverable request — should produce an `output` note with `durability: ephemeral`
- [ ] Test `/granite-lint` — should run doctor, find orphans, report health

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly adds new skill markdown docs and improves CLI UX/output messaging; the only behavioral changes are the new `granite status` command and `doctor --json`, which are low-risk but could affect downstream scripts expecting previous `doctor` output.
> 
> **Overview**
> Splits the previously monolithic Granite agent skill into four new loop-phase skills (`/granite-capture`, `/granite-compile`, `/granite-brief`, `/granite-lint`) and refocuses `/granite` on **query + CRUD** with tighter safety/provenance rules.
> 
> Extends the `granite` CLI with a new `status` command (plus `--json`) that summarizes vault counts, inbox/draft/orphan signals, doctor errors, and suggests next actions; `doctor` now supports `--json` and prints more actionable follow-up guidance.
> 
> Improves CLI ergonomics across commands (`new`, `add`, `edit`, `search`, `list`, `backlinks`, `suggest-links`, `recommend`, `types`, `init`) by adding contextual “next step” hints and clearer messaging around empty results/orphan notes and the capture→compile loop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77b57331fddd4db92e94e866b3f8ef9a9eb0a875. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the monolithic `granite` skill into loop‑phase skills and taught the `granite` CLI to guide users through the knowledge loop with actionable next steps. Adds a `status` dashboard and smarter `doctor` to keep vaults healthy while making capture → compile → query → output → lint workflows clearer and safer.

- **New Features**
  - Added `/granite-capture`, `/granite-compile`, `/granite-brief`, `/granite-lint` aligned to loop phases.
  - New `granite status` dashboard: vault stats, inbox/drafts/orphans, errors, and prioritized next actions (`--json` supported).
  - `granite doctor` now supports `--json` and explains how to fix issues (broken links, line limits) with actionable hints.
  - Every command now teaches methodology with concise descriptions and “Next:” guidance; help text highlights the loop.

- **Refactors**
  - Slimmed `/granite` to query + CRUD with clear safety rules: read before write, `--source agent`, respect `locked`, always set `--derived-from` on `synthesis`/`output`.
  - Clarified note flow and types (`source → note → synthesis → output`) across CLI (`types`, `init`, help) and simplified guidance by moving phase-specific docs into the new skills.

<sup>Written for commit 77b57331fddd4db92e94e866b3f8ef9a9eb0a875. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

