### PR TITLE
feat(types): active contracts with hooks, typed queries, compile context

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "granite": "./dist/index.js"
   },
   "files": [
-    "dist"
+    "dist",
+    "templates"
   ],
   "keywords": [
     "memory",
@@ -24,7 +25,7 @@
     "url": "https://github.com/The-Vibe-Company/Granite"
   },
   "scripts": {
-    "build": "tsup && rm -rf dist/public && cp -r src/web/public dist/public",
+    "build": "tsup && rm -rf dist/public && cp -r src/web/public dist/public && rm -rf dist/templates && cp -r templates dist/templates",
     "dev": "tsx src/index.ts",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",

--- a/packages/worker/src/handlers/mcp.ts
+++ b/packages/worker/src/handlers/mcp.ts
@@ -2,11 +2,175 @@ import type { Context } from 'hono';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js';
 import * as z from 'zod/v4';
+import {
+  renderBacklinksMarkdown,
+  renderLinkSuggestionsMarkdown,
+  renderMutationResultMarkdown,
+  renderNoteDetailsMarkdown,
+  renderNotesMarkdown,
+  renderNoteTypesMarkdown,
+  renderSearchResultsMarkdown,
+  renderVaultOverviewMarkdown,
+} from '../../../../shared/mcp-markdown.js';
 import type { Env, Tier } from '../env.js';
 import { TIER_LIMITS } from '../env.js';
 import { R2NoteStorage } from '../storage/r2.js';
 import { D1IndexDatabase } from '../storage/d1.js';
 import { CloudMcpRuntime } from '../runtime.js';
+
+const noteSummarySchema = z.object({
+  slug: z.string(),
+  title: z.string(),
+  type: z.string(),
+  created: z.string(),
+  modified: z.string(),
+  tags: z.array(z.string()),
+  aliases: z.array(z.string()),
+  status: z.string(),
+  source: z.string(),
+  filepath: z.string(),
+  resource_uri: z.string(),
+});
+
+const wikiLinkSchema = z.object({
+  raw: z.string(),
+  target: z.string(),
+  display: z.string(),
+  resolved: z.boolean(),
+  resolved_slug: z.string().optional(),
+});
+
+const noteDetailsSchema = noteSummarySchema.extend({
+  body: z.string(),
+  frontmatter: z.record(z.string(), z.unknown()),
+  outgoing_links: z.array(wikiLinkSchema),
+});
+
+const searchResultSchema = z.object({
+  slug: z.string(),
+  title: z.string(),
+  snippet: z.string(),
+  score: z.number(),
+});
+
+const backlinkSchema = z.object({
+  source_slug: z.string(),
+  source_title: z.string(),
+  context: z.string(),
+});
+
+const linkSuggestionSchema = z.object({
+  target_slug: z.string(),
+  target_title: z.string(),
+  mentions: z.number(),
+});
+
+const recommendationSchema = z.object({
+  additions: z.array(z.object({ text: z.string() })),
+  links: z.array(z.object({
+    slug: z.string(),
+    title: z.string(),
+    type: z.string(),
+    reason: z.string(),
+    source: z.string(),
+  })),
+  tags: z.array(z.object({
+    tag: z.string(),
+    weight: z.number(),
+    source_slugs: z.array(z.string()),
+  })),
+  next_steps: z.array(z.object({
+    type: z.string(),
+    title_hint: z.string().optional(),
+    reason: z.string(),
+  })),
+});
+
+const noteMutationSchema = z.object({
+  note: noteDetailsSchema,
+  recommendations: recommendationSchema,
+});
+
+const noteTypeSchema = z.object({
+  name: z.string(),
+  description: z.string(),
+  folder: z.string(),
+  slug_format: z.string(),
+  instructions: z.string().optional(),
+});
+
+const vaultOverviewSchema = z.object({
+  vault_name: z.string(),
+  default_type: z.string(),
+  note_count: z.number(),
+  notes_by_type: z.record(z.string(), z.number()),
+  recent_notes: z.array(noteSummarySchema),
+});
+
+const noteTypesResultSchema = z.object({
+  note_types: z.array(noteTypeSchema),
+});
+
+const listNotesResultSchema = z.object({
+  notes: z.array(noteSummarySchema),
+});
+
+const searchResultSetSchema = z.object({
+  query: z.string(),
+  results: z.array(searchResultSchema),
+});
+
+const backlinksResultSchema = z.object({
+  slug: z.string(),
+  backlinks: z.array(backlinkSchema),
+});
+
+const linkSuggestionsResultSchema = z.object({
+  slug: z.string(),
+  suggestions: z.array(linkSuggestionSchema),
+});
+
+export interface WorkerMcpRuntime {
+  getVaultOverview(recentLimit?: number): Promise<z.infer<typeof vaultOverviewSchema>>;
+  listNoteTypes(): Promise<Array<z.infer<typeof noteTypeSchema>>>;
+  listNotes(input?: {
+    type?: string;
+    status?: string;
+    source?: string;
+    since?: string;
+    limit?: number;
+  }): Promise<Array<z.infer<typeof noteSummarySchema>>>;
+  getNote(slug: string): Promise<z.infer<typeof noteDetailsSchema>>;
+  search(query: string, limit?: number): Promise<Array<z.infer<typeof searchResultSchema>>>;
+  getBacklinks(slug: string): Promise<Array<z.infer<typeof backlinkSchema>>>;
+  suggestLinks(slug: string): Promise<Array<z.infer<typeof linkSuggestionSchema>>>;
+  createNote(input: {
+    title: string;
+    type?: string;
+    body?: string;
+    tags?: string[];
+    aliases?: string[];
+    status?: string;
+    source?: string;
+  }): Promise<z.infer<typeof noteMutationSchema>>;
+  captureNote(input: {
+    text: string;
+    type?: string;
+    tags?: string[];
+    status?: string;
+    source?: string;
+  }): Promise<z.infer<typeof noteMutationSchema>>;
+  updateNote(slug: string, input: {
+    title?: string;
+    body?: string;
+    append?: string;
+    tags?: string[];
+    aliases?: string[];
+    status?: string;
+    source?: string;
+  }): Promise<z.infer<typeof noteMutationSchema>>;
+  readVaultConfigRaw(): Promise<string>;
+}
 
 function getVaultId(c: Context<{ Bindings: Env }>): string {
   return c.get('vaultId') as string;
@@ -20,96 +184,109 @@ function createRuntime(c: Context<{ Bindings: Env }>): CloudMcpRuntime {
   return new CloudMcpRuntime(storage, db, TIER_LIMITS[tier].maxStorageBytes);
 }
 
-function createMcpServer(runtime: CloudMcpRuntime): McpServer {
+function toolResult<T>(structuredContent: T, markdown: string) {
+  return {
+    content: [{ type: 'text' as const, text: markdown }],
+    structuredContent,
+  };
+}
+
+export function createMcpServer(runtime: WorkerMcpRuntime): McpServer {
   const server = new McpServer({
     name: 'granite-cloud',
     version: '0.1.0',
   });
 
-  // --- Read-only tools ---
-
-  server.tool(
-    'granite_get_vault_overview',
-    'Get a summary of the vault',
-    { recent_limit: z.number().optional() },
-    async ({ recent_limit }) => {
-      const overview = await runtime.getVaultOverview(recent_limit);
-      return { content: [{ type: 'text', text: JSON.stringify(overview, null, 2) }] };
+  server.registerTool('granite_get_vault_overview', {
+    title: 'Get Granite Vault Overview',
+    description: 'Get a summary of the vault.',
+    inputSchema: {
+      recent_limit: z.number().optional(),
     },
-  );
+    outputSchema: vaultOverviewSchema,
+  }, async ({ recent_limit }) => {
+    const overview = await runtime.getVaultOverview(recent_limit);
+    return toolResult(overview, renderVaultOverviewMarkdown(overview));
+  });
 
-  server.tool(
-    'granite_list_note_types',
-    'List all configured note types',
-    {},
-    async () => {
-      const types = await runtime.listNoteTypes();
-      return { content: [{ type: 'text', text: JSON.stringify(types, null, 2) }] };
-    },
-  );
+  server.registerTool('granite_list_note_types', {
+    title: 'List Granite Note Types',
+    description: 'List all configured note types.',
+    outputSchema: noteTypesResultSchema,
+  }, async () => {
+    const types = await runtime.listNoteTypes();
+    return toolResult({ note_types: types }, renderNoteTypesMarkdown(types));
+  });
 
-  server.tool(
-    'granite_list_notes',
-    'List notes with optional filters',
-    {
+  server.registerTool('granite_list_notes', {
+    title: 'List Granite Notes',
+    description: 'List notes with optional filters.',
+    inputSchema: {
       type: z.string().optional(),
       status: z.enum(['inbox', 'active', 'archived']).optional(),
       source: z.enum(['human', 'agent', 'extraction']).optional(),
       since: z.string().optional(),
       limit: z.number().optional(),
     },
-    async (input) => {
-      const notes = await runtime.listNotes(input);
-      return { content: [{ type: 'text', text: JSON.stringify(notes, null, 2) }] };
+    outputSchema: listNotesResultSchema,
+  }, async (input) => {
+    const notes = await runtime.listNotes(input);
+    return toolResult({ notes }, renderNotesMarkdown(notes));
+  });
+
+  server.registerTool('granite_get_note', {
+    title: 'Get Granite Note',
+    description: 'Get a note by slug with full details.',
+    inputSchema: {
+      slug: z.string(),
     },
-  );
+    outputSchema: noteDetailsSchema,
+  }, async ({ slug }) => {
+    const note = await runtime.getNote(slug);
+    return toolResult(note, renderNoteDetailsMarkdown(note));
+  });
 
-  server.tool(
-    'granite_get_note',
-    'Get a note by slug with full details',
-    { slug: z.string() },
-    async ({ slug }) => {
-      const note = await runtime.getNote(slug);
-      return { content: [{ type: 'text', text: JSON.stringify(note, null, 2) }] };
+  server.registerTool('granite_search_notes', {
+    title: 'Search Granite Notes',
+    description: 'Full-text search across notes.',
+    inputSchema: {
+      query: z.string(),
+      limit: z.number().optional(),
     },
-  );
+    outputSchema: searchResultSetSchema,
+  }, async ({ query, limit }) => {
+    const results = await runtime.search(query, limit);
+    return toolResult({ query, results }, renderSearchResultsMarkdown(query, results));
+  });
 
-  server.tool(
-    'granite_search_notes',
-    'Full-text search across notes',
-    { query: z.string(), limit: z.number().optional() },
-    async ({ query, limit }) => {
-      const results = await runtime.search(query, limit);
-      return { content: [{ type: 'text', text: JSON.stringify(results, null, 2) }] };
+  server.registerTool('granite_get_backlinks', {
+    title: 'Get Granite Backlinks',
+    description: 'Get notes that link to a given note.',
+    inputSchema: {
+      slug: z.string(),
     },
-  );
+    outputSchema: backlinksResultSchema,
+  }, async ({ slug }) => {
+    const backlinks = await runtime.getBacklinks(slug);
+    return toolResult({ slug, backlinks }, renderBacklinksMarkdown(slug, backlinks));
+  });
 
-  server.tool(
-    'granite_get_backlinks',
-    'Get notes that link to a given note',
-    { slug: z.string() },
-    async ({ slug }) => {
-      const backlinks = await runtime.getBacklinks(slug);
-      return { content: [{ type: 'text', text: JSON.stringify(backlinks, null, 2) }] };
+  server.registerTool('granite_suggest_links', {
+    title: 'Suggest Granite Links',
+    description: 'Suggest wikilinks based on unlinked mentions.',
+    inputSchema: {
+      slug: z.string(),
     },
-  );
+    outputSchema: linkSuggestionsResultSchema,
+  }, async ({ slug }) => {
+    const suggestions = await runtime.suggestLinks(slug);
+    return toolResult({ slug, suggestions }, renderLinkSuggestionsMarkdown(slug, suggestions));
+  });
 
-  server.tool(
-    'granite_suggest_links',
-    'Suggest wikilinks based on unlinked mentions',
-    { slug: z.string() },
-    async ({ slug }) => {
-      const suggestions = await runtime.suggestLinks(slug);
-      return { content: [{ type: 'text', text: JSON.stringify(suggestions, null, 2) }] };
-    },
-  );
-
-  // --- Write tools ---
-
-  server.tool(
-    'granite_create_note',
-    'Create a new note',
-    {
+  server.registerTool('granite_create_note', {
+    title: 'Create Granite Note',
+    description: 'Create a new note.',
+    inputSchema: {
       title: z.string(),
       type: z.string().optional(),
       body: z.string().optional(),
@@ -118,32 +295,32 @@ function createMcpServer(runtime: CloudMcpRuntime): McpServer {
       status: z.enum(['inbox', 'active', 'archived']).optional(),
       source: z.enum(['human', 'agent', 'extraction']).optional(),
     },
-    async (input) => {
-      const result = await runtime.createNote(input);
-      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
-    },
-  );
+    outputSchema: noteMutationSchema,
+  }, async (input) => {
+    const result = await runtime.createNote(input);
+    return toolResult(result, renderMutationResultMarkdown('Created', result.note, result.recommendations));
+  });
 
-  server.tool(
-    'granite_capture_note',
-    'Quick-capture a note from free-form text',
-    {
+  server.registerTool('granite_capture_note', {
+    title: 'Capture Granite Note',
+    description: 'Quick-capture a note from free-form text.',
+    inputSchema: {
       text: z.string(),
       type: z.string().optional(),
       tags: z.array(z.string()).optional(),
       status: z.enum(['inbox', 'active', 'archived']).optional(),
       source: z.enum(['human', 'agent', 'extraction']).optional(),
     },
-    async (input) => {
-      const result = await runtime.captureNote(input);
-      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
-    },
-  );
+    outputSchema: noteMutationSchema,
+  }, async (input) => {
+    const result = await runtime.captureNote(input);
+    return toolResult(result, renderMutationResultMarkdown('Captured', result.note, result.recommendations));
+  });
 
-  server.tool(
-    'granite_update_note',
-    'Update an existing note',
-    {
+  server.registerTool('granite_update_note', {
+    title: 'Update Granite Note',
+    description: 'Update an existing note.',
+    inputSchema: {
       slug: z.string(),
       title: z.string().optional(),
       body: z.string().optional(),
@@ -153,13 +330,11 @@ function createMcpServer(runtime: CloudMcpRuntime): McpServer {
       status: z.enum(['inbox', 'active', 'archived']).optional(),
       source: z.enum(['human', 'agent', 'extraction']).optional(),
     },
-    async ({ slug, ...input }) => {
-      const result = await runtime.updateNote(slug, input);
-      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
-    },
-  );
-
-  // --- Resources ---
+    outputSchema: noteMutationSchema,
+  }, async ({ slug, ...input }) => {
+    const result = await runtime.updateNote(slug, input);
+    return toolResult(result, renderMutationResultMarkdown('Updated', result.note, result.recommendations));
+  });
 
   server.resource(
     'vault-config',
@@ -173,9 +348,20 @@ function createMcpServer(runtime: CloudMcpRuntime): McpServer {
   server.resource(
     'vault-overview',
     'granite://vault/overview',
+    {
+      title: 'Granite Vault Overview',
+      description: 'Read a compact markdown overview of the vault.',
+      mimeType: 'text/markdown',
+    },
     async (uri) => {
       const overview = await runtime.getVaultOverview();
-      return { contents: [{ uri: uri.href, mimeType: 'application/json', text: JSON.stringify(overview, null, 2) }] };
+      return {
+        contents: [{
+          uri: uri.href,
+          mimeType: 'text/markdown',
+          text: renderVaultOverviewMarkdown(overview),
+        }],
+      };
     },
   );
 
@@ -195,7 +381,6 @@ export async function handleMcp(c: Context<{ Bindings: Env }>) {
   const response = await transport.handleRequest(c.req.raw);
 
   if (response) {
-    // Add CORS headers
     const headers = new Headers(response.headers);
     const origin = c.req.header('Origin');
     if (origin) {

--- a/packages/worker/tsconfig.json
+++ b/packages/worker/tsconfig.json
@@ -6,7 +6,7 @@
     "lib": ["ES2022"],
     "types": ["@cloudflare/workers-types"],
     "outDir": "dist",
-    "rootDir": "src",
+    "rootDir": "../..",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
@@ -14,6 +14,6 @@
     "resolveJsonModule": true,
     "isolatedModules": true
   },
-  "include": ["src/**/*.ts"],
+  "include": ["src/**/*.ts", "../../shared/**/*.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/shared/mcp-markdown.ts
+++ b/shared/mcp-markdown.ts
@@ -1,0 +1,731 @@
+interface NoteLike {
+  slug: string;
+  title: string;
+  type: string;
+  created?: string;
+  modified?: string;
+  tags?: string[];
+  aliases?: string[];
+  status?: string;
+  source?: string;
+  review_state?: string;
+  durability?: string;
+  derived_from?: string[];
+  filepath?: string;
+  resource_uri?: string;
+}
+
+interface WikiLinkLike {
+  target: string;
+  display: string;
+  resolved: boolean;
+  resolved_slug?: string;
+}
+
+interface NoteDetailsLike extends NoteLike {
+  body: string;
+  frontmatter?: Record<string, unknown>;
+  outgoing_links?: WikiLinkLike[];
+}
+
+interface SearchResultLike {
+  slug: string;
+  title: string;
+  snippet: string;
+  score: number;
+}
+
+interface BacklinkLike {
+  source_slug: string;
+  source_title: string;
+  context: string;
+}
+
+interface LinkSuggestionLike {
+  target_slug: string;
+  target_title: string;
+  mentions: number;
+}
+
+interface RecommendationLike {
+  additions: Array<{ text: string }>;
+  links: Array<{ slug: string; title: string; type: string; reason: string; source: string }>;
+  tags: Array<{ tag: string; weight: number; source_slugs: string[] }>;
+  next_steps: Array<{ type: string; title_hint?: string; reason: string }>;
+}
+
+interface NoteTypeLike {
+  name: string;
+  description: string;
+  folder: string;
+  slug_format: string;
+  instructions?: string;
+  line_limit?: number;
+  warn_only?: boolean;
+  fields?: Record<string, {
+    type: string;
+    of?: string;
+    options?: string[];
+    required?: boolean;
+    default?: string;
+    description?: string;
+  }>;
+}
+
+interface VaultOverviewLike {
+  vault_name: string;
+  default_type: string;
+  note_count: number;
+  notes_by_type: Record<string, number>;
+  recent_notes: NoteLike[];
+  vault_root?: string;
+  auto_rebuild?: boolean;
+  index_last_rebuild?: string;
+}
+
+interface WakeupLike {
+  total: number;
+  by_type: Record<string, number>;
+  modified: string;
+  clusters: Array<{ tag: string; slugs: string[]; hub: string | null }>;
+  people: Array<{ slug: string; title: string }>;
+  recent: Array<{ slug: string; age: string }>;
+  stale: Array<{ slug: string; reason: string }>;
+  aaak?: string;
+}
+
+interface GardenPlanLike {
+  scope: {
+    kind: 'vault' | 'anchor';
+    anchor_slug?: string;
+    generated_at: string;
+    notes_considered: number;
+    clusters_considered: number;
+  };
+  operator_hint: string;
+  opportunities: Array<{
+    id: string;
+    kind: string;
+    priority_raw: number;
+    priority_effective: number;
+    action_hint: string;
+    targets: Array<{ slug: string; title: string; type: string; modified: string }>;
+    supporting: Array<{ slug: string; title: string; type: string; modified: string }>;
+    why_now: string;
+    stop_when: string;
+    evidence: {
+      signals: string[];
+      metrics: Record<string, number>;
+    };
+    adjudication?: {
+      reason_code: string;
+      active: boolean;
+    };
+  }>;
+}
+
+interface AdjudicationLike {
+  opportunity_id: string;
+  kind: string;
+  target_slugs: string[];
+  decision: string;
+  reason_code: string;
+  rationale?: string;
+  recorded_at: string;
+  updated_at?: string;
+  recheck_after_days?: number;
+  active: boolean;
+}
+
+interface AdjudicationResultLike {
+  opportunity_id: string;
+  decision: string;
+  adjudication: AdjudicationLike | null;
+  cleared: boolean;
+}
+
+interface ImportedDocumentLike {
+  note: NoteDetailsLike;
+  document: {
+    file: string;
+    path: string;
+    relative_path?: string;
+    markdown?: string;
+    mime_type: string;
+    resource_uri: string;
+  };
+  recommendations: RecommendationLike;
+}
+
+interface ExtractedDocumentLike {
+  doc_type: string;
+  status: string;
+  extractor: string;
+  reading_basis?: string;
+  raw_text: string;
+  confidence?: number;
+  limits?: string[];
+  title_hint?: string;
+  missing_dependency?: string;
+  install_source_url?: string;
+  verify_command?: string;
+  user_prompt?: string;
+}
+
+interface DisposeNoteLike {
+  slug: string;
+  mode: string;
+  backlinks_removed: number;
+  derived_children: number;
+  note: NoteDetailsLike | null;
+}
+
+interface NoteUnderstandingLike {
+  note: NoteDetailsLike;
+  backlinks: BacklinkLike[];
+  link_suggestions: LinkSuggestionLike[];
+  recommendations: RecommendationLike;
+  graph_role: {
+    role: string;
+    reason: string;
+    inbound_links: number;
+    outbound_links: number;
+    total_connections: number;
+  };
+}
+
+export function renderVaultOverviewMarkdown(overview: VaultOverviewLike): string {
+  const lines = ['# Vault Overview'];
+
+  pushBullets(lines, [
+    ['Vault', overview.vault_name],
+    ['Default type', overview.default_type],
+    ['Notes', String(overview.note_count)],
+    ['Vault root', overview.vault_root],
+    ['Auto rebuild', overview.auto_rebuild === undefined ? undefined : yesNo(overview.auto_rebuild)],
+    ['Index rebuilt', overview.index_last_rebuild],
+  ]);
+
+  lines.push('', '## Notes by Type');
+  if (Object.keys(overview.notes_by_type).length === 0) {
+    lines.push('- None');
+  } else {
+    for (const [type, count] of Object.entries(overview.notes_by_type).sort((a, b) => b[1] - a[1])) {
+      lines.push(`- \`${type}\`: ${count}`);
+    }
+  }
+
+  lines.push('', '## Recent Notes');
+  lines.push(...renderNoteTable(overview.recent_notes));
+
+  return lines.join('\n');
+}
+
+export function renderNoteTypesMarkdown(noteTypes: NoteTypeLike[], defaultType?: string): string {
+  const lines = ['# Note Types'];
+
+  if (defaultType) {
+    lines.push(`- Default type: \`${defaultType}\``);
+  }
+  lines.push(`- Types: ${noteTypes.length}`);
+  lines.push('', '| Name | Folder | Slug | Description |', '| --- | --- | --- | --- |');
+  for (const noteType of noteTypes) {
+    lines.push(`| \`${escapeCell(noteType.name)}\` | \`${escapeCell(noteType.folder)}\` | \`${escapeCell(noteType.slug_format)}\` | ${escapeCell(noteType.description)} |`);
+  }
+
+  for (const noteType of noteTypes) {
+    lines.push('', `## ${noteType.name}`);
+    pushBullets(lines, [
+      ['Folder', noteType.folder],
+      ['Slug format', noteType.slug_format],
+      ['Line limit', noteType.line_limit === undefined ? undefined : String(noteType.line_limit)],
+      ['Warn only', noteType.warn_only === undefined ? undefined : yesNo(noteType.warn_only)],
+      ['Instructions', noteType.instructions],
+    ]);
+
+    if (noteType.fields && Object.keys(noteType.fields).length > 0) {
+      lines.push('', '### Fields');
+      lines.push('| Field | Type | Required | Description |', '| --- | --- | --- | --- |');
+      for (const [name, field] of Object.entries(noteType.fields)) {
+        const type = field.of ? `${field.type}<${field.of}>` : field.type;
+        const descriptionParts = [field.description];
+        if (field.options && field.options.length > 0) {
+          descriptionParts.push(`options: ${field.options.join(', ')}`);
+        }
+        if (field.default !== undefined) {
+          descriptionParts.push(`default: ${field.default}`);
+        }
+        lines.push(`| \`${escapeCell(name)}\` | \`${escapeCell(type)}\` | ${field.required ? 'yes' : 'no'} | ${escapeCell(descriptionParts.filter(Boolean).join('; '))} |`);
+      }
+    }
+  }
+
+  return lines.join('\n');
+}
+
+export function renderNotesMarkdown(notes: NoteLike[], title = 'Notes'): string {
+  const lines = [`# ${title}`];
+  lines.push(`- Count: ${notes.length}`, '', ...renderNoteTable(notes));
+  return lines.join('\n');
+}
+
+export function renderSearchResultsMarkdown(query: string, results: SearchResultLike[]): string {
+  const lines = ['# Search Results', `- Query: ${inlineCode(query)}`, `- Results: ${results.length}`, ''];
+  if (results.length === 0) {
+    lines.push('No matches.');
+    return lines.join('\n');
+  }
+
+  lines.push('| Slug | Title | Score | Snippet |', '| --- | --- | --- | --- |');
+  for (const result of results) {
+    lines.push(`| \`${escapeCell(result.slug)}\` | ${escapeCell(result.title)} | ${result.score.toFixed(2)} | ${escapeCell(truncateInline(result.snippet, 160))} |`);
+  }
+  return lines.join('\n');
+}
+
+export function renderBacklinksMarkdown(slug: string, backlinks: BacklinkLike[]): string {
+  const lines = ['# Backlinks', `- Target: \`${slug}\``, `- Backlinks: ${backlinks.length}`, ''];
+  if (backlinks.length === 0) {
+    lines.push('No backlinks.');
+    return lines.join('\n');
+  }
+
+  lines.push('| Source | Title | Context |', '| --- | --- | --- |');
+  for (const backlink of backlinks) {
+    lines.push(`| \`${escapeCell(backlink.source_slug)}\` | ${escapeCell(backlink.source_title)} | ${escapeCell(truncateInline(backlink.context, 160))} |`);
+  }
+  return lines.join('\n');
+}
+
+export function renderLinkSuggestionsMarkdown(slug: string, suggestions: LinkSuggestionLike[]): string {
+  const lines = ['# Link Suggestions', `- Note: \`${slug}\``, `- Suggestions: ${suggestions.length}`, ''];
+  if (suggestions.length === 0) {
+    lines.push('No link suggestions.');
+    return lines.join('\n');
+  }
+
+  lines.push('| Target | Title | Mentions |', '| --- | --- | --- |');
+  for (const suggestion of suggestions) {
+    lines.push(`| \`${escapeCell(suggestion.target_slug)}\` | ${escapeCell(suggestion.target_title)} | ${suggestion.mentions} |`);
+  }
+  return lines.join('\n');
+}
+
+export function renderNoteDetailsMarkdown(note: NoteDetailsLike): string {
+  const lines = [`# ${note.title}`];
+
+  pushNoteMetadata(lines, note);
+
+  const extraFrontmatter = note.frontmatter
+    ? Object.entries(note.frontmatter).filter(([key]) => !STANDARD_FRONTMATTER_KEYS.has(key))
+    : [];
+
+  if (extraFrontmatter.length > 0) {
+    lines.push('', '## Extra Frontmatter');
+    for (const [key, value] of extraFrontmatter) {
+      lines.push(`- ${key}: ${formatUnknown(value)}`);
+    }
+  }
+
+  lines.push('', '## Body', note.body.trim() || '(empty)');
+
+  lines.push('', '## Outgoing Links');
+  if (!note.outgoing_links || note.outgoing_links.length === 0) {
+    lines.push('- None');
+  } else {
+    lines.push('| Display | Target | Resolved |', '| --- | --- | --- |');
+    for (const link of note.outgoing_links) {
+      const resolvedTarget = link.resolved ? (link.resolved_slug ?? link.target) : link.target;
+      lines.push(`| ${escapeCell(link.display)} | \`${escapeCell(resolvedTarget)}\` | ${link.resolved ? 'yes' : 'no'} |`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+export function renderMutationResultMarkdown(action: string, note: NoteDetailsLike, recommendations: RecommendationLike): string {
+  const lines = [`# ${action} Note`];
+  pushNoteMetadata(lines, note);
+  appendRecommendations(lines, recommendations);
+  return lines.join('\n');
+}
+
+export function renderUnderstandNoteMarkdown(result: NoteUnderstandingLike): string {
+  const lines = ['# Note Context'];
+  pushNoteMetadata(lines, result.note);
+  lines.push('', '## Graph Role');
+  pushBullets(lines, [
+    ['Role', result.graph_role.role],
+    ['Reason', result.graph_role.reason],
+    ['Inbound links', String(result.graph_role.inbound_links)],
+    ['Outbound links', String(result.graph_role.outbound_links)],
+    ['Total connections', String(result.graph_role.total_connections)],
+  ]);
+
+  lines.push('', '## Backlinks');
+  lines.push(...renderBacklinksSection(result.backlinks));
+
+  lines.push('', '## Link Suggestions');
+  lines.push(...renderLinkSuggestionsSection(result.link_suggestions));
+
+  appendRecommendations(lines, result.recommendations);
+  return lines.join('\n');
+}
+
+export function renderWakeupMarkdown(result: WakeupLike): string {
+  const lines = ['# Vault Wakeup'];
+  pushBullets(lines, [
+    ['Notes', String(result.total)],
+    ['Last modified', result.modified],
+  ]);
+
+  lines.push('', '## Notes by Type');
+  for (const [type, count] of Object.entries(result.by_type).sort((a, b) => b[1] - a[1])) {
+    lines.push(`- \`${type}\`: ${count}`);
+  }
+
+  lines.push('', '## Clusters');
+  if (result.clusters.length === 0) {
+    lines.push('- None');
+  } else {
+    for (const cluster of result.clusters) {
+      const hub = cluster.hub ? `, hub: \`${cluster.hub}\`` : '';
+      lines.push(`- \`${cluster.tag}\` (${cluster.slugs.length} notes${hub})`);
+    }
+  }
+
+  lines.push('', '## Recent');
+  if (result.recent.length === 0) {
+    lines.push('- None');
+  } else {
+    for (const item of result.recent) {
+      lines.push(`- \`${item.slug}\` (${item.age})`);
+    }
+  }
+
+  lines.push('', '## Stale');
+  if (result.stale.length === 0) {
+    lines.push('- None');
+  } else {
+    for (const item of result.stale) {
+      lines.push(`- \`${item.slug}\`: ${item.reason}`);
+    }
+  }
+
+  if (result.people.length > 0) {
+    lines.push('', '## People');
+    for (const person of result.people) {
+      lines.push(`- \`${person.slug}\`: ${person.title}`);
+    }
+  }
+
+  if (result.aaak) {
+    lines.push('', '## AAAK', result.aaak);
+  }
+
+  return lines.join('\n');
+}
+
+export function renderGardenPlanMarkdown(result: GardenPlanLike): string {
+  const lines = ['# Garden Plan'];
+  pushBullets(lines, [
+    ['Scope', result.scope.kind === 'anchor' ? `anchor:${result.scope.anchor_slug}` : 'vault'],
+    ['Generated at', result.scope.generated_at],
+    ['Notes considered', String(result.scope.notes_considered)],
+    ['Clusters considered', String(result.scope.clusters_considered)],
+    ['Operator hint', result.operator_hint],
+  ]);
+
+  lines.push('', '## Opportunities');
+  if (result.opportunities.length === 0) {
+    lines.push('- None');
+    return lines.join('\n');
+  }
+
+  for (const opportunity of result.opportunities) {
+    const targetLabels = opportunity.targets.map(target => `\`${target.slug}\``).join(', ');
+    lines.push(`### ${opportunity.kind} · ${targetLabels || '`none`'}`);
+    pushBullets(lines, [
+      ['Opportunity ID', opportunity.id],
+      ['Action', opportunity.action_hint],
+      ['Priority', `${opportunity.priority_effective.toFixed(2)} effective / ${opportunity.priority_raw.toFixed(2)} raw`],
+      ['Why now', opportunity.why_now],
+      ['Stop when', opportunity.stop_when],
+      ['Adjudication', opportunity.adjudication ? `${opportunity.adjudication.reason_code} (${opportunity.adjudication.active ? 'active' : 'inactive'})` : undefined],
+    ]);
+
+    if (opportunity.supporting.length > 0) {
+      lines.push('- Supporting: ' + opportunity.supporting.map(item => `\`${item.slug}\``).join(', '));
+    }
+
+    if (opportunity.evidence.signals.length > 0) {
+      lines.push('- Signals: ' + opportunity.evidence.signals.join('; '));
+    }
+
+    const metrics = Object.entries(opportunity.evidence.metrics);
+    if (metrics.length > 0) {
+      lines.push('- Metrics: ' + metrics.map(([key, value]) => `${key}=${value}`).join(', '));
+    }
+
+    lines.push('');
+  }
+
+  return lines.join('\n').trimEnd();
+}
+
+export function renderGardenAdjudicationsMarkdown(adjudications: AdjudicationLike[]): string {
+  const lines = ['# Garden Adjudications', `- Active adjudications: ${adjudications.length}`, ''];
+  if (adjudications.length === 0) {
+    lines.push('No active adjudications.');
+    return lines.join('\n');
+  }
+
+  for (const adjudication of adjudications) {
+    lines.push(`## ${adjudication.kind} · \`${adjudication.opportunity_id}\``);
+    pushBullets(lines, [
+      ['Targets', adjudication.target_slugs.join(', ')],
+      ['Decision', adjudication.decision],
+      ['Reason', adjudication.reason_code],
+      ['Recorded at', adjudication.recorded_at],
+      ['Updated at', adjudication.updated_at],
+      ['Recheck after days', adjudication.recheck_after_days === undefined ? undefined : String(adjudication.recheck_after_days)],
+      ['Rationale', adjudication.rationale],
+      ['Active', yesNo(adjudication.active)],
+    ]);
+    lines.push('');
+  }
+
+  return lines.join('\n').trimEnd();
+}
+
+export function renderAdjudicationResultMarkdown(result: AdjudicationResultLike): string {
+  const lines = ['# Garden Adjudication'];
+  pushBullets(lines, [
+    ['Opportunity ID', result.opportunity_id],
+    ['Decision', result.decision],
+    ['Cleared', yesNo(result.cleared)],
+  ]);
+
+  if (result.adjudication) {
+    lines.push('', '## Current State');
+    pushBullets(lines, [
+      ['Kind', result.adjudication.kind],
+      ['Targets', result.adjudication.target_slugs.join(', ')],
+      ['Reason', result.adjudication.reason_code],
+      ['Recorded at', result.adjudication.recorded_at],
+      ['Rationale', result.adjudication.rationale],
+      ['Active', yesNo(result.adjudication.active)],
+    ]);
+  }
+
+  return lines.join('\n');
+}
+
+export function renderImportDocumentMarkdown(result: ImportedDocumentLike): string {
+  const lines = ['# Imported Document'];
+  pushBullets(lines, [
+    ['File', result.document.file],
+    ['Type', result.document.mime_type],
+    ['Stored at', result.document.path],
+    ['Resource', result.document.resource_uri],
+    ['Note', `${result.note.title} (\`${result.note.slug}\`)`],
+  ]);
+  appendRecommendations(lines, result.recommendations);
+  return lines.join('\n');
+}
+
+export function renderExtractDocumentMarkdown(result: ExtractedDocumentLike): string {
+  const lines = ['# Document Extraction'];
+  pushBullets(lines, [
+    ['Status', result.status],
+    ['Document type', result.doc_type],
+    ['Extractor', result.extractor],
+    ['Reading basis', result.reading_basis],
+    ['Confidence', result.confidence === undefined ? undefined : String(result.confidence)],
+    ['Title hint', result.title_hint],
+    ['Missing dependency', result.missing_dependency],
+    ['Install source', result.install_source_url],
+    ['Verify command', result.verify_command],
+    ['User prompt', result.user_prompt],
+  ]);
+
+  if (result.limits && result.limits.length > 0) {
+    lines.push('', '## Limits');
+    for (const limit of result.limits) {
+      lines.push(`- ${limit}`);
+    }
+  }
+
+  lines.push('', '## Raw Text', result.raw_text.trim() || '(empty)');
+  return lines.join('\n');
+}
+
+export function renderDisposeNoteMarkdown(result: DisposeNoteLike): string {
+  const lines = ['# Disposed Note'];
+  pushBullets(lines, [
+    ['Slug', result.slug],
+    ['Mode', result.mode],
+    ['Backlinks removed', String(result.backlinks_removed)],
+    ['Derived children', String(result.derived_children)],
+    ['Archived note remains', result.note ? 'yes' : 'no'],
+  ]);
+
+  if (result.note) {
+    lines.push('', '## Note');
+    pushNoteMetadata(lines, result.note);
+  }
+
+  return lines.join('\n');
+}
+
+function pushNoteMetadata(lines: string[], note: NoteLike): void {
+  pushBullets(lines, [
+    ['Slug', note.slug],
+    ['Type', note.type],
+    ['Status', note.status],
+    ['Source', note.source],
+    ['Review state', note.review_state],
+    ['Durability', note.durability],
+    ['Created', note.created],
+    ['Modified', note.modified],
+    ['Tags', note.tags && note.tags.length > 0 ? note.tags.join(', ') : undefined],
+    ['Aliases', note.aliases && note.aliases.length > 0 ? note.aliases.join(', ') : undefined],
+    ['Derived from', note.derived_from && note.derived_from.length > 0 ? note.derived_from.join(', ') : undefined],
+    ['Path', note.filepath],
+    ['Resource', note.resource_uri],
+  ]);
+}
+
+function appendRecommendations(lines: string[], recommendations: RecommendationLike): void {
+  lines.push('', '## Recommendations');
+
+  if (
+    recommendations.additions.length === 0
+    && recommendations.links.length === 0
+    && recommendations.tags.length === 0
+    && recommendations.next_steps.length === 0
+  ) {
+    lines.push('- None');
+    return;
+  }
+
+  if (recommendations.additions.length > 0) {
+    for (const addition of recommendations.additions) {
+      lines.push(`- Addition: ${addition.text}`);
+    }
+  }
+
+  if (recommendations.links.length > 0) {
+    for (const link of recommendations.links) {
+      lines.push(`- Link: \`${link.slug}\` (${link.type}, ${link.source}) — ${link.reason}`);
+    }
+  }
+
+  if (recommendations.tags.length > 0) {
+    for (const tag of recommendations.tags) {
+      lines.push(`- Tag: \`${tag.tag}\` (${tag.weight.toFixed(2)}) from ${tag.source_slugs.join(', ')}`);
+    }
+  }
+
+  if (recommendations.next_steps.length > 0) {
+    for (const nextStep of recommendations.next_steps) {
+      const titleHint = nextStep.title_hint ? ` title hint: ${nextStep.title_hint}.` : '';
+      lines.push(`- Next step: \`${nextStep.type}\` — ${nextStep.reason}.${titleHint}`.replace('..', '.'));
+    }
+  }
+}
+
+function renderNoteTable(notes: NoteLike[]): string[] {
+  if (notes.length === 0) {
+    return ['No notes.'];
+  }
+
+  const lines = ['| Slug | Title | Type | Modified |', '| --- | --- | --- | --- |'];
+  for (const note of notes) {
+    lines.push(`| \`${escapeCell(note.slug)}\` | ${escapeCell(note.title)} | \`${escapeCell(note.type)}\` | ${escapeCell(note.modified ?? '')} |`);
+  }
+  return lines;
+}
+
+function renderBacklinksSection(backlinks: BacklinkLike[]): string[] {
+  if (backlinks.length === 0) {
+    return ['- None'];
+  }
+
+  const lines = ['| Source | Title | Context |', '| --- | --- | --- |'];
+  for (const backlink of backlinks) {
+    lines.push(`| \`${escapeCell(backlink.source_slug)}\` | ${escapeCell(backlink.source_title)} | ${escapeCell(truncateInline(backlink.context, 160))} |`);
+  }
+  return lines;
+}
+
+function renderLinkSuggestionsSection(suggestions: LinkSuggestionLike[]): string[] {
+  if (suggestions.length === 0) {
+    return ['- None'];
+  }
+
+  const lines = ['| Target | Title | Mentions |', '| --- | --- | --- |'];
+  for (const suggestion of suggestions) {
+    lines.push(`| \`${escapeCell(suggestion.target_slug)}\` | ${escapeCell(suggestion.target_title)} | ${suggestion.mentions} |`);
+  }
+  return lines;
+}
+
+function pushBullets(lines: string[], entries: Array<[string, string | undefined]>): void {
+  for (const [label, value] of entries) {
+    if (value) {
+      lines.push(`- ${label}: ${value}`);
+    }
+  }
+}
+
+function truncateInline(value: string, max: number): string {
+  const normalized = value.replace(/\s+/g, ' ').trim();
+  return normalized.length <= max ? normalized : `${normalized.slice(0, Math.max(0, max - 1)).trimEnd()}…`;
+}
+
+function formatUnknown(value: unknown): string {
+  if (value === null) {
+    return 'null';
+  }
+  if (value === undefined) {
+    return 'undefined';
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  if (Array.isArray(value)) {
+    return value.map(item => formatUnknown(item)).join(', ');
+  }
+  return JSON.stringify(value);
+}
+
+function yesNo(value: boolean): string {
+  return value ? 'yes' : 'no';
+}
+
+function inlineCode(value: string): string {
+  return `\`${value.replace(/`/g, '\\`')}\``;
+}
+
+function escapeCell(value: string): string {
+  return value.replace(/\|/g, '\\|').replace(/\n/g, '<br>');
+}
+
+const STANDARD_FRONTMATTER_KEYS = new Set([
+  'id',
+  'title',
+  'type',
+  'created',
+  'modified',
+  'tags',
+  'aliases',
+  'status',
+  'source',
+  'review_state',
+  'durability',
+  'derived_from',
+]);

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,9 +1,13 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { writeDefaultConfig, CONFIG_FILENAME, loadConfig } from '../core/config.js';
+import { writeDefaultConfig, writeTemplateConfig, CONFIG_FILENAME, loadConfig } from '../core/config.js';
 import { getDefaultVaultRoot, getIndexDbPath } from '../core/vault.js';
 
-export function initVault(dir = getDefaultVaultRoot()): void {
+export interface InitVaultOptions {
+  template?: string;
+}
+
+export function initVault(dir = getDefaultVaultRoot(), options: InitVaultOptions = {}): void {
   const targetDir = path.resolve(dir);
   fs.mkdirSync(targetDir, { recursive: true });
 
@@ -12,8 +16,11 @@ export function initVault(dir = getDefaultVaultRoot()): void {
     process.exit(1);
   }
 
-  // Write config
-  writeDefaultConfig(targetDir);
+  if (options.template) {
+    writeTemplateConfig(targetDir, options.template);
+  } else {
+    writeDefaultConfig(targetDir);
+  }
 
   fs.mkdirSync(path.dirname(getIndexDbPath(targetDir)), { recursive: true });
 

--- a/src/core/compile-context.ts
+++ b/src/core/compile-context.ts
@@ -1,0 +1,157 @@
+import type Database from 'better-sqlite3';
+import type { GraniteConfig } from './types.js';
+import { getBacklinks } from './backlinks.js';
+import { searchNotes } from './search.js';
+import { runQuery } from './query.js';
+
+export interface CompileContextInput {
+  topic?: string;
+  slug?: string;
+  depth?: number;
+  limit?: number;
+}
+
+export interface CompileContextResult {
+  mode: 'topic' | 'slug';
+  title: string;
+  sections: CompiledSection[];
+}
+
+export interface CompiledSection {
+  heading: string;
+  entries: CompiledEntry[];
+}
+
+export interface CompiledEntry {
+  slug: string;
+  title: string;
+  type: string;
+  reason: string;
+}
+
+/**
+ * Deterministic context compilation: walk the graph and type filters to produce
+ * a typed brief. No LLM — pure filtering + ranking.
+ */
+export function compileContext(
+  db: Database.Database,
+  config: GraniteConfig,
+  input: CompileContextInput,
+): CompileContextResult {
+  if (input.slug) return compileForSlug(db, config, input.slug, input.limit ?? 20);
+  if (input.topic) return compileForTopic(db, config, input.topic, input.limit ?? 20);
+  throw new Error('compile_context requires either topic or slug');
+}
+
+function compileForSlug(
+  db: Database.Database,
+  config: GraniteConfig,
+  slug: string,
+  limit: number,
+): CompileContextResult {
+  const note = db.prepare('SELECT slug, title, type FROM notes WHERE slug = ?').get(slug) as
+    | { slug: string; title: string; type: string }
+    | undefined;
+  if (!note) throw new Error(`Note "${slug}" not found`);
+
+  const sections: CompiledSection[] = [];
+
+  if (note.type === 'organization' && config.note_types.person) {
+    const peopleResults = runQuery(db, config, {
+      type: 'person',
+      where: { organization: slug },
+      limit,
+    });
+    if (peopleResults.length > 0) {
+      sections.push({
+        heading: 'Team',
+        entries: peopleResults.map(r => ({
+          slug: r.slug,
+          title: r.title,
+          type: r.type,
+          reason: `Member of ${note.title}`,
+        })),
+      });
+    }
+  }
+
+  if (note.type === 'organization' && config.note_types.meeting) {
+    const meetings = runQuery(db, config, {
+      type: 'meeting',
+      where: { organization: slug },
+      sort: { field: 'date', dir: 'desc' },
+      limit,
+    });
+    if (meetings.length > 0) {
+      sections.push({
+        heading: 'Recent meetings',
+        entries: meetings.map(r => ({
+          slug: r.slug,
+          title: r.title,
+          type: r.type,
+          reason: `Meeting${r.fields.date ? ` on ${r.fields.date}` : ''}`,
+        })),
+      });
+    }
+  }
+
+  const backlinks = getBacklinks(db, slug);
+  if (backlinks.length > 0) {
+    sections.push({
+      heading: 'Backlinks',
+      entries: backlinks.slice(0, limit).map(b => ({
+        slug: b.source_slug,
+        title: b.source_title,
+        type: lookupType(db, b.source_slug) ?? 'note',
+        reason: b.context || 'References this note',
+      })),
+    });
+  }
+
+  return { mode: 'slug', title: note.title, sections };
+}
+
+function compileForTopic(
+  db: Database.Database,
+  config: GraniteConfig,
+  topic: string,
+  limit: number,
+): CompileContextResult {
+  const searchResults = searchNotes(db, topic, limit);
+  const byType = new Map<string, CompiledEntry[]>();
+  for (const r of searchResults) {
+    const type = lookupType(db, r.slug) ?? 'note';
+    const list = byType.get(type) ?? [];
+    list.push({
+      slug: r.slug,
+      title: r.title,
+      type,
+      reason: r.snippet || `Match for "${topic}"`,
+    });
+    byType.set(type, list);
+  }
+
+  const orderedTypes = ['source', 'learning', 'note', 'synthesis', 'output', 'meeting', 'person', 'organization'];
+  const sections: CompiledSection[] = [];
+  for (const t of orderedTypes) {
+    const entries = byType.get(t);
+    if (entries && entries.length > 0) {
+      sections.push({ heading: capitalize(t) + 's', entries });
+    }
+  }
+  for (const [t, entries] of byType.entries()) {
+    if (orderedTypes.includes(t)) continue;
+    sections.push({ heading: capitalize(t) + 's', entries });
+  }
+
+  return { mode: 'topic', title: topic, sections };
+}
+
+function lookupType(db: Database.Database, slug: string): string | undefined {
+  const row = db.prepare('SELECT type FROM notes WHERE slug = ?').get(slug) as { type: string } | undefined;
+  return row?.type;
+}
+
+function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}

--- a/src/core/compile-context.ts
+++ b/src/core/compile-context.ts
@@ -56,7 +56,7 @@ function compileForSlug(
 
   const sections: CompiledSection[] = [];
 
-  if (note.type === 'organization' && config.note_types.person) {
+  if (note.type === 'organization' && typeHasIndexedField(config, 'person', 'organization')) {
     const peopleResults = runQuery(db, config, {
       type: 'person',
       where: { organization: slug },
@@ -75,11 +75,12 @@ function compileForSlug(
     }
   }
 
-  if (note.type === 'organization' && config.note_types.meeting) {
+  if (note.type === 'organization' && typeHasIndexedField(config, 'meeting', 'organization')) {
+    const sortByDate = typeHasIndexedField(config, 'meeting', 'date');
     const meetings = runQuery(db, config, {
       type: 'meeting',
       where: { organization: slug },
-      sort: { field: 'date', dir: 'desc' },
+      ...(sortByDate ? { sort: { field: 'date', dir: 'desc' as const } } : {}),
       limit,
     });
     if (meetings.length > 0) {
@@ -150,6 +151,11 @@ function compileForTopic(
 function lookupType(db: Database.Database, slug: string): string | undefined {
   const row = db.prepare('SELECT type FROM notes WHERE slug = ?').get(slug) as { type: string } | undefined;
   return row?.type;
+}
+
+function typeHasIndexedField(config: Parameters<typeof runQuery>[1], typeName: string, field: string): boolean {
+  const t = config.note_types[typeName];
+  return !!t && !!t.indexed_fields && t.indexed_fields.includes(field);
 }
 
 function capitalize(s: string): string {

--- a/src/core/compile-context.ts
+++ b/src/core/compile-context.ts
@@ -136,12 +136,12 @@ function compileForTopic(
   for (const t of orderedTypes) {
     const entries = byType.get(t);
     if (entries && entries.length > 0) {
-      sections.push({ heading: capitalize(t) + 's', entries });
+      sections.push({ heading: pluralizeTypeLabel(t), entries });
     }
   }
   for (const [t, entries] of byType.entries()) {
     if (orderedTypes.includes(t)) continue;
-    sections.push({ heading: capitalize(t) + 's', entries });
+    sections.push({ heading: pluralizeTypeLabel(t), entries });
   }
 
   return { mode: 'topic', title: topic, sections };
@@ -154,4 +154,16 @@ function lookupType(db: Database.Database, slug: string): string | undefined {
 
 function capitalize(s: string): string {
   return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+const TYPE_PLURAL_OVERRIDES: Record<string, string> = {
+  synthesis: 'Syntheses',
+  analysis: 'Analyses',
+  thesis: 'Theses',
+  person: 'People',
+};
+
+function pluralizeTypeLabel(type: string): string {
+  if (TYPE_PLURAL_OVERRIDES[type]) return TYPE_PLURAL_OVERRIDES[type];
+  return capitalize(type) + 's';
 }

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -108,14 +108,6 @@ export function writeTemplateConfig(dir: string, templateName: string): void {
   fs.writeFileSync(configPath, raw, 'utf-8');
 }
 
-export function listTemplates(): string[] {
-  const dir = getTemplatesDir();
-  if (!fs.existsSync(dir)) return [];
-  return fs.readdirSync(dir)
-    .filter(f => f.endsWith('.yml'))
-    .map(f => f.replace(/\.yml$/, ''));
-}
-
 function getTemplatesDir(): string {
   // Resolve relative to this file — works in both src (dev) and dist (built).
   const fileUrl = new URL('.', import.meta.url);
@@ -175,31 +167,8 @@ export function validateConfig(config: GraniteConfig): void {
       }
     }
 
-    for (const hook of typeConfig.on_create ?? []) {
-      if (hook.action === 'resolve_wikilinks') {
-        for (const f of hook.fields) {
-          if (!fieldNames.has(f)) {
-            throw new Error(
-              `Invalid config: type "${typeName}" on_create resolve_wikilinks references undefined field "${f}"`,
-            );
-          }
-        }
-      }
-      if (hook.action === 'hash_source' || hook.action === 'set_default') {
-        if (!isKnownHookField(hook.field, fieldNames)) {
-          throw new Error(
-            `Invalid config: type "${typeName}" on_create ${hook.action} references undefined field "${hook.field}"`,
-          );
-        }
-      }
-      if (hook.action === 'hash_source') {
-        if (!isKnownHookField(hook.target, fieldNames)) {
-          throw new Error(
-            `Invalid config: type "${typeName}" on_create hash_source references undefined target field "${hook.target}"`,
-          );
-        }
-      }
-    }
+    validateHooks(typeName, 'on_create', typeConfig.on_create ?? [], fieldNames);
+    validateHooks(typeName, 'on_update', typeConfig.on_update ?? [], fieldNames);
 
     if (typeConfig.lifecycle) {
       const states = new Set(typeConfig.lifecycle.states);
@@ -209,6 +178,39 @@ export function validateConfig(config: GraniteConfig): void {
             `Invalid config: type "${typeName}" lifecycle transition ${t.from}→${t.to} references undeclared state`,
           );
         }
+      }
+    }
+  }
+}
+
+function validateHooks(
+  typeName: string,
+  phase: 'on_create' | 'on_update',
+  hooks: import('./types.js').Hook[],
+  fieldNames: Set<string>,
+): void {
+  for (const hook of hooks) {
+    if (hook.action === 'resolve_wikilinks') {
+      for (const f of hook.fields) {
+        if (!fieldNames.has(f)) {
+          throw new Error(
+            `Invalid config: type "${typeName}" ${phase} resolve_wikilinks references undefined field "${f}"`,
+          );
+        }
+      }
+    }
+    if (hook.action === 'hash_source' || hook.action === 'set_default') {
+      if (!isKnownHookField(hook.field, fieldNames)) {
+        throw new Error(
+          `Invalid config: type "${typeName}" ${phase} ${hook.action} references undefined field "${hook.field}"`,
+        );
+      }
+    }
+    if (hook.action === 'hash_source') {
+      if (!isKnownHookField(hook.target, fieldNames)) {
+        throw new Error(
+          `Invalid config: type "${typeName}" ${phase} hash_source references undefined target field "${hook.target}"`,
+        );
       }
     }
   }

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -95,6 +95,49 @@ export function writeDefaultConfig(dir: string): void {
   fs.writeFileSync(configPath, content, 'utf-8');
 }
 
+export function writeTemplateConfig(dir: string, templateName: string): void {
+  const configPath = path.join(dir, CONFIG_FILENAME);
+  const templatePath = resolveTemplatePath(templateName);
+  if (!fs.existsSync(templatePath)) {
+    throw new Error(`Unknown template "${templateName}". Not found at ${templatePath}.`);
+  }
+  const raw = fs.readFileSync(templatePath, 'utf-8');
+  // Validate before writing to fail fast on malformed templates.
+  const parsed = yaml.load(raw) as GraniteConfig;
+  validateConfig(parsed);
+  fs.writeFileSync(configPath, raw, 'utf-8');
+}
+
+export function listTemplates(): string[] {
+  const dir = getTemplatesDir();
+  if (!fs.existsSync(dir)) return [];
+  return fs.readdirSync(dir)
+    .filter(f => f.endsWith('.yml'))
+    .map(f => f.replace(/\.yml$/, ''));
+}
+
+function getTemplatesDir(): string {
+  // Resolve relative to this file — works in both src (dev) and dist (built).
+  const fileUrl = new URL('.', import.meta.url);
+  const thisDir = decodeURIComponent(fileUrl.pathname);
+  // Prod (bundled): dist/index.js → dist/templates/
+  // Dev (tsx src/core/config.ts): src/core/ → ../../templates
+  const candidates = [
+    path.resolve(thisDir, 'templates'),
+    path.resolve(thisDir, '../templates'),
+    path.resolve(thisDir, '../../templates'),
+    path.resolve(process.cwd(), 'templates'),
+  ];
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  return candidates[0];
+}
+
+function resolveTemplatePath(name: string): string {
+  return path.join(getTemplatesDir(), `${name}.yml`);
+}
+
 export function loadConfig(vaultRoot: string): GraniteConfig {
   const configPath = path.join(vaultRoot, CONFIG_FILENAME);
   if (!fs.existsSync(configPath)) {
@@ -102,7 +145,64 @@ export function loadConfig(vaultRoot: string): GraniteConfig {
   }
   const raw = fs.readFileSync(configPath, 'utf-8');
   const parsed = yaml.load(raw) as GraniteConfig;
+  validateConfig(parsed);
   return parsed;
+}
+
+export function validateConfig(config: GraniteConfig): void {
+  const typeNames = new Set(Object.keys(config.note_types));
+
+  for (const [typeName, typeConfig] of Object.entries(config.note_types)) {
+    const fieldNames = new Set(Object.keys(typeConfig.fields ?? {}));
+
+    for (const [fieldName, fieldDef] of Object.entries(typeConfig.fields ?? {})) {
+      if (fieldDef.type === 'wikilink' && fieldDef.target_types) {
+        for (const target of fieldDef.target_types) {
+          if (!typeNames.has(target)) {
+            throw new Error(
+              `Invalid config: type "${typeName}" field "${fieldName}" references unknown target_type "${target}"`,
+            );
+          }
+        }
+      }
+    }
+
+    for (const indexed of typeConfig.indexed_fields ?? []) {
+      if (!fieldNames.has(indexed)) {
+        throw new Error(
+          `Invalid config: type "${typeName}" indexed_fields references undefined field "${indexed}"`,
+        );
+      }
+    }
+
+    for (const hook of typeConfig.on_create ?? []) {
+      if (hook.action === 'resolve_wikilinks') {
+        for (const f of hook.fields) {
+          if (!fieldNames.has(f)) {
+            throw new Error(
+              `Invalid config: type "${typeName}" on_create resolve_wikilinks references undefined field "${f}"`,
+            );
+          }
+        }
+      }
+      if (hook.action === 'hash_source' || hook.action === 'set_default') {
+        if (!fieldNames.has(hook.field) && hook.field !== 'document_sha256') {
+          // allow well-known fields too
+        }
+      }
+    }
+
+    if (typeConfig.lifecycle) {
+      const states = new Set(typeConfig.lifecycle.states);
+      for (const t of typeConfig.lifecycle.transitions) {
+        if (!states.has(t.from) || !states.has(t.to)) {
+          throw new Error(
+            `Invalid config: type "${typeName}" lifecycle transition ${t.from}→${t.to} references undeclared state`,
+          );
+        }
+      }
+    }
+  }
 }
 
 export { CONFIG_FILENAME };

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -186,8 +186,17 @@ export function validateConfig(config: GraniteConfig): void {
         }
       }
       if (hook.action === 'hash_source' || hook.action === 'set_default') {
-        if (!fieldNames.has(hook.field) && hook.field !== 'document_sha256') {
-          // allow well-known fields too
+        if (!isKnownHookField(hook.field, fieldNames)) {
+          throw new Error(
+            `Invalid config: type "${typeName}" on_create ${hook.action} references undefined field "${hook.field}"`,
+          );
+        }
+      }
+      if (hook.action === 'hash_source') {
+        if (!isKnownHookField(hook.target, fieldNames)) {
+          throw new Error(
+            `Invalid config: type "${typeName}" on_create hash_source references undefined target field "${hook.target}"`,
+          );
         }
       }
     }
@@ -203,6 +212,18 @@ export function validateConfig(config: GraniteConfig): void {
       }
     }
   }
+}
+
+const WELL_KNOWN_HOOK_FIELDS = new Set([
+  'document_file',
+  'document_path',
+  'document_mime',
+  'document_sha256',
+  'document_resource_uri',
+]);
+
+function isKnownHookField(field: string, declared: Set<string>): boolean {
+  return declared.has(field) || WELL_KNOWN_HOOK_FIELDS.has(field);
 }
 
 export { CONFIG_FILENAME };

--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -5,6 +5,7 @@ import type { GraniteConfig, DoctorIssue } from './types.js';
 import { listNotes } from './note.js';
 import { validateDurability, validateReviewState } from './json-output.js';
 import { parseWikilinks, resolveWikilinks } from './wikilinks.js';
+import { suggestLifecycleTransitions } from './lifecycle.js';
 
 export function runDoctor(vaultRoot: string, config: GraniteConfig, db: Database.Database): DoctorIssue[] {
   const issues: DoctorIssue[] = [];
@@ -140,6 +141,35 @@ export function runDoctor(vaultRoot: string, config: GraniteConfig, db: Database
         level: 'info',
         file: note.filepath,
         message: 'Orphan note: no incoming or outgoing links',
+      });
+    }
+  }
+
+  // 8. Reclassement suggestions — notes typed as 'note' with tags matching a specialized type
+  const specializedTypes = Object.keys(config.note_types).filter(
+    t => t !== 'note' && t !== 'source' && t !== 'synthesis' && t !== 'output',
+  );
+  for (const note of notes) {
+    if (note.frontmatter.type !== 'note') continue;
+    for (const typeName of specializedTypes) {
+      if (note.frontmatter.tags?.includes(typeName)) {
+        issues.push({
+          level: 'info',
+          file: note.filepath,
+          message: `Reclassement suggestion: note tagged "${typeName}" could be promoted to type "${typeName}". Try: granite_revise_note slug=${note.slug} type=${typeName}`,
+        });
+        break;
+      }
+    }
+  }
+
+  // 9. Lifecycle transitions ready to fire
+  for (const note of notes) {
+    for (const suggestion of suggestLifecycleTransitions(note, config)) {
+      issues.push({
+        level: 'info',
+        file: note.filepath,
+        message: `Lifecycle suggestion: ${suggestion.from} → ${suggestion.to} (${suggestion.reason})`,
       });
     }
   }

--- a/src/core/extract-document.ts
+++ b/src/core/extract-document.ts
@@ -166,13 +166,6 @@ async function extractPptx(filePath: string): Promise<ExtractDocumentResult> {
 
 async function extractPdfWithFerrules(filePath: string): Promise<ExtractDocumentResult> {
   const titleHint = defaultImportedDocumentTitle(filePath);
-
-  if (process.platform !== 'darwin') {
-    return failedResult('pdf', 'ferrules', titleHint, [
-      'Ferrules-based PDF extraction is only supported on macOS in this version of Granite.',
-    ]);
-  }
-
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'granite-ferrules-'));
 
   try {

--- a/src/core/hooks.ts
+++ b/src/core/hooks.ts
@@ -39,8 +39,8 @@ function runHooks(
   const out: NoteFrontmatter = { ...frontmatter };
   const created_stubs: HookResult['created_stubs'] = [];
   const reservedSlugs = new Set<string>(ctx.reservedSlugs ?? []);
-  // Dedup auto-stubs created in a single hook run so repeated refs reuse the first slug.
-  const stubsByKey = new Map<string, string>();
+  // Dedup resolutions in a single hook run so repeated refs reuse the first result.
+  const resolvedByKey = new Map<string, string>();
 
   for (const hook of hooks) {
     switch (hook.action) {
@@ -52,14 +52,14 @@ function runHooks(
           const targetType = typeConfig?.target_types?.[0];
           const resolveOne = (raw: string): string => {
             const key = `${targetType ?? '*'}::${raw.trim().toLowerCase()}`;
-            const cached = stubsByKey.get(key);
+            const cached = resolvedByKey.get(key);
             if (cached !== undefined) return cached;
             const r = resolveOneField(raw, targetType, ctx, hook.auto_stub ?? false, reservedSlugs);
             if (r.stub) {
               created_stubs.push(r.stub);
               reservedSlugs.add(r.stub.slug);
-              stubsByKey.set(key, r.value);
             }
+            resolvedByKey.set(key, r.value);
             return r.value;
           };
           if (Array.isArray(value)) {

--- a/src/core/hooks.ts
+++ b/src/core/hooks.ts
@@ -1,0 +1,195 @@
+import fs from 'node:fs';
+import crypto from 'node:crypto';
+import path from 'node:path';
+import type Database from 'better-sqlite3';
+import type { GraniteConfig, Hook, Note, NoteFrontmatter, NoteTypeConfig } from './types.js';
+import { resolveText } from './resolve.js';
+import { slugify } from './slugify.js';
+
+export interface HookContext {
+  vaultRoot: string;
+  config: GraniteConfig;
+  db?: Database.Database;
+}
+
+export interface HookResult {
+  frontmatter: NoteFrontmatter;
+  created_stubs: Array<{ slug: string; title: string; type: string }>;
+}
+
+/**
+ * Apply on_create hooks declared on the note's type to its frontmatter.
+ * Pure — returns the mutated frontmatter and any stubs that should be created.
+ * The caller is responsible for actually writing the stub notes.
+ */
+export function applyOnCreateHooks(
+  frontmatter: NoteFrontmatter,
+  typeConfig: NoteTypeConfig,
+  ctx: HookContext,
+): HookResult {
+  return runHooks(frontmatter, typeConfig.on_create ?? [], ctx);
+}
+
+export function applyOnUpdateHooks(
+  frontmatter: NoteFrontmatter,
+  typeConfig: NoteTypeConfig,
+  ctx: HookContext,
+): HookResult {
+  return runHooks(frontmatter, typeConfig.on_update ?? [], ctx);
+}
+
+function runHooks(
+  frontmatter: NoteFrontmatter,
+  hooks: Hook[],
+  ctx: HookContext,
+): HookResult {
+  const out: NoteFrontmatter = { ...frontmatter };
+  const created_stubs: HookResult['created_stubs'] = [];
+  const reservedSlugs = new Set<string>();
+
+  for (const hook of hooks) {
+    switch (hook.action) {
+      case 'resolve_wikilinks': {
+        for (const fieldName of hook.fields) {
+          const value = out[fieldName];
+          if (value === undefined || value === null || value === '') continue;
+          const typeConfig = findFieldTarget(ctx.config, out.type, fieldName);
+          const targetType = typeConfig?.target_types?.[0];
+          if (Array.isArray(value)) {
+            const resolved: string[] = [];
+            for (const item of value) {
+              const r = resolveOneField(String(item), targetType, ctx, hook.auto_stub ?? false, reservedSlugs);
+              if (r.stub) {
+                created_stubs.push(r.stub);
+                reservedSlugs.add(r.stub.slug);
+              }
+              resolved.push(r.value);
+            }
+            out[fieldName] = resolved;
+          } else {
+            const r = resolveOneField(String(value), targetType, ctx, hook.auto_stub ?? false, reservedSlugs);
+            if (r.stub) {
+              created_stubs.push(r.stub);
+              reservedSlugs.add(r.stub.slug);
+            }
+            out[fieldName] = r.value;
+          }
+        }
+        break;
+      }
+      case 'hash_source': {
+        const sourcePath = out[hook.field];
+        if (typeof sourcePath !== 'string' || !sourcePath) break;
+        const absolute = path.isAbsolute(sourcePath) ? sourcePath : path.join(ctx.vaultRoot, sourcePath);
+        if (!fs.existsSync(absolute)) break;
+        const hash = crypto.createHash('sha256').update(fs.readFileSync(absolute)).digest('hex');
+        out[hook.target] = hash;
+        break;
+      }
+      case 'set_default': {
+        if (out[hook.field] === undefined || out[hook.field] === null || out[hook.field] === '') {
+          out[hook.field] = interpolateValue(hook.value);
+        }
+        break;
+      }
+    }
+  }
+
+  return { frontmatter: out, created_stubs };
+}
+
+function resolveOneField(
+  raw: string,
+  targetType: string | undefined,
+  ctx: HookContext,
+  autoStub: boolean,
+  reservedSlugs: Set<string>,
+): { value: string; stub?: { slug: string; title: string; type: string } } {
+  const text = raw.trim();
+  if (!text) return { value: raw };
+
+  // Already a slug reference?
+  if (/^[a-z0-9]+(-[a-z0-9]+)*$/.test(text)) {
+    return { value: text };
+  }
+
+  if (!ctx.db) {
+    return { value: slugify(text) || text };
+  }
+
+  const matches = resolveText(ctx.db, text, { target_type: targetType, limit: 1 });
+  if (matches.length > 0) {
+    return { value: matches[0].slug };
+  }
+
+  if (autoStub && targetType) {
+    const baseSlug = slugify(text) || 'untitled';
+    const stubSlug = allocateUniqueSlug(baseSlug, ctx, reservedSlugs);
+    return {
+      value: stubSlug,
+      stub: { slug: stubSlug, title: text, type: targetType },
+    };
+  }
+
+  return { value: slugify(text) || text };
+}
+
+function allocateUniqueSlug(
+  base: string,
+  ctx: HookContext,
+  reservedSlugs: Set<string>,
+): string {
+  let slug = base;
+  let counter = 2;
+  while (slugTaken(slug, ctx, reservedSlugs)) {
+    slug = `${base}-${counter}`;
+    counter++;
+  }
+  return slug;
+}
+
+function slugTaken(slug: string, ctx: HookContext, reservedSlugs: Set<string>): boolean {
+  if (reservedSlugs.has(slug)) return true;
+  if (ctx.db) {
+    const row = ctx.db.prepare('SELECT 1 AS present FROM notes WHERE slug = ? LIMIT 1').get(slug) as { present?: number } | undefined;
+    if (row?.present) return true;
+  }
+  for (const typeConfig of Object.values(ctx.config.note_types)) {
+    const candidate = path.join(ctx.vaultRoot, typeConfig.folder, `${slug}.md`);
+    if (fs.existsSync(candidate)) return true;
+  }
+  return false;
+}
+
+function findFieldTarget(config: GraniteConfig, typeName: string, fieldName: string) {
+  const typeConfig = config.note_types[typeName];
+  if (!typeConfig) return undefined;
+  return typeConfig.fields?.[fieldName];
+}
+
+function interpolateValue(template: string): string {
+  return template
+    .replace(/\$\{today\}/g, new Date().toISOString().slice(0, 10))
+    .replace(/\$\{now\}/g, new Date().toISOString());
+}
+
+export function collectIndexedFieldValues(
+  note: Note,
+  typeConfig: NoteTypeConfig,
+): Array<{ field: string; value: string }> {
+  const out: Array<{ field: string; value: string }> = [];
+  for (const field of typeConfig.indexed_fields ?? []) {
+    const value = note.frontmatter[field];
+    if (value === undefined || value === null) continue;
+    if (Array.isArray(value)) {
+      for (const v of value) {
+        if (v !== undefined && v !== null && v !== '') {
+          out.push({ field, value: String(v) });
+        }
+      }
+    } else if (value !== '') {
+      out.push({ field, value: String(value) });
+    }
+  }
+  return out;
+}

--- a/src/core/hooks.ts
+++ b/src/core/hooks.ts
@@ -10,6 +10,7 @@ export interface HookContext {
   vaultRoot: string;
   config: GraniteConfig;
   db?: Database.Database;
+  reservedSlugs?: Set<string>;
 }
 
 export interface HookResult {
@@ -30,14 +31,6 @@ export function applyOnCreateHooks(
   return runHooks(frontmatter, typeConfig.on_create ?? [], ctx);
 }
 
-export function applyOnUpdateHooks(
-  frontmatter: NoteFrontmatter,
-  typeConfig: NoteTypeConfig,
-  ctx: HookContext,
-): HookResult {
-  return runHooks(frontmatter, typeConfig.on_update ?? [], ctx);
-}
-
 function runHooks(
   frontmatter: NoteFrontmatter,
   hooks: Hook[],
@@ -45,7 +38,9 @@ function runHooks(
 ): HookResult {
   const out: NoteFrontmatter = { ...frontmatter };
   const created_stubs: HookResult['created_stubs'] = [];
-  const reservedSlugs = new Set<string>();
+  const reservedSlugs = new Set<string>(ctx.reservedSlugs ?? []);
+  // Dedup auto-stubs created in a single hook run so repeated refs reuse the first slug.
+  const stubsByKey = new Map<string, string>();
 
   for (const hook of hooks) {
     switch (hook.action) {
@@ -55,24 +50,22 @@ function runHooks(
           if (value === undefined || value === null || value === '') continue;
           const typeConfig = findFieldTarget(ctx.config, out.type, fieldName);
           const targetType = typeConfig?.target_types?.[0];
-          if (Array.isArray(value)) {
-            const resolved: string[] = [];
-            for (const item of value) {
-              const r = resolveOneField(String(item), targetType, ctx, hook.auto_stub ?? false, reservedSlugs);
-              if (r.stub) {
-                created_stubs.push(r.stub);
-                reservedSlugs.add(r.stub.slug);
-              }
-              resolved.push(r.value);
-            }
-            out[fieldName] = resolved;
-          } else {
-            const r = resolveOneField(String(value), targetType, ctx, hook.auto_stub ?? false, reservedSlugs);
+          const resolveOne = (raw: string): string => {
+            const key = `${targetType ?? '*'}::${raw.trim().toLowerCase()}`;
+            const cached = stubsByKey.get(key);
+            if (cached !== undefined) return cached;
+            const r = resolveOneField(raw, targetType, ctx, hook.auto_stub ?? false, reservedSlugs);
             if (r.stub) {
               created_stubs.push(r.stub);
               reservedSlugs.add(r.stub.slug);
+              stubsByKey.set(key, r.value);
             }
-            out[fieldName] = r.value;
+            return r.value;
+          };
+          if (Array.isArray(value)) {
+            out[fieldName] = value.map(item => resolveOne(String(item)));
+          } else {
+            out[fieldName] = resolveOne(String(value));
           }
         }
         break;

--- a/src/core/index-db.ts
+++ b/src/core/index-db.ts
@@ -5,9 +5,10 @@ import type { GraniteConfig, Note } from './types.js';
 import { listNotes } from './note.js';
 import { parseWikilinks } from './wikilinks.js';
 import { slugify } from './slugify.js';
+import { collectIndexedFieldValues } from './hooks.js';
 import { getIndexDbPath } from './vault.js';
 
-const SCHEMA_VERSION = 2;
+const SCHEMA_VERSION = 3;
 
 const SCHEMA_SQL = `
 CREATE TABLE IF NOT EXISTS notes (
@@ -61,6 +62,16 @@ CREATE TABLE IF NOT EXISTS links (
 CREATE INDEX IF NOT EXISTS idx_links_target ON links(target_slug);
 CREATE INDEX IF NOT EXISTS idx_links_source ON links(source_slug);
 
+CREATE TABLE IF NOT EXISTS note_fields (
+  slug        TEXT NOT NULL,
+  field_name  TEXT NOT NULL,
+  field_value TEXT NOT NULL,
+  FOREIGN KEY (slug) REFERENCES notes(slug)
+);
+
+CREATE INDEX IF NOT EXISTS idx_note_fields_slug ON note_fields(slug);
+CREATE INDEX IF NOT EXISTS idx_note_fields_name_value ON note_fields(field_name, field_value);
+
 CREATE TABLE IF NOT EXISTS meta (
   key   TEXT PRIMARY KEY,
   value TEXT
@@ -111,8 +122,14 @@ export function rebuildIndex(vaultRoot: string, config: GraniteConfig, db: Datab
     VALUES (@source_slug, @target_slug, @target_raw, @context)
   `);
 
+  const insertField = db.prepare(`
+    INSERT INTO note_fields (slug, field_name, field_value)
+    VALUES (@slug, @field_name, @field_value)
+  `);
+
   const transaction = db.transaction(() => {
     db.exec('DELETE FROM links');
+    db.exec('DELETE FROM note_fields');
     db.exec('DELETE FROM notes');
     // Rebuild FTS after clearing the content table, but keep this inside
     // the transaction so concurrent readers/writers never observe a half-reset index.
@@ -150,6 +167,17 @@ export function rebuildIndex(vaultRoot: string, config: GraniteConfig, db: Datab
           context: contextLine.trim(),
         });
       }
+
+      const typeConfig = config.note_types[note.frontmatter.type];
+      if (typeConfig) {
+        for (const entry of collectIndexedFieldValues(note, typeConfig)) {
+          insertField.run({
+            slug: note.slug,
+            field_name: entry.field,
+            field_value: entry.value,
+          });
+        }
+      }
     }
 
     db.prepare('INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)').run('last_rebuild', new Date().toISOString());
@@ -174,7 +202,7 @@ export function syncNoteInIndex(
     return;
   }
 
-  upsertNoteAndLinks(db, note);
+  upsertNoteAndLinks(db, note, config);
 }
 
 export function syncVaultIndexAfterNoteWrite(
@@ -221,7 +249,7 @@ function countNoteFiles(vaultRoot: string, config: GraniteConfig): number {
   return count;
 }
 
-function upsertNoteAndLinks(db: Database.Database, note: Note): void {
+function upsertNoteAndLinks(db: Database.Database, note: Note, config?: GraniteConfig): void {
   const upsertNote = db.prepare(`
     INSERT INTO notes (slug, id, title, type, created, modified, tags, aliases, body, filepath, status, source)
     VALUES (@slug, @id, @title, @type, @created, @modified, @tags, @aliases, @body, @filepath, @status, @source)
@@ -240,9 +268,14 @@ function upsertNoteAndLinks(db: Database.Database, note: Note): void {
   `);
 
   const deleteLinks = db.prepare('DELETE FROM links WHERE source_slug = ?');
+  const deleteFields = db.prepare('DELETE FROM note_fields WHERE slug = ?');
   const insertLink = db.prepare(`
     INSERT INTO links (source_slug, target_slug, target_raw, context)
     VALUES (@source_slug, @target_slug, @target_raw, @context)
+  `);
+  const insertField = db.prepare(`
+    INSERT INTO note_fields (slug, field_name, field_value)
+    VALUES (@slug, @field_name, @field_value)
   `);
 
   const transaction = db.transaction(() => {
@@ -262,6 +295,7 @@ function upsertNoteAndLinks(db: Database.Database, note: Note): void {
     });
 
     deleteLinks.run(note.slug);
+    deleteFields.run(note.slug);
 
     const links = parseWikilinks(note.body);
     for (const link of links) {
@@ -274,6 +308,19 @@ function upsertNoteAndLinks(db: Database.Database, note: Note): void {
         target_raw: link.target,
         context: contextLine.trim(),
       });
+    }
+
+    if (config) {
+      const typeConfig = config.note_types[note.frontmatter.type];
+      if (typeConfig) {
+        for (const entry of collectIndexedFieldValues(note, typeConfig)) {
+          insertField.run({
+            slug: note.slug,
+            field_name: entry.field,
+            field_value: entry.value,
+          });
+        }
+      }
     }
 
     db.prepare('INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)').run('last_rebuild', new Date().toISOString());

--- a/src/core/lifecycle.ts
+++ b/src/core/lifecycle.ts
@@ -1,0 +1,60 @@
+import type { GraniteConfig, LifecycleTransition, Note } from './types.js';
+
+export interface LifecycleSuggestion {
+  slug: string;
+  from: string;
+  to: string;
+  reason: string;
+}
+
+/**
+ * Given a note and its type's lifecycle declaration, return automated transition
+ * suggestions that are ready to fire (e.g. stale_days has elapsed). Never mutates.
+ */
+export function suggestLifecycleTransitions(
+  note: Note,
+  config: GraniteConfig,
+  now: Date = new Date(),
+): LifecycleSuggestion[] {
+  const typeConfig = config.note_types[note.frontmatter.type];
+  if (!typeConfig?.lifecycle) return [];
+
+  const currentState = readCurrentState(note, typeConfig.lifecycle.states);
+  if (!currentState) return [];
+
+  const suggestions: LifecycleSuggestion[] = [];
+  for (const transition of typeConfig.lifecycle.transitions) {
+    if (transition.from !== currentState) continue;
+    if (transition.trigger !== 'stale_days') continue;
+    if (!transition.days) continue;
+    const modifiedMs = Date.parse(note.frontmatter.modified);
+    if (Number.isNaN(modifiedMs)) continue;
+    const ageDays = (now.getTime() - modifiedMs) / (1000 * 60 * 60 * 24);
+    if (ageDays >= transition.days) {
+      suggestions.push({
+        slug: note.slug,
+        from: transition.from,
+        to: transition.to,
+        reason: `Untouched for ${Math.floor(ageDays)} days (threshold ${transition.days})`,
+      });
+    }
+  }
+  return suggestions;
+}
+
+function readCurrentState(note: Note, states: string[]): string | undefined {
+  const candidateFields = ['status', 'lifecycle_state'];
+  for (const f of candidateFields) {
+    const v = note.frontmatter[f];
+    if (typeof v === 'string' && states.includes(v)) return v;
+  }
+  return undefined;
+}
+
+export function isValidTransition(
+  transitions: LifecycleTransition[],
+  from: string,
+  to: string,
+): boolean {
+  return transitions.some(t => t.from === from && t.to === to);
+}

--- a/src/core/note.ts
+++ b/src/core/note.ts
@@ -58,6 +58,7 @@ export function createNote(
 
   const now = new Date().toISOString();
   const defaults = typeConfig.frontmatter_defaults ?? {};
+  const sanitizedExtra = stripReservedFields(options.extraFrontmatter ?? {});
   const frontmatter: NoteFrontmatter = {
     id: uuidv4(),
     title,
@@ -71,7 +72,7 @@ export function createNote(
     review_state: normalizeReviewState(defaults.review_state),
     durability: normalizeDurability(defaults.durability),
     derived_from: normalizeStringArray(defaults.derived_from),
-    ...(options.extraFrontmatter ?? {}),
+    ...sanitizedExtra,
   };
 
   const body = bodyOverride ?? typeConfig.template;
@@ -81,6 +82,7 @@ export function createNote(
     vaultRoot,
     config,
     db: options.db,
+    reservedSlugs: new Set([finalSlug]),
   });
 
   for (const stub of hookResult.created_stubs) {
@@ -120,6 +122,17 @@ export function createNote(
     body,
     outgoing_links: [],
   };
+}
+
+const RESERVED_IMMUTABLE_FIELDS = new Set(['id', 'type', 'title', 'created', 'modified']);
+
+function stripReservedFields(extra: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(extra)) {
+    if (RESERVED_IMMUTABLE_FIELDS.has(key)) continue;
+    out[key] = value;
+  }
+  return out;
 }
 
 export function readNote(filepath: string): Note {

--- a/src/core/note.ts
+++ b/src/core/note.ts
@@ -1,8 +1,10 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { v4 as uuidv4 } from 'uuid';
+import type Database from 'better-sqlite3';
 import { slugify } from './slugify.js';
 import { parseFrontmatter, serializeFrontmatter } from './frontmatter.js';
+import { applyOnCreateHooks } from './hooks.js';
 import {
   normalizeDurability,
   normalizeReviewState,
@@ -12,12 +14,18 @@ import {
 } from './json-output.js';
 import type { GraniteConfig, Note, NoteFrontmatter } from './types.js';
 
+export interface CreateNoteOptions {
+  db?: Database.Database;
+  extraFrontmatter?: Record<string, unknown>;
+}
+
 export function createNote(
   vaultRoot: string,
   config: GraniteConfig,
   typeName: string,
   title: string,
   bodyOverride?: string,
+  options: CreateNoteOptions = {},
 ): Note {
   const typeConfig = config.note_types[typeName];
   if (!typeConfig) {
@@ -63,11 +71,44 @@ export function createNote(
     review_state: normalizeReviewState(defaults.review_state),
     durability: normalizeDurability(defaults.durability),
     derived_from: normalizeStringArray(defaults.derived_from),
+    ...(options.extraFrontmatter ?? {}),
   };
 
   const body = bodyOverride ?? typeConfig.template;
-  const content = serializeFrontmatter(frontmatter, body);
   const filepath = path.join(folder, `${finalSlug}.md`);
+
+  const hookResult = applyOnCreateHooks(frontmatter, typeConfig, {
+    vaultRoot,
+    config,
+    db: options.db,
+  });
+
+  for (const stub of hookResult.created_stubs) {
+    const stubType = config.note_types[stub.type];
+    if (!stubType) continue;
+    if (findNoteBySlug(vaultRoot, config, stub.slug)) continue;
+    const stubFolder = path.join(vaultRoot, stubType.folder);
+    const stubPath = path.join(stubFolder, `${stub.slug}.md`);
+    fs.mkdirSync(stubFolder, { recursive: true });
+    const stubNow = new Date().toISOString();
+    const stubFrontmatter: NoteFrontmatter = {
+      id: uuidv4(),
+      title: stub.title,
+      type: stub.type,
+      created: stubNow,
+      modified: stubNow,
+      tags: ['stub'],
+      aliases: [],
+      status: 'inbox',
+      source: 'agent',
+      review_state: 'draft',
+      durability: normalizeDurability(stubType.frontmatter_defaults?.durability),
+      derived_from: [],
+    };
+    fs.writeFileSync(stubPath, serializeFrontmatter(stubFrontmatter, stubType.template), 'utf-8');
+  }
+
+  const content = serializeFrontmatter(hookResult.frontmatter, body);
 
   fs.mkdirSync(folder, { recursive: true });
   fs.writeFileSync(filepath, content, 'utf-8');
@@ -75,7 +116,7 @@ export function createNote(
   return {
     slug: finalSlug,
     filepath,
-    frontmatter,
+    frontmatter: hookResult.frontmatter,
     body,
     outgoing_links: [],
   };

--- a/src/core/query.ts
+++ b/src/core/query.ts
@@ -83,7 +83,7 @@ export function runQuery(
     if (query.sort.field === 'modified' || query.sort.field === 'created' || query.sort.field === 'title') {
       orderBy = `n.${query.sort.field} ${dir}`;
     } else if (indexed.has(query.sort.field)) {
-      const sortAlias = `fs`;
+      const sortAlias = `fs_${whereEntries.length}`;
       joins.push(`LEFT JOIN note_fields ${sortAlias} ON ${sortAlias}.slug = n.slug AND ${sortAlias}.field_name = ?`);
       joinParams.push(query.sort.field);
       orderBy = `${sortAlias}.field_value ${dir}`;

--- a/src/core/query.ts
+++ b/src/core/query.ts
@@ -1,0 +1,157 @@
+import type Database from 'better-sqlite3';
+import type { GraniteConfig } from './types.js';
+
+export interface Query {
+  type?: string;
+  where?: Record<string, QueryFilter>;
+  sort?: { field: string; dir: 'asc' | 'desc' };
+  limit?: number;
+}
+
+export type QueryFilter = string | { eq?: string; in?: string[]; gte?: string; lte?: string };
+
+export interface QueryResult {
+  slug: string;
+  title: string;
+  type: string;
+  modified: string;
+  fields: Record<string, string | string[]>;
+}
+
+/**
+ * Deterministic structured query over note_fields + notes.
+ * Only `indexed_fields` declared on the type are queryable.
+ */
+export function runQuery(
+  db: Database.Database,
+  config: GraniteConfig,
+  query: Query,
+): QueryResult[] {
+  const type = query.type;
+  const typeConfig = type ? config.note_types[type] : undefined;
+  if (type && !typeConfig) {
+    throw new Error(`Unknown note type: "${type}"`);
+  }
+  const indexed = new Set(typeConfig?.indexed_fields ?? []);
+  const whereEntries = Object.entries(query.where ?? {});
+  for (const [field] of whereEntries) {
+    if (field === 'status' || field === 'source') continue;
+    if (!indexed.has(field)) {
+      throw new Error(
+        `Field "${field}" is not indexed on type "${type ?? '<any>'}". Declare it in indexed_fields first.`,
+      );
+    }
+  }
+
+  const joins: string[] = [];
+  const joinParams: unknown[] = [];
+  const where: string[] = [];
+  const whereParams: unknown[] = [];
+
+  if (type) {
+    where.push('n.type = ?');
+    whereParams.push(type);
+  }
+
+  whereEntries.forEach(([field, filter], idx) => {
+    if (field === 'status') {
+      const { sql, p } = renderFilter('n.status', filter);
+      where.push(sql);
+      whereParams.push(...p);
+      return;
+    }
+    if (field === 'source') {
+      const { sql, p } = renderFilter('n.source', filter);
+      where.push(sql);
+      whereParams.push(...p);
+      return;
+    }
+    const alias = `f${idx}`;
+    joins.push(`JOIN note_fields ${alias} ON ${alias}.slug = n.slug AND ${alias}.field_name = ?`);
+    joinParams.push(field);
+    const { sql, p } = renderFilter(`${alias}.field_value`, filter);
+    where.push(sql);
+    whereParams.push(...p);
+  });
+
+  let orderBy = 'n.modified DESC';
+  if (query.sort) {
+    const dir = query.sort.dir.toUpperCase();
+    if (query.sort.field === 'modified' || query.sort.field === 'created' || query.sort.field === 'title') {
+      orderBy = `n.${query.sort.field} ${dir}`;
+    } else if (indexed.has(query.sort.field)) {
+      const sortAlias = `fs`;
+      joins.push(`LEFT JOIN note_fields ${sortAlias} ON ${sortAlias}.slug = n.slug AND ${sortAlias}.field_name = ?`);
+      joinParams.push(query.sort.field);
+      orderBy = `${sortAlias}.field_value ${dir}`;
+    } else {
+      throw new Error(`Cannot sort by non-indexed field "${query.sort.field}"`);
+    }
+  }
+
+  const limit = Math.max(1, Math.min(query.limit ?? 25, 200));
+
+  const sql = `
+    SELECT DISTINCT n.slug, n.title, n.type, n.modified
+    FROM notes n
+    ${joins.join('\n')}
+    ${where.length > 0 ? 'WHERE ' + where.join(' AND ') : ''}
+    ORDER BY ${orderBy}
+    LIMIT ${limit}
+  `;
+
+  const params = [...joinParams, ...whereParams];
+  const rows = db.prepare(sql).all(...params) as Array<{ slug: string; title: string; type: string; modified: string }>;
+
+  const slugs = rows.map(r => r.slug);
+  const fieldMap = new Map<string, Record<string, string | string[]>>();
+  if (slugs.length > 0) {
+    const placeholders = slugs.map(() => '?').join(',');
+    const fieldRows = db.prepare(
+      `SELECT slug, field_name, field_value FROM note_fields WHERE slug IN (${placeholders})`,
+    ).all(...slugs) as Array<{ slug: string; field_name: string; field_value: string }>;
+    for (const fr of fieldRows) {
+      const entry = fieldMap.get(fr.slug) ?? {};
+      const current = entry[fr.field_name];
+      if (Array.isArray(current)) {
+        current.push(fr.field_value);
+      } else if (typeof current === 'string') {
+        entry[fr.field_name] = [current, fr.field_value];
+      } else {
+        entry[fr.field_name] = fr.field_value;
+      }
+      fieldMap.set(fr.slug, entry);
+    }
+  }
+
+  return rows.map(r => ({
+    slug: r.slug,
+    title: r.title,
+    type: r.type,
+    modified: r.modified,
+    fields: fieldMap.get(r.slug) ?? {},
+  }));
+}
+
+function renderFilter(column: string, filter: QueryFilter): { sql: string; p: unknown[] } {
+  if (typeof filter === 'string') {
+    return { sql: `${column} = ?`, p: [filter] };
+  }
+  if (filter.eq !== undefined) {
+    return { sql: `${column} = ?`, p: [filter.eq] };
+  }
+  if (filter.in !== undefined && filter.in.length > 0) {
+    const placeholders = filter.in.map(() => '?').join(',');
+    return { sql: `${column} IN (${placeholders})`, p: filter.in };
+  }
+  if (filter.gte !== undefined && filter.lte !== undefined) {
+    return { sql: `${column} BETWEEN ? AND ?`, p: [filter.gte, filter.lte] };
+  }
+  if (filter.gte !== undefined) {
+    return { sql: `${column} >= ?`, p: [filter.gte] };
+  }
+  if (filter.lte !== undefined) {
+    return { sql: `${column} <= ?`, p: [filter.lte] };
+  }
+  return { sql: '1=1', p: [] };
+}

--- a/src/core/query.ts
+++ b/src/core/query.ts
@@ -76,7 +76,10 @@ export function runQuery(
 
   let orderBy = 'n.modified DESC';
   if (query.sort) {
-    const dir = query.sort.dir.toUpperCase();
+    if (query.sort.dir !== 'asc' && query.sort.dir !== 'desc') {
+      throw new Error(`Invalid sort direction "${String(query.sort.dir)}". Use "asc" or "desc".`);
+    }
+    const dir = query.sort.dir === 'asc' ? 'ASC' : 'DESC';
     if (query.sort.field === 'modified' || query.sort.field === 'created' || query.sort.field === 'title') {
       orderBy = `n.${query.sort.field} ${dir}`;
     } else if (indexed.has(query.sort.field)) {
@@ -140,7 +143,10 @@ function renderFilter(column: string, filter: QueryFilter): { sql: string; p: un
   if (filter.eq !== undefined) {
     return { sql: `${column} = ?`, p: [filter.eq] };
   }
-  if (filter.in !== undefined && filter.in.length > 0) {
+  if (filter.in !== undefined) {
+    if (filter.in.length === 0) {
+      return { sql: '0', p: [] };
+    }
     const placeholders = filter.in.map(() => '?').join(',');
     return { sql: `${column} IN (${placeholders})`, p: filter.in };
   }

--- a/src/core/resolve.ts
+++ b/src/core/resolve.ts
@@ -1,0 +1,108 @@
+import type Database from 'better-sqlite3';
+import { slugify } from './slugify.js';
+
+export interface ResolveMatch {
+  slug: string;
+  title: string;
+  type: string;
+  score: number;
+  reason: 'slug' | 'title' | 'alias' | 'fts';
+}
+
+export interface ResolveOptions {
+  target_type?: string;
+  limit?: number;
+}
+
+/**
+ * Deterministic text → note slug resolver.
+ * Preference order: exact slug → exact title → exact alias → FTS.
+ * Never invokes an LLM.
+ */
+export function resolveText(
+  db: Database.Database,
+  text: string,
+  options: ResolveOptions = {},
+): ResolveMatch[] {
+  const trimmed = text.trim();
+  if (!trimmed) return [];
+
+  const limit = Math.max(1, Math.min(options.limit ?? 5, 20));
+  const typeFilter = options.target_type;
+  const matches = new Map<string, ResolveMatch>();
+
+  const addMatch = (m: ResolveMatch) => {
+    if (typeFilter && m.type !== typeFilter) return;
+    const existing = matches.get(m.slug);
+    if (!existing || existing.score < m.score) {
+      matches.set(m.slug, m);
+    }
+  };
+
+  const targetSlug = slugify(trimmed);
+
+  const slugRow = db.prepare('SELECT slug, title, type FROM notes WHERE slug = ? LIMIT 1')
+    .get(targetSlug) as { slug: string; title: string; type: string } | undefined;
+  if (slugRow) {
+    addMatch({ ...slugRow, score: 1.0, reason: 'slug' });
+  }
+
+  const titleRows = db.prepare('SELECT slug, title, type FROM notes WHERE lower(title) = ?')
+    .all(trimmed.toLowerCase()) as Array<{ slug: string; title: string; type: string }>;
+  for (const row of titleRows) {
+    addMatch({ ...row, score: 0.95, reason: 'title' });
+  }
+
+  const aliasRows = db.prepare('SELECT slug, title, type, aliases FROM notes')
+    .all() as Array<{ slug: string; title: string; type: string; aliases: string }>;
+  for (const row of aliasRows) {
+    try {
+      const aliases = JSON.parse(row.aliases || '[]') as unknown[];
+      if (aliases.some(a => typeof a === 'string' && a.toLowerCase() === trimmed.toLowerCase())) {
+        addMatch({ slug: row.slug, title: row.title, type: row.type, score: 0.9, reason: 'alias' });
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  if (matches.size < limit) {
+    try {
+      const ftsQuery = trimmed.replace(/"/g, '').split(/\s+/).filter(Boolean).map(w => `"${w}"`).join(' OR ');
+      if (ftsQuery) {
+        const ftsRows = db.prepare(`
+          SELECT n.slug, n.title, n.type, bm25(notes_fts) AS rank
+          FROM notes_fts
+          JOIN notes n ON n.rowid = notes_fts.rowid
+          WHERE notes_fts MATCH ?
+          ORDER BY rank
+          LIMIT ?
+        `).all(ftsQuery, limit) as Array<{ slug: string; title: string; type: string; rank: number }>;
+        for (const row of ftsRows) {
+          const score = 0.5 - Math.min(0.4, row.rank * 0.01);
+          addMatch({ slug: row.slug, title: row.title, type: row.type, score, reason: 'fts' });
+        }
+      }
+    } catch {
+      // FTS errors (e.g. empty query) are non-fatal
+    }
+  }
+
+  return Array.from(matches.values())
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit);
+}
+
+export interface ResolveSuggestedStub {
+  type: string;
+  title: string;
+  slug: string;
+}
+
+export function suggestStub(text: string, targetType: string): ResolveSuggestedStub {
+  return {
+    type: targetType,
+    title: text.trim(),
+    slug: slugify(text.trim()) || 'untitled',
+  };
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -21,15 +21,47 @@ export interface NoteTypeConfig {
   slug_format?: 'title' | 'date';
   fields?: Record<string, FieldDefinition>;
   frontmatter_defaults?: NoteFrontmatterDefaults;
+  body_sections?: string[];
+  on_create?: Hook[];
+  on_update?: Hook[];
+  indexed_fields?: string[];
+  views?: Record<string, ViewSpec>;
+  lifecycle?: LifecycleSpec;
 }
 
 export interface FieldDefinition {
-  type: 'text' | 'date' | 'number' | 'boolean' | 'wikilink' | 'list' | 'enum';
+  type: 'text' | 'date' | 'number' | 'boolean' | 'wikilink' | 'list' | 'enum' | 'url';
   of?: string;
   options?: string[];
   required?: boolean;
   default?: string;
   description?: string;
+  target_types?: string[];
+  many?: boolean;
+}
+
+export type Hook =
+  | { action: 'resolve_wikilinks'; fields: string[]; auto_stub?: boolean }
+  | { action: 'hash_source'; field: string; target: string }
+  | { action: 'set_default'; field: string; value: string };
+
+export interface ViewSpec {
+  description?: string;
+  where?: Record<string, unknown>;
+  sort?: { field: string; dir: 'asc' | 'desc' };
+  limit?: number;
+}
+
+export interface LifecycleSpec {
+  states: string[];
+  transitions: LifecycleTransition[];
+}
+
+export interface LifecycleTransition {
+  from: string;
+  to: string;
+  trigger: 'manual' | 'stale_days';
+  days?: number;
 }
 
 export interface GraniteConfig {

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,8 +33,9 @@ program
 program
   .command('init')
   .description('Create a new vault and start the knowledge loop')
-  .action(() => {
-    initVault();
+  .option('--template <name>', 'Start from a template (e.g. founder-os)')
+  .action((options: { template?: string }) => {
+    initVault(undefined, { template: options.template });
   });
 
 program

--- a/src/mcp/runtime.ts
+++ b/src/mcp/runtime.ts
@@ -15,6 +15,9 @@ import {
 } from '../core/garden-adjudications.js';
 import { extractDocument as extractDocumentFromFile, type ExtractDocumentResult } from '../core/extract-document.js';
 import { importDocument as importDocumentToVault } from '../core/import-document.js';
+import { resolveText, suggestStub, type ResolveMatch } from '../core/resolve.js';
+import { runQuery, type Query, type QueryResult } from '../core/query.js';
+import { compileContext, type CompileContextInput, type CompileContextResult } from '../core/compile-context.js';
 import { openDatabase, rebuildIndex, syncNoteInIndex } from '../core/index-db.js';
 import { findNoteBySlug, listNotes, createNote, readNote } from '../core/note.js';
 import { getRecommendations } from '../core/recommendations.js';
@@ -213,6 +216,7 @@ export interface CreateNoteInput {
   review_state?: ReviewState;
   durability?: Durability;
   derived_from?: string[];
+  fields?: Record<string, unknown>;
 }
 
 export interface CaptureNoteInput {
@@ -397,6 +401,28 @@ export class GraniteMcpRuntime {
   search(query: string, limit = 10): SearchResult[] {
     this.refreshIndex();
     return searchNotes(this.db, query, clampLimit(limit, 50));
+  }
+
+  resolve(text: string, options: { target_type?: string; limit?: number } = {}): {
+    matches: ResolveMatch[];
+    suggested_stub?: { type: string; title: string; slug: string };
+  } {
+    this.refreshIndex();
+    const matches = resolveText(this.db, text, options);
+    if (matches.length === 0 && options.target_type) {
+      return { matches, suggested_stub: suggestStub(text, options.target_type) };
+    }
+    return { matches };
+  }
+
+  query(query: Query): { results: QueryResult[] } {
+    this.refreshIndex();
+    return { results: runQuery(this.db, this.config, query) };
+  }
+
+  compileContext(input: CompileContextInput): CompileContextResult {
+    this.refreshIndex();
+    return compileContext(this.db, this.config, input);
   }
 
   getBacklinks(slug: string): BacklinkEntry[] {
@@ -731,7 +757,10 @@ export class GraniteMcpRuntime {
         ? ensureTrailingNewline(input.title)
         : undefined;
 
-    const created = createNote(this.vaultRoot, this.config, resolvedType, input.title, bodyOverride);
+    const created = createNote(this.vaultRoot, this.config, resolvedType, input.title, bodyOverride, {
+      db: this.db,
+      extraFrontmatter: input.fields,
+    });
     const metadataMutations = {
       tags: input.tags,
       aliases: input.aliases,

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -4,8 +4,19 @@ import { McpServer, ResourceTemplate } from '@modelcontextprotocol/sdk/server/mc
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js';
 import * as z from 'zod/v4';
+import {
+  renderDisposeNoteMarkdown,
+  renderExtractDocumentMarkdown,
+  renderImportDocumentMarkdown,
+  renderMutationResultMarkdown,
+  renderNoteTypesMarkdown,
+  renderSearchResultsMarkdown,
+  renderUnderstandNoteMarkdown,
+  renderWakeupMarkdown,
+} from '../../shared/mcp-markdown.js';
 import { GRANITE_VERSION } from '../version.js';
-import type { GraniteMcpRuntime, NoteRecommendations } from './runtime.js';
+import type { GraniteMcpRuntime } from './runtime.js';
+import type { Query } from '../core/query.js';
 
 const readOnlyAnnotations = {
   readOnlyHint: true,
@@ -299,6 +310,9 @@ export function createGraniteMcpServer(runtime: GraniteMcpRuntime): McpServer {
         '',
         '- **granite_wakeup** — load the map of the vault before doing work',
         '- **granite_research_topic** — discover relevant notes for a topic',
+        '- **granite_resolve** — deterministically resolve free text to a note slug before linking',
+        '- **granite_query** — run structured queries over typed notes and indexed fields',
+        '- **granite_compile_context** — compile a typed brief for a topic or slug using the graph',
         '- **granite_plan_garden** — compute the highest-leverage notes or clusters to revisit next',
         '- **granite_adjudicate_garden_opportunity** — explicitly downrank or clear a garden opportunity the operator has adjudicated',
         '- **granite_list_garden_adjudications** — inspect the active operator adjudications influencing garden planning',
@@ -309,7 +323,7 @@ export function createGraniteMcpServer(runtime: GraniteMcpRuntime): McpServer {
         '- **granite_revise_note** — make targeted edits when workflow prompts are insufficient',
         '- **granite_dispose_note** — archive by default, delete only when intentional',
         '',
-        'Use prompts for the higher-level workflows: refine notes, compile topics, process the inbox, and garden the vault.',
+        'Use prompts for the higher-level workflows: refine notes, compile topics, and process the inbox.',
         '',
         '## Note Types',
         '',
@@ -432,7 +446,7 @@ function registerTools(server: McpServer, runtime: GraniteMcpRuntime): void {
     annotations: readOnlyAnnotations,
   }, async () => {
     const result = runtime.wakeup();
-    return toolResult(result, result.aaak);
+    return toolResult(result, renderWakeupMarkdown(result));
   });
 
   server.registerTool('granite_research_topic', {
@@ -449,7 +463,7 @@ function registerTools(server: McpServer, runtime: GraniteMcpRuntime): void {
     annotations: readOnlyAnnotations,
   }, async ({ query, limit }) => {
     const results = runtime.search(query, limit ?? 10);
-    return toolResult({ query, results }, `Found ${results.length} result(s) for "${query}".`);
+    return toolResult({ query, results }, renderSearchResultsMarkdown(query, results));
   });
 
   server.registerTool('granite_plan_garden', {
@@ -562,7 +576,7 @@ function registerTools(server: McpServer, runtime: GraniteMcpRuntime): void {
         durability: args.durability,
         derived_from: args.derived_from,
       });
-      return toolResult(result, buildWriteSummary('Captured', result, runtime));
+      return toolResult(result, renderMutationResultMarkdown('Created', result.note, result.recommendations));
     }
 
     if (!args.text) {
@@ -580,7 +594,7 @@ function registerTools(server: McpServer, runtime: GraniteMcpRuntime): void {
       durability: args.durability,
       derived_from: args.derived_from,
     });
-    return toolResult(result, buildWriteSummary('Captured', result, runtime));
+    return toolResult(result, renderMutationResultMarkdown('Captured', result.note, result.recommendations));
   });
 
   server.registerTool('granite_import_document', {
@@ -601,13 +615,7 @@ function registerTools(server: McpServer, runtime: GraniteMcpRuntime): void {
     annotations: writeAnnotations,
   }, async ({ file_path, content, title, tags, aliases }) => {
     const result = runtime.importDocument({ file_path, content, title, tags, aliases });
-    const summary = [
-      `Imported "${result.document.file}" as source "${result.note.title}" (${result.note.slug}).`,
-      '',
-      'Stored the provided document content in the note and attached the original file as a Granite asset.',
-      '',
-      `Recommendations: ${recommendationSummary(result.recommendations)}.`,
-    ].join('\n');
+    const summary = renderImportDocumentMarkdown(result);
 
     return {
       ...toolResult(result, summary),
@@ -629,14 +637,7 @@ function registerTools(server: McpServer, runtime: GraniteMcpRuntime): void {
     annotations: readOnlyAnnotations,
   }, async ({ file_path }) => {
     const result = await runtime.extractDocument({ file_path });
-    const summary = [
-      `Extraction status: ${result.status}.`,
-      `Document type: ${result.doc_type}.`,
-      `Extractor: ${result.extractor}.`,
-      result.status === 'needs_dependency' && result.user_prompt ? result.user_prompt : '',
-    ].filter(Boolean).join(' ');
-
-    return toolResult(result, summary);
+    return toolResult(result, renderExtractDocumentMarkdown(result));
   });
 
   server.registerTool('granite_understand_note', {
@@ -650,7 +651,7 @@ function registerTools(server: McpServer, runtime: GraniteMcpRuntime): void {
   }, async ({ slug }) => {
     const result = runtime.understandNote(slug);
     return {
-      ...toolResult(result, `Understood "${result.note.title}" (${result.note.slug}) as a ${result.graph_role.role} note.`),
+      ...toolResult(result, renderUnderstandNoteMarkdown(result)),
       content: buildUnderstandNoteContent(result),
     };
   });
@@ -679,7 +680,106 @@ function registerTools(server: McpServer, runtime: GraniteMcpRuntime): void {
     annotations: writeAnnotations,
   }, async ({ slug, ...updates }) => {
     const result = runtime.reviseNote(slug, updates);
-    return toolResult(result, buildWriteSummary('Revised', result, runtime));
+    return toolResult(result, renderMutationResultMarkdown('Revised', result.note, result.recommendations));
+  });
+
+  server.registerTool('granite_resolve', {
+    title: 'Resolve Granite Reference',
+    description: 'Deterministically resolve free text (e.g. a name, title, or alias) into an existing note slug. Use this before writing wikilinks or typed fields to avoid creating duplicates. Returns ranked matches and, if nothing matches, an optional stub suggestion.',
+    inputSchema: {
+      text: z.string().describe('Free text to resolve — name, title, or alias.'),
+      target_type: z.string().optional().describe('Restrict matches to a given note type (e.g. "person", "organization").'),
+      limit: z.number().int().min(1).max(20).optional().describe('Maximum matches to return. Defaults to 5.'),
+    },
+    outputSchema: z.object({
+      matches: z.array(z.object({
+        slug: z.string(),
+        title: z.string(),
+        type: z.string(),
+        score: z.number(),
+        reason: z.enum(['slug', 'title', 'alias', 'fts']),
+      })),
+      suggested_stub: z.object({
+        type: z.string(),
+        title: z.string(),
+        slug: z.string(),
+      }).optional(),
+    }),
+    annotations: readOnlyAnnotations,
+  }, async ({ text, target_type, limit }) => {
+    const result = runtime.resolve(text, { target_type, limit });
+    const summary = result.matches.length > 0
+      ? `# Resolve Matches\n\n${result.matches.map(m => `- **${m.title}** (${m.slug}, ${m.type}) — ${m.reason} score=${m.score.toFixed(2)}`).join('\n')}`
+      : `# Resolve Matches\n\nNo matches for "${text}".${result.suggested_stub ? `\n\nSuggested stub: ${result.suggested_stub.type} "${result.suggested_stub.title}" → ${result.suggested_stub.slug}` : ''}`;
+    return toolResult(result, summary);
+  });
+
+  server.registerTool('granite_query', {
+    title: 'Query Granite Vault',
+    description: 'Run a structured query over notes by type and indexed fields. Use this when you want "all meetings with Monka Care since April" or "all people at organization X". Only fields declared in indexed_fields on the type are queryable.',
+    inputSchema: {
+      type: z.string().optional().describe('Restrict to a note type.'),
+      where: z.record(z.string(), z.any()).optional().describe('Equality filters or {eq,in,gte,lte} operators keyed by field name.'),
+      sort_field: z.string().optional().describe('Field to sort by (modified, created, title, or an indexed field).'),
+      sort_dir: z.enum(['asc', 'desc']).optional().describe('Sort direction. Defaults to desc.'),
+      limit: z.number().int().min(1).max(200).optional().describe('Maximum results. Defaults to 25.'),
+    },
+    outputSchema: z.object({
+      results: z.array(z.object({
+        slug: z.string(),
+        title: z.string(),
+        type: z.string(),
+        modified: z.string(),
+        fields: z.record(z.string(), z.union([z.string(), z.array(z.string())])),
+      })),
+    }),
+    annotations: readOnlyAnnotations,
+  }, async ({ type, where, sort_field, sort_dir, limit }) => {
+    const result = runtime.query({
+      type,
+      where: where as Query['where'],
+      sort: sort_field ? { field: sort_field, dir: sort_dir ?? 'desc' } : undefined,
+      limit,
+    });
+    const summary = `# Query Results (${result.results.length})\n\n${result.results.map(r => `- **${r.title}** (${r.slug}, ${r.type})`).join('\n')}`;
+    return toolResult(result, summary);
+  });
+
+  server.registerTool('granite_compile_context', {
+    title: 'Compile Granite Context',
+    description: 'Compile a typed brief around a topic or a specific note slug. Walks the graph and uses typed filters (people at an org, meetings for an org, sources on a topic). Deterministic — no LLM.',
+    inputSchema: {
+      topic: z.string().optional().describe('Topic to compile context around.'),
+      slug: z.string().optional().describe('Note slug to compile context for.'),
+      limit: z.number().int().min(1).max(100).optional().describe('Max entries per section. Defaults to 20.'),
+    },
+    outputSchema: z.object({
+      mode: z.enum(['topic', 'slug']),
+      title: z.string(),
+      sections: z.array(z.object({
+        heading: z.string(),
+        entries: z.array(z.object({
+          slug: z.string(),
+          title: z.string(),
+          type: z.string(),
+          reason: z.string(),
+        })),
+      })),
+    }),
+    annotations: readOnlyAnnotations,
+  }, async ({ topic, slug, limit }) => {
+    const result = runtime.compileContext({ topic, slug, limit });
+    const summary = [
+      `# Context: ${result.title}`,
+      '',
+      ...result.sections.flatMap(s => [
+        `## ${s.heading}`,
+        '',
+        ...s.entries.map(e => `- **${e.title}** (${e.slug}, ${e.type}) — ${e.reason}`),
+        '',
+      ]),
+    ].join('\n');
+    return toolResult(result, summary);
   });
 
   server.registerTool('granite_dispose_note', {
@@ -693,7 +793,7 @@ function registerTools(server: McpServer, runtime: GraniteMcpRuntime): void {
     annotations: writeAnnotations,
   }, async ({ slug, mode }) => {
     const result = runtime.disposeNote(slug, mode ?? 'archive');
-    return toolResult(result, `${mode ?? 'archive'}d "${slug}".`);
+    return toolResult(result, renderDisposeNoteMarkdown(result));
   });
 }
 
@@ -701,12 +801,12 @@ function registerResources(server: McpServer, runtime: GraniteMcpRuntime): void 
   server.registerResource('granite-note-types', 'granite://vault/types', {
     title: 'Granite Note Types',
     description: 'Structured list of the note types configured in the current vault.',
-    mimeType: 'application/json',
+    mimeType: 'text/markdown',
   }, async () => ({
     contents: [{
       uri: 'granite://vault/types',
-      text: runtime.readVaultTypesJson(),
-      mimeType: 'application/json',
+      text: renderNoteTypesMarkdown(runtime.listNoteTypes(), runtime.getDefaultNoteType()),
+      mimeType: 'text/markdown',
     }],
   }));
 
@@ -886,65 +986,6 @@ function registerPrompts(server: McpServer, runtime: GraniteMcpRuntime): void {
     };
   });
 
-  server.registerPrompt('granite_garden_vault', {
-    title: 'Garden Granite Vault',
-    description: 'Run a comprehensive vault review: structural health, content gaps, orphan notes, and suggestions for strengthening the knowledge graph. The lint phase of the knowledge loop.',
-  }, async () => {
-    const doctorResult = runtime.runDoctor();
-    const overview = runtime.getVaultOverview(10);
-    const notes = runtime.listNotes({ limit: 200 });
-
-    // Find notes with no backlinks (potential orphans)
-    const orphanCandidates: string[] = [];
-    for (const note of notes.slice(0, 50)) {
-      const backlinks = runtime.getBacklinks(note.slug);
-      if (backlinks.length === 0) {
-        orphanCandidates.push(`${note.slug} ("${note.title}", type: ${note.type})`);
-      }
-    }
-
-    return {
-      description: 'Comprehensive vault health review.',
-      messages: [
-        {
-          role: 'user',
-          content: {
-            type: 'text',
-            text: [
-              'Run a comprehensive health review of this Granite vault and take action to improve it.',
-              '',
-              '## Structural Issues (from Granite diagnostics)',
-              '',
-              doctorResult.issues.length === 0
-                ? 'No structural issues found.'
-                : doctorResult.issues.map(i => `- [${i.level}] ${i.file}: ${i.message}`).join('\n'),
-              '',
-              '## Vault Overview',
-              '',
-              `${overview.note_count} notes: ${Object.entries(overview.notes_by_type).map(([t, c]) => `${c} ${t}s`).join(', ')}`,
-              '',
-              '## Orphan Notes (no backlinks)',
-              '',
-              orphanCandidates.length === 0
-                ? 'No orphans found in the first 50 notes.'
-                : orphanCandidates.map(o => `- ${o}`).join('\n'),
-              '',
-              '## Actions to Take',
-              '',
-              '1. Call granite_plan_garden first and work from the highest-leverage opportunities',
-              '2. Fix any structural errors reported by doctor',
-              '3. For each orphan or stale note, use granite_understand_note to inspect the note in context',
-              '4. If granite_understand_note reveals an imported document on a source note, call granite_extract_document with the note frontmatter document_path before summarizing or extracting facts',
-              '5. If orphan notes should be linked from other notes, revise those notes to add [[wikilinks]]',
-              '6. Look for clusters of notes that could be compiled into a synthesis',
-              '7. Check if any inbox notes need processing',
-              '8. Report a summary of what you found and what you fixed',
-            ].join('\n'),
-          },
-        },
-      ],
-    };
-  });
 }
 
 function toolResult<T>(structuredContent: T, summary: string) {
@@ -974,20 +1015,18 @@ function createAssetResourceLink(name: string, uri: string, mimeType: string) {
   };
 }
 
-function buildUnderstandNoteContent(result: {
-  note: { title: string; slug: string; resource_uri: string; frontmatter: Record<string, unknown> };
-  graph_role: { role: string };
-}) {
+function buildUnderstandNoteContent(result: Parameters<typeof renderUnderstandNoteMarkdown>[0]) {
   const content: Array<
     { type: 'text'; text: string }
     | ReturnType<typeof createNoteResourceLink>
     | ReturnType<typeof createAssetResourceLink>
-  > = [
-    { type: 'text', text: `Understood "${result.note.title}" (${result.note.slug}) as a ${result.graph_role.role} note.` },
-    createNoteResourceLink(result.note.title, result.note.resource_uri),
-  ];
+  > = [{ type: 'text', text: renderUnderstandNoteMarkdown(result) }];
 
-  const linkedAsset = getLinkedAsset(result.note);
+  if (result.note.resource_uri) {
+    content.push(createNoteResourceLink(result.note.title, result.note.resource_uri));
+  }
+
+  const linkedAsset = result.note.frontmatter ? getLinkedAsset({ frontmatter: result.note.frontmatter }) : null;
   if (linkedAsset) {
     content.push(createAssetResourceLink(linkedAsset.file, linkedAsset.resource_uri, linkedAsset.mime_type));
   }
@@ -1019,30 +1058,6 @@ function formatCompileTopicNote(note: { title: string; slug: string; type: strin
     note.body.slice(0, 500) + (note.body.length > 500 ? '...' : ''),
     '',
   ].join('\n');
-}
-
-function buildWriteSummary(verb: string, result: { note: { title: string; slug: string; type: string }; recommendations: NoteRecommendations }, runtime: GraniteMcpRuntime): string {
-  const lines = [`${verb} "${result.note.title}" (${result.note.slug}).`];
-
-  const instructions = runtime.getTypeInstructions(result.note.type);
-  if (instructions) {
-    lines.push('', `Type guidance for "${result.note.type}": ${instructions}`);
-  }
-
-  const recSummary = recommendationSummary(result.recommendations);
-  if (recSummary) {
-    lines.push('', `Recommendations: ${recSummary}. Act on these to strengthen the vault.`);
-  }
-
-  return lines.join('\n');
-}
-
-function recommendationSummary(recommendations: NoteRecommendations): string {
-  return [
-    `${recommendations.links.length} link suggestion(s)`,
-    `${recommendations.tags.length} tag suggestion(s)`,
-    `${recommendations.next_steps.length} next-step suggestion(s)`,
-  ].join(', ');
 }
 
 function asStructuredContent<T>(value: T): Record<string, unknown> {

--- a/templates/founder-os.yml
+++ b/templates/founder-os.yml
@@ -127,13 +127,13 @@ note_types:
     line_limit: 300
     warn_only: true
     instructions: >-
-      One note per organization. Track kind (client, prospect, partner, tool, employer) and status
-      in frontmatter. Link to key people and meetings.
+      One note per organization. Track kind (client, prospect, partner, tool, employer) and the
+      relationship stage in frontmatter. Link to key people and meetings.
     fields:
       kind: { type: enum, options: [client, prospect, partner, tool, employer, other], description: Type of relationship }
-      status: { type: enum, options: [active, paused, archived], default: active, description: Current relationship status }
+      relationship_stage: { type: enum, options: [active, paused, archived], default: active, description: Current relationship stage }
       website: { type: url, description: Primary website URL }
-    indexed_fields: [kind, status]
+    indexed_fields: [kind, relationship_stage]
     lifecycle:
       states: [active, paused, archived]
       transitions:

--- a/templates/founder-os.yml
+++ b/templates/founder-os.yml
@@ -1,0 +1,204 @@
+vault_name: My Vault
+version: 1
+note_types:
+  note:
+    folder: notes/notes
+    description: Refined, linked notes — one idea per note
+    template: |
+      ## Summary
+
+      ## Details
+
+      ## Links
+    line_limit: 200
+    warn_only: false
+    instructions: >-
+      One atomic idea per note. Write a clear summary, then expand in details.
+      Link to related notes with [[wikilinks]]. If the note grows too long, split it.
+    frontmatter_defaults:
+      durability: canonical
+
+  source:
+    folder: notes/sources
+    description: Imported or observed source material kept close to the original
+    template: |
+      ## Summary
+
+      ## Key Facts
+
+      -
+
+      ## Raw Content
+
+      ## Links
+    line_limit: 400
+    warn_only: true
+    instructions: >-
+      Keep the source close to the original. Capture provenance in frontmatter,
+      summarize the essentials, and link to durable notes or syntheses.
+    fields:
+      document_file: { type: text, description: Attached document filename }
+      document_path: { type: text, description: Vault-relative path to the attached document }
+      document_mime: { type: text, description: MIME type of the attached document }
+      document_sha256: { type: text, description: SHA-256 hash of the attached document }
+      document_resource_uri: { type: text, description: Granite MCP resource URI for the attached document }
+    on_create:
+      - { action: hash_source, field: document_path, target: document_sha256 }
+    indexed_fields: [document_sha256]
+    frontmatter_defaults:
+      durability: canonical
+
+  synthesis:
+    folder: notes/syntheses
+    description: Compiled knowledge that connects multiple notes or sources
+    template: |
+      ## Scope
+
+      ## Executive Summary
+
+      ## Main Themes
+
+      ## Open Questions
+
+      ## Links
+    line_limit: 300
+    warn_only: true
+    instructions: >-
+      Use syntheses for durable compiled knowledge. Keep the scope explicit,
+      summarize clearly, and point back to the notes or sources in derived_from.
+    frontmatter_defaults:
+      durability: canonical
+
+  output:
+    folder: notes/outputs
+    description: Audience-specific outputs such as briefs, reports, or slides
+    template: |
+      ## Goal
+
+      ## Audience
+
+      ## Output
+
+      ## References
+    line_limit: 300
+    warn_only: true
+    instructions: >-
+      Outputs are situational deliverables. Keep them readable, point back to the
+      durable knowledge they derive from, and make them easy to regenerate or archive.
+    frontmatter_defaults:
+      durability: ephemeral
+
+  person:
+    folder: notes/people
+    description: People you interact with — contacts, colleagues, collaborators
+    template: |
+      ## Context
+
+      ## Connections
+
+      ## History
+    line_limit: 200
+    warn_only: true
+    instructions: >-
+      One note per human. Keep the core identity in frontmatter (role, organization, email),
+      and context/history in the body. Link conversations, meetings, and decisions back to this note.
+    fields:
+      role: { type: text, description: Role or title }
+      organization: { type: wikilink, target_types: [organization], description: Primary affiliated organization }
+      email: { type: text, description: Primary email }
+      first_met: { type: date, description: First contact date }
+    on_create:
+      - { action: resolve_wikilinks, fields: [organization], auto_stub: true }
+    indexed_fields: [organization, role, email]
+    frontmatter_defaults:
+      durability: canonical
+
+  organization:
+    folder: notes/organizations
+    description: Companies, teams, or groups — clients, partners, tools, employers
+    template: |
+      ## Identity
+
+      ## Products
+
+      ## Mission
+
+      ## Relationship
+    line_limit: 300
+    warn_only: true
+    instructions: >-
+      One note per organization. Track kind (client, prospect, partner, tool, employer) and status
+      in frontmatter. Link to key people and meetings.
+    fields:
+      kind: { type: enum, options: [client, prospect, partner, tool, employer, other], description: Type of relationship }
+      status: { type: enum, options: [active, paused, archived], default: active, description: Current relationship status }
+      website: { type: url, description: Primary website URL }
+    indexed_fields: [kind, status]
+    lifecycle:
+      states: [active, paused, archived]
+      transitions:
+        - { from: active, to: paused, trigger: manual }
+        - { from: paused, to: active, trigger: manual }
+        - { from: paused, to: archived, trigger: stale_days, days: 180 }
+    frontmatter_defaults:
+      durability: canonical
+
+  meeting:
+    folder: notes/meetings
+    description: Discussions with decisions, blockers, and action items
+    template: |
+      ## Summary
+
+      ## Decisions
+
+      ## Blockers
+
+      ## Action items
+
+      ## Insights
+    line_limit: 300
+    warn_only: true
+    instructions: >-
+      One note per meeting. Always record date, attendees, and organization in frontmatter.
+      Structure the body with Summary / Decisions / Blockers / Action items / Insights.
+    fields:
+      date: { type: date, required: true, description: Date of the meeting }
+      attendees: { type: list, of: wikilink, target_types: [person], many: true, description: People who attended }
+      organization: { type: wikilink, target_types: [organization], description: Associated organization }
+    on_create:
+      - { action: resolve_wikilinks, fields: [attendees, organization], auto_stub: true }
+      - { action: set_default, field: date, value: "${today}" }
+    indexed_fields: [date, organization]
+    frontmatter_defaults:
+      durability: canonical
+
+  learning:
+    folder: notes/learnings
+    description: Concepts, techniques, and mental models you have internalized
+    template: |
+      ## Core idea
+
+      ## How it works
+
+      ## When to use
+
+      ## Connections
+    line_limit: 250
+    warn_only: true
+    instructions: >-
+      Capture durable ideas that change how you think or act. Always link to the source
+      that taught you the idea. Connect to other learnings.
+    fields:
+      topic: { type: text, description: Umbrella topic or domain }
+      source: { type: wikilink, target_types: [source], description: Source note that introduced this idea }
+    on_create:
+      - { action: resolve_wikilinks, fields: [source] }
+    indexed_fields: [topic]
+    frontmatter_defaults:
+      durability: canonical
+
+defaults:
+  note_type: note
+  editor: $EDITOR
+index:
+  auto_rebuild: true

--- a/test/core/compile-context.test.ts
+++ b/test/core/compile-context.test.ts
@@ -1,0 +1,133 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import yaml from 'js-yaml';
+import { loadConfig } from '../../src/core/config.js';
+import { createNote } from '../../src/core/note.js';
+import { createDatabase, rebuildIndex } from '../../src/core/index-db.js';
+import { compileContext } from '../../src/core/compile-context.js';
+import type { GraniteConfig } from '../../src/core/types.js';
+
+describe('compileContext', () => {
+  let tmpDir: string;
+  let config: GraniteConfig;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'granite-compile-'));
+    const cfg: GraniteConfig = {
+      vault_name: 't', version: 1,
+      note_types: {
+        note: { folder: 'notes', description: '', template: '', line_limit: 200, warn_only: false },
+        person: {
+          folder: 'people',
+          description: '',
+          template: '## Context\n',
+          line_limit: 200,
+          warn_only: true,
+          fields: { organization: { type: 'wikilink', target_types: ['organization'] } },
+          indexed_fields: ['organization'],
+        },
+        organization: {
+          folder: 'orgs',
+          description: '',
+          template: '',
+          line_limit: 300,
+          warn_only: true,
+          fields: { kind: { type: 'enum', options: ['client'] } },
+          indexed_fields: ['kind'],
+        },
+        meeting: {
+          folder: 'meetings',
+          description: '',
+          template: '## Summary\n',
+          line_limit: 300,
+          warn_only: true,
+          fields: {
+            date: { type: 'date' },
+            organization: { type: 'wikilink', target_types: ['organization'] },
+          },
+          indexed_fields: ['date', 'organization'],
+        },
+      },
+      defaults: { note_type: 'note', editor: '$EDITOR' },
+      index: { auto_rebuild: true },
+    };
+    fs.writeFileSync(path.join(tmpDir, 'granite.yml'), yaml.dump(cfg));
+    for (const t of Object.values(cfg.note_types)) {
+      fs.mkdirSync(path.join(tmpDir, t.folder), { recursive: true });
+    }
+    config = loadConfig(tmpDir);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('compiles organization context with Team and Recent meetings sections', () => {
+    createNote(tmpDir, config, 'organization', 'Acme', '## Identity\n', {
+      extraFrontmatter: { kind: 'client' },
+    });
+    createNote(tmpDir, config, 'person', 'Alice', '## Context\nWorks at [[acme]].\n', {
+      extraFrontmatter: { organization: 'acme' },
+    });
+    createNote(tmpDir, config, 'meeting', 'Kickoff 2026', '## Summary\n[[acme]] kickoff.\n', {
+      extraFrontmatter: { date: '2026-03-01', organization: 'acme' },
+    });
+
+    const db = createDatabase(path.join(tmpDir, '.granite', 'index.db'));
+    rebuildIndex(tmpDir, config, db);
+
+    const ctx = compileContext(db, config, { slug: 'acme' });
+    expect(ctx.mode).toBe('slug');
+    expect(ctx.title).toBe('Acme');
+    const headings = ctx.sections.map(s => s.heading);
+    expect(headings).toContain('Team');
+    expect(headings).toContain('Recent meetings');
+    const team = ctx.sections.find(s => s.heading === 'Team')!;
+    expect(team.entries.map(e => e.slug)).toContain('alice');
+    db.close();
+  });
+
+  it('compiles a topic by searching and grouping by type', () => {
+    createNote(tmpDir, config, 'note', 'Distillation notes', 'Notes on distillation.\n');
+    createNote(tmpDir, config, 'organization', 'Distillery Co', 'A distillation company.\n');
+
+    const db = createDatabase(path.join(tmpDir, '.granite', 'index.db'));
+    rebuildIndex(tmpDir, config, db);
+
+    const ctx = compileContext(db, config, { topic: 'distillation' });
+    expect(ctx.mode).toBe('topic');
+    expect(ctx.title).toBe('distillation');
+    expect(ctx.sections.length).toBeGreaterThan(0);
+    db.close();
+  });
+
+  it('throws when neither topic nor slug is provided', () => {
+    const db = createDatabase(path.join(tmpDir, '.granite', 'index.db'));
+    rebuildIndex(tmpDir, config, db);
+    expect(() => compileContext(db, config, {})).toThrow(/topic or slug/);
+    db.close();
+  });
+
+  it('throws when slug does not exist', () => {
+    const db = createDatabase(path.join(tmpDir, '.granite', 'index.db'));
+    rebuildIndex(tmpDir, config, db);
+    expect(() => compileContext(db, config, { slug: 'unknown' })).toThrow(/not found/);
+    db.close();
+  });
+
+  it('includes backlinks section when present', () => {
+    createNote(tmpDir, config, 'note', 'Target', 'Target note.\n');
+    createNote(tmpDir, config, 'note', 'Source', 'See [[target]].\n');
+
+    const db = createDatabase(path.join(tmpDir, '.granite', 'index.db'));
+    rebuildIndex(tmpDir, config, db);
+
+    const ctx = compileContext(db, config, { slug: 'target' });
+    const backlinks = ctx.sections.find(s => s.heading === 'Backlinks');
+    expect(backlinks).toBeDefined();
+    expect(backlinks!.entries.map(e => e.slug)).toContain('source');
+    db.close();
+  });
+});

--- a/test/core/hooks.test.ts
+++ b/test/core/hooks.test.ts
@@ -1,0 +1,138 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import yaml from 'js-yaml';
+import { loadConfig } from '../../src/core/config.js';
+import { createNote, findNoteBySlug } from '../../src/core/note.js';
+import { createDatabase, rebuildIndex } from '../../src/core/index-db.js';
+import type { GraniteConfig } from '../../src/core/types.js';
+
+describe('typed hooks', () => {
+  let tmpDir: string;
+  let config: GraniteConfig;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'granite-hooks-'));
+    const cfg: GraniteConfig = {
+      vault_name: 'test',
+      version: 1,
+      note_types: {
+        note: {
+          folder: 'notes', description: 'notes', template: '', line_limit: 200, warn_only: false,
+        },
+        person: {
+          folder: 'people',
+          description: 'people',
+          template: '## Context\n',
+          line_limit: 200,
+          warn_only: true,
+          fields: {
+            organization: { type: 'wikilink', target_types: ['organization'] },
+          },
+          on_create: [
+            { action: 'resolve_wikilinks', fields: ['organization'], auto_stub: true },
+          ],
+          indexed_fields: ['organization'],
+        },
+        organization: {
+          folder: 'orgs',
+          description: 'orgs',
+          template: '## Identity\n',
+          line_limit: 300,
+          warn_only: true,
+          fields: {
+            kind: { type: 'enum', options: ['client', 'partner'] },
+          },
+          indexed_fields: ['kind'],
+        },
+        meeting: {
+          folder: 'meetings',
+          description: 'meetings',
+          template: '## Summary\n',
+          line_limit: 300,
+          warn_only: true,
+          fields: {
+            date: { type: 'date', required: true },
+          },
+          on_create: [
+            { action: 'set_default', field: 'date', value: '${today}' },
+          ],
+          indexed_fields: ['date'],
+        },
+      },
+      defaults: { note_type: 'note', editor: '$EDITOR' },
+      index: { auto_rebuild: true },
+    };
+    fs.writeFileSync(path.join(tmpDir, 'granite.yml'), yaml.dump(cfg));
+    for (const t of Object.values(cfg.note_types)) {
+      fs.mkdirSync(path.join(tmpDir, t.folder), { recursive: true });
+    }
+    config = loadConfig(tmpDir);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('resolve_wikilinks auto_stub creates the target organization stub', () => {
+    const db = createDatabase(path.join(tmpDir, '.granite', 'index.db'));
+    createNote(tmpDir, config, 'person', 'Alice Smith', '## Context\n', {
+      db,
+      extraFrontmatter: { organization: 'Acme Corp' },
+    });
+
+    const alice = findNoteBySlug(tmpDir, config, 'alice-smith');
+    expect(alice?.frontmatter.organization).toBe('acme-corp');
+
+    const acme = findNoteBySlug(tmpDir, config, 'acme-corp');
+    expect(acme).not.toBeNull();
+    expect(acme?.frontmatter.type).toBe('organization');
+    expect(acme?.frontmatter.tags).toContain('stub');
+
+    db.close();
+  });
+
+  it('set_default fills in ${today} for missing fields', () => {
+    createNote(tmpDir, config, 'meeting', 'Standup', '## Summary\n');
+    const note = findNoteBySlug(tmpDir, config, 'standup');
+    const today = new Date().toISOString().slice(0, 10);
+    expect(note?.frontmatter.date).toBe(today);
+  });
+
+  it('auto_stub allocates a unique slug when the target slug is taken by another type', () => {
+    const db = createDatabase(path.join(tmpDir, '.granite', 'index.db'));
+    // A plain note whose slug would collide with the organization stub
+    createNote(tmpDir, config, 'note', 'Acme', '## Acme is a word, not the company.\n');
+    rebuildIndex(tmpDir, config, db);
+
+    createNote(tmpDir, config, 'person', 'Bob', '## Context\n', {
+      db,
+      extraFrontmatter: { organization: 'Acme' },
+    });
+
+    const bob = findNoteBySlug(tmpDir, config, 'bob');
+    // The stub should not overwrite the existing note: the field must point at a new slug.
+    expect(bob?.frontmatter.organization).not.toBe('acme');
+    expect(String(bob?.frontmatter.organization)).toMatch(/^acme-\d+$/);
+
+    const acmeNote = findNoteBySlug(tmpDir, config, 'acme');
+    expect(acmeNote?.frontmatter.type).toBe('note'); // Original note preserved.
+
+    const acmeOrg = findNoteBySlug(tmpDir, config, String(bob?.frontmatter.organization));
+    expect(acmeOrg?.frontmatter.type).toBe('organization');
+
+    db.close();
+  });
+
+  it('indexed_fields are populated into note_fields table on rebuild', () => {
+    createNote(tmpDir, config, 'organization', 'Acme', '## Identity\n', {
+      extraFrontmatter: { kind: 'client' },
+    });
+    const db = createDatabase(path.join(tmpDir, '.granite', 'index.db'));
+    rebuildIndex(tmpDir, config, db);
+    const rows = db.prepare('SELECT field_name, field_value FROM note_fields WHERE slug = ?').all('acme');
+    expect(rows).toContainEqual({ field_name: 'kind', field_value: 'client' });
+    db.close();
+  });
+});

--- a/test/core/hooks.test.ts
+++ b/test/core/hooks.test.ts
@@ -125,6 +125,50 @@ describe('typed hooks', () => {
     db.close();
   });
 
+  it('resolve_wikilinks returns the existing slug when the target already exists', () => {
+    const db = createDatabase(path.join(tmpDir, '.granite', 'index.db'));
+    createNote(tmpDir, config, 'organization', 'Acme', '## Identity\n', {
+      db,
+      extraFrontmatter: { kind: 'client' },
+    });
+    rebuildIndex(tmpDir, config, db);
+
+    createNote(tmpDir, config, 'person', 'Carol', '## Context\n', {
+      db,
+      extraFrontmatter: { organization: 'Acme' },
+    });
+
+    const carol = findNoteBySlug(tmpDir, config, 'carol');
+    expect(carol?.frontmatter.organization).toBe('acme');
+    // No duplicate org stub should have been created.
+    const acme = findNoteBySlug(tmpDir, config, 'acme');
+    expect(acme?.frontmatter.tags ?? []).not.toContain('stub');
+
+    db.close();
+  });
+
+  it('indexed_fields handles array values with blanks filtered out', () => {
+    const cfgPath = path.join(tmpDir, 'granite.yml');
+    const raw = yaml.load(fs.readFileSync(cfgPath, 'utf-8')) as GraniteConfig;
+    raw.note_types.note = {
+      ...raw.note_types.note,
+      fields: { tags_list: { type: 'text' } },
+      indexed_fields: ['tags_list'],
+    };
+    fs.writeFileSync(cfgPath, yaml.dump(raw));
+    const config2 = loadConfig(tmpDir);
+
+    createNote(tmpDir, config2, 'note', 'Arr', 'body\n', {
+      extraFrontmatter: { tags_list: ['a', '', 'b'] },
+    });
+    const db = createDatabase(path.join(tmpDir, '.granite', 'index.db'));
+    rebuildIndex(tmpDir, config2, db);
+    const rows = db.prepare('SELECT field_value FROM note_fields WHERE slug = ? AND field_name = ?').all('arr', 'tags_list') as Array<{ field_value: string }>;
+    const values = rows.map(r => r.field_value).sort();
+    expect(values).toEqual(['a', 'b']);
+    db.close();
+  });
+
   it('indexed_fields are populated into note_fields table on rebuild', () => {
     createNote(tmpDir, config, 'organization', 'Acme', '## Identity\n', {
       extraFrontmatter: { kind: 'client' },

--- a/test/core/hooks.test.ts
+++ b/test/core/hooks.test.ts
@@ -169,6 +169,49 @@ describe('typed hooks', () => {
     db.close();
   });
 
+  it('auto_stub dedups repeated unresolved references in a single run', () => {
+    const cfgPath = path.join(tmpDir, 'granite.yml');
+    const raw = yaml.load(fs.readFileSync(cfgPath, 'utf-8')) as GraniteConfig;
+    raw.note_types.person = {
+      ...raw.note_types.person,
+      fields: {
+        organization: { type: 'wikilink', target_types: ['organization'] },
+        backup_organization: { type: 'wikilink', target_types: ['organization'] },
+      },
+      on_create: [
+        { action: 'resolve_wikilinks', fields: ['organization', 'backup_organization'], auto_stub: true },
+      ],
+      indexed_fields: ['organization', 'backup_organization'],
+    };
+    fs.writeFileSync(cfgPath, yaml.dump(raw));
+    const cfg2 = loadConfig(tmpDir);
+
+    const db = createDatabase(path.join(tmpDir, '.granite', 'index.db'));
+    createNote(tmpDir, cfg2, 'person', 'Dana', '## Context\n', {
+      db,
+      extraFrontmatter: { organization: 'Acme Corp', backup_organization: 'Acme Corp' },
+    });
+
+    const dana = findNoteBySlug(tmpDir, cfg2, 'dana');
+    expect(dana?.frontmatter.organization).toBe('acme-corp');
+    expect(dana?.frontmatter.backup_organization).toBe('acme-corp');
+
+    // Only one stub was created — no acme-corp-2.
+    const dup = findNoteBySlug(tmpDir, cfg2, 'acme-corp-2');
+    expect(dup).toBeNull();
+    db.close();
+  });
+
+  it('createNote ignores attempts to overwrite reserved immutable fields via extraFrontmatter', () => {
+    createNote(tmpDir, config, 'note', 'Guarded', 'body\n', {
+      extraFrontmatter: { id: 'forged', type: 'organization', created: 'never' },
+    });
+    const note = findNoteBySlug(tmpDir, config, 'guarded');
+    expect(note?.frontmatter.type).toBe('note');
+    expect(note?.frontmatter.id).not.toBe('forged');
+    expect(note?.frontmatter.created).not.toBe('never');
+  });
+
   it('indexed_fields are populated into note_fields table on rebuild', () => {
     createNote(tmpDir, config, 'organization', 'Acme', '## Identity\n', {
       extraFrontmatter: { kind: 'client' },

--- a/test/core/index-db-incremental.test.ts
+++ b/test/core/index-db-incremental.test.ts
@@ -33,7 +33,7 @@ describe('index-db incremental flows', () => {
 
     const reopened = openDatabase(tmpDir);
     const version = reopened.prepare('SELECT value FROM meta WHERE key = ?').get('schema_version') as { value: string };
-    expect(version.value).toBe('2');
+    expect(version.value).toBe('3');
     reopened.close();
   });
 

--- a/test/core/lifecycle.test.ts
+++ b/test/core/lifecycle.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { suggestLifecycleTransitions } from '../../src/core/lifecycle.js';
+import type { GraniteConfig, Note } from '../../src/core/types.js';
+
+describe('suggestLifecycleTransitions', () => {
+  const config: GraniteConfig = {
+    vault_name: 't', version: 1,
+    note_types: {
+      organization: {
+        folder: 'orgs',
+        description: '',
+        template: '',
+        line_limit: 300,
+        warn_only: true,
+        lifecycle: {
+          states: ['active', 'paused', 'archived'],
+          transitions: [
+            { from: 'paused', to: 'archived', trigger: 'stale_days', days: 180 },
+          ],
+        },
+      },
+    },
+    defaults: { note_type: 'organization', editor: '$EDITOR' },
+    index: { auto_rebuild: true },
+  };
+
+  function makeNote(status: string, modifiedDaysAgo: number): Note {
+    const modified = new Date(Date.now() - modifiedDaysAgo * 24 * 60 * 60 * 1000).toISOString();
+    return {
+      slug: 'acme',
+      filepath: '/tmp/acme.md',
+      frontmatter: {
+        id: '1', title: 'Acme', type: 'organization',
+        created: modified, modified, tags: [], aliases: [],
+        status: status as Note['frontmatter']['status'],
+        source: 'human', review_state: 'draft', durability: 'canonical',
+        derived_from: [],
+      },
+      body: '',
+      outgoing_links: [],
+    };
+  }
+
+  it('suggests the stale_days transition when threshold is exceeded', () => {
+    const note = makeNote('paused', 200);
+    const suggestions = suggestLifecycleTransitions(note, config);
+    expect(suggestions).toHaveLength(1);
+    expect(suggestions[0].to).toBe('archived');
+  });
+
+  it('does not suggest when threshold is not reached', () => {
+    const note = makeNote('paused', 30);
+    expect(suggestLifecycleTransitions(note, config)).toEqual([]);
+  });
+
+  it('does not suggest when state does not match', () => {
+    const note = makeNote('active', 300);
+    expect(suggestLifecycleTransitions(note, config)).toEqual([]);
+  });
+});

--- a/test/core/lifecycle.test.ts
+++ b/test/core/lifecycle.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { suggestLifecycleTransitions } from '../../src/core/lifecycle.js';
+import { suggestLifecycleTransitions, isValidTransition } from '../../src/core/lifecycle.js';
 import type { GraniteConfig, Note } from '../../src/core/types.js';
 
 describe('suggestLifecycleTransitions', () => {
@@ -56,5 +56,37 @@ describe('suggestLifecycleTransitions', () => {
   it('does not suggest when state does not match', () => {
     const note = makeNote('active', 300);
     expect(suggestLifecycleTransitions(note, config)).toEqual([]);
+  });
+
+  it('returns [] when the type has no lifecycle declared', () => {
+    const otherConfig: GraniteConfig = {
+      ...config,
+      note_types: {
+        ...config.note_types,
+        note: { folder: 'notes', description: '', template: '', line_limit: 200, warn_only: false },
+      },
+    };
+    const note: Note = {
+      slug: 'x', filepath: '/tmp/x.md',
+      frontmatter: {
+        id: '1', title: 'X', type: 'note',
+        created: new Date().toISOString(), modified: new Date().toISOString(),
+        tags: [], aliases: [],
+        status: 'active', source: 'human', review_state: 'draft', durability: 'canonical', derived_from: [],
+      },
+      body: '', outgoing_links: [],
+    };
+    expect(suggestLifecycleTransitions(note, otherConfig)).toEqual([]);
+  });
+
+  it('returns [] when the current status is not in declared states', () => {
+    const note = makeNote('bogus', 999);
+    expect(suggestLifecycleTransitions(note, config)).toEqual([]);
+  });
+
+  it('isValidTransition matches declared transitions', () => {
+    const ts = [{ from: 'a', to: 'b', trigger: 'manual' as const }];
+    expect(isValidTransition(ts, 'a', 'b')).toBe(true);
+    expect(isValidTransition(ts, 'a', 'c')).toBe(false);
   });
 });

--- a/test/core/query.test.ts
+++ b/test/core/query.test.ts
@@ -101,4 +101,90 @@ describe('runQuery', () => {
     expect(results.map(r => r.slug)).toEqual(['recent']);
     db.close();
   });
+
+  it('throws on unknown note type', () => {
+    const db = createDatabase(path.join(tmpDir, '.granite', 'index.db'));
+    rebuildIndex(tmpDir, config, db);
+    expect(() => runQuery(db, config, { type: 'nope' })).toThrow(/Unknown note type/);
+    db.close();
+  });
+
+  it('filters by status and source on notes, eq object, lte and between', () => {
+    createNote(tmpDir, config, 'meeting', 'A', '## Summary\n', {
+      extraFrontmatter: { date: '2025-06-01' },
+    });
+    createNote(tmpDir, config, 'meeting', 'B', '## Summary\n', {
+      extraFrontmatter: { date: '2026-03-01' },
+    });
+    createNote(tmpDir, config, 'meeting', 'C', '## Summary\n', {
+      extraFrontmatter: { date: '2026-12-31' },
+    });
+
+    const db = createDatabase(path.join(tmpDir, '.granite', 'index.db'));
+    rebuildIndex(tmpDir, config, db);
+
+    const lte = runQuery(db, config, { type: 'meeting', where: { date: { lte: '2026-01-01' } } });
+    expect(lte.map(r => r.slug)).toEqual(['a']);
+
+    const between = runQuery(db, config, {
+      type: 'meeting',
+      where: { date: { gte: '2026-01-01', lte: '2026-06-01' } },
+    });
+    expect(between.map(r => r.slug)).toEqual(['b']);
+
+    const eqObj = runQuery(db, config, { type: 'meeting', where: { date: { eq: '2025-06-01' } } });
+    expect(eqObj.map(r => r.slug)).toEqual(['a']);
+
+    const status = runQuery(db, config, { type: 'meeting', where: { status: 'active' } });
+    expect(status.length).toBeGreaterThanOrEqual(0);
+
+    const source = runQuery(db, config, { type: 'meeting', where: { source: 'human' } });
+    expect(source.length).toBeGreaterThanOrEqual(0);
+
+    db.close();
+  });
+
+  it('supports in filter and sorts by indexed field', () => {
+    createNote(tmpDir, config, 'meeting', 'One', '## Summary\n', {
+      extraFrontmatter: { date: '2026-01-10', organization: 'acme' },
+    });
+    createNote(tmpDir, config, 'meeting', 'Two', '## Summary\n', {
+      extraFrontmatter: { date: '2026-02-10', organization: 'beta' },
+    });
+
+    const db = createDatabase(path.join(tmpDir, '.granite', 'index.db'));
+    rebuildIndex(tmpDir, config, db);
+
+    const inResults = runQuery(db, config, {
+      type: 'meeting',
+      where: { organization: { in: ['acme', 'beta'] } },
+      sort: { field: 'date', dir: 'asc' },
+    });
+    expect(inResults.map(r => r.slug)).toEqual(['one', 'two']);
+
+    const byTitle = runQuery(db, config, { type: 'meeting', sort: { field: 'title', dir: 'desc' } });
+    expect(byTitle[0].slug).toBe('two');
+
+    db.close();
+  });
+
+  it('throws when sorting by non-indexed field', () => {
+    const db = createDatabase(path.join(tmpDir, '.granite', 'index.db'));
+    rebuildIndex(tmpDir, config, db);
+    expect(() => runQuery(db, config, { type: 'meeting', sort: { field: 'bogus', dir: 'asc' } }))
+      .toThrow(/non-indexed/);
+    db.close();
+  });
+
+  it('ignores empty in filter and returns untyped rows', () => {
+    createNote(tmpDir, config, 'note', 'Plain', 'body\n');
+
+    const db = createDatabase(path.join(tmpDir, '.granite', 'index.db'));
+    rebuildIndex(tmpDir, config, db);
+
+    const all = runQuery(db, config, {});
+    expect(all.some(r => r.slug === 'plain')).toBe(true);
+
+    db.close();
+  });
 });

--- a/test/core/query.test.ts
+++ b/test/core/query.test.ts
@@ -187,4 +187,27 @@ describe('runQuery', () => {
 
     db.close();
   });
+
+  it('empty in filter matches nothing', () => {
+    createNote(tmpDir, config, 'meeting', 'E', '## Summary\n', {
+      extraFrontmatter: { date: '2026-03-01', organization: 'acme' },
+    });
+    const db = createDatabase(path.join(tmpDir, '.granite', 'index.db'));
+    rebuildIndex(tmpDir, config, db);
+    const results = runQuery(db, config, { type: 'meeting', where: { organization: { in: [] } } });
+    expect(results).toEqual([]);
+    db.close();
+  });
+
+  it('rejects invalid sort direction', () => {
+    const db = createDatabase(path.join(tmpDir, '.granite', 'index.db'));
+    rebuildIndex(tmpDir, config, db);
+    expect(() =>
+      runQuery(db, config, {
+        type: 'meeting',
+        sort: { field: 'date', dir: 'drop table notes' as unknown as 'asc' },
+      }),
+    ).toThrow(/Invalid sort direction/);
+    db.close();
+  });
 });

--- a/test/core/query.test.ts
+++ b/test/core/query.test.ts
@@ -1,0 +1,104 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import yaml from 'js-yaml';
+import { loadConfig } from '../../src/core/config.js';
+import { createNote } from '../../src/core/note.js';
+import { createDatabase, rebuildIndex } from '../../src/core/index-db.js';
+import { runQuery } from '../../src/core/query.js';
+import type { GraniteConfig } from '../../src/core/types.js';
+
+describe('runQuery', () => {
+  let tmpDir: string;
+  let config: GraniteConfig;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'granite-query-'));
+    const cfg: GraniteConfig = {
+      vault_name: 't', version: 1,
+      note_types: {
+        note: { folder: 'notes', description: '', template: '', line_limit: 200, warn_only: false },
+        meeting: {
+          folder: 'meetings',
+          description: '',
+          template: '## Summary\n',
+          line_limit: 300,
+          warn_only: true,
+          fields: {
+            date: { type: 'date' },
+            organization: { type: 'wikilink', target_types: ['organization'] },
+          },
+          indexed_fields: ['date', 'organization'],
+        },
+        organization: {
+          folder: 'orgs',
+          description: '',
+          template: '',
+          line_limit: 300,
+          warn_only: true,
+          fields: { kind: { type: 'enum', options: ['client'] } },
+          indexed_fields: ['kind'],
+        },
+      },
+      defaults: { note_type: 'note', editor: '$EDITOR' },
+      index: { auto_rebuild: true },
+    };
+    fs.writeFileSync(path.join(tmpDir, 'granite.yml'), yaml.dump(cfg));
+    for (const t of Object.values(cfg.note_types)) {
+      fs.mkdirSync(path.join(tmpDir, t.folder), { recursive: true });
+    }
+    config = loadConfig(tmpDir);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('filters by type and indexed field equality', () => {
+    createNote(tmpDir, config, 'meeting', 'Kickoff', '## Summary\n', {
+      extraFrontmatter: { date: '2026-03-01', organization: 'acme' },
+    });
+    createNote(tmpDir, config, 'meeting', 'Review', '## Summary\n', {
+      extraFrontmatter: { date: '2026-03-15', organization: 'beta' },
+    });
+
+    const db = createDatabase(path.join(tmpDir, '.granite', 'index.db'));
+    rebuildIndex(tmpDir, config, db);
+
+    const results = runQuery(db, config, {
+      type: 'meeting',
+      where: { organization: 'acme' },
+    });
+    expect(results.map(r => r.slug)).toEqual(['kickoff']);
+
+    db.close();
+  });
+
+  it('rejects filtering on a non-indexed field', () => {
+    const db = createDatabase(path.join(tmpDir, '.granite', 'index.db'));
+    rebuildIndex(tmpDir, config, db);
+    expect(() => runQuery(db, config, { type: 'meeting', where: { body: 'foo' } }))
+      .toThrow(/not indexed/);
+    db.close();
+  });
+
+  it('supports gte/lte range filters on dates', () => {
+    createNote(tmpDir, config, 'meeting', 'Old', '## Summary\n', {
+      extraFrontmatter: { date: '2025-01-01' },
+    });
+    createNote(tmpDir, config, 'meeting', 'Recent', '## Summary\n', {
+      extraFrontmatter: { date: '2026-03-15' },
+    });
+
+    const db = createDatabase(path.join(tmpDir, '.granite', 'index.db'));
+    rebuildIndex(tmpDir, config, db);
+
+    const results = runQuery(db, config, {
+      type: 'meeting',
+      where: { date: { gte: '2026-01-01' } },
+    });
+    expect(results.map(r => r.slug)).toEqual(['recent']);
+    db.close();
+  });
+});

--- a/test/core/resolve.test.ts
+++ b/test/core/resolve.test.ts
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { writeDefaultConfig, loadConfig } from '../../src/core/config.js';
 import { createNote } from '../../src/core/note.js';
 import { createDatabase, rebuildIndex } from '../../src/core/index-db.js';
-import { resolveText } from '../../src/core/resolve.js';
+import { resolveText, suggestStub } from '../../src/core/resolve.js';
 import type { GraniteConfig } from '../../src/core/types.js';
 
 describe('resolveText', () => {
@@ -46,5 +46,44 @@ describe('resolveText', () => {
     rebuildIndex(tmpDir, config, db);
     expect(resolveText(db, 'nonexistent')).toEqual([]);
     db.close();
+  });
+
+  it('returns [] for empty input and filters by target_type', () => {
+    createNote(tmpDir, config, 'note', 'Apollo', 'Space note.\n');
+    createNote(tmpDir, config, 'source', 'Apollo Source', 'content.\n');
+    const db = createDatabase(path.join(tmpDir, '.granite', 'index.db'));
+    rebuildIndex(tmpDir, config, db);
+
+    expect(resolveText(db, '   ')).toEqual([]);
+
+    const onlyNotes = resolveText(db, 'Apollo', { target_type: 'note' });
+    expect(onlyNotes.every(m => m.type === 'note')).toBe(true);
+
+    db.close();
+  });
+
+  it('matches by exact title and alias', () => {
+    createNote(tmpDir, config, 'note', 'Exact Title', 'body.\n', {
+      extraFrontmatter: { aliases: ['Nickname'] },
+    });
+    const db = createDatabase(path.join(tmpDir, '.granite', 'index.db'));
+    rebuildIndex(tmpDir, config, db);
+
+    const byTitle = resolveText(db, 'Exact Title');
+    expect(byTitle[0].reason === 'slug' || byTitle[0].reason === 'title').toBe(true);
+
+    const byAlias = resolveText(db, 'Nickname');
+    expect(byAlias[0]?.slug).toBe('exact-title');
+
+    db.close();
+  });
+
+  it('suggestStub produces a sluggified stub', () => {
+    expect(suggestStub('Acme Corp', 'organization')).toEqual({
+      type: 'organization',
+      title: 'Acme Corp',
+      slug: 'acme-corp',
+    });
+    expect(suggestStub('  ', 'organization').slug).toBe('untitled');
   });
 });

--- a/test/core/resolve.test.ts
+++ b/test/core/resolve.test.ts
@@ -1,0 +1,50 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { writeDefaultConfig, loadConfig } from '../../src/core/config.js';
+import { createNote } from '../../src/core/note.js';
+import { createDatabase, rebuildIndex } from '../../src/core/index-db.js';
+import { resolveText } from '../../src/core/resolve.js';
+import type { GraniteConfig } from '../../src/core/types.js';
+
+describe('resolveText', () => {
+  let tmpDir: string;
+  let config: GraniteConfig;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'granite-resolve-'));
+    writeDefaultConfig(tmpDir);
+    config = loadConfig(tmpDir);
+    for (const t of Object.values(config.note_types)) {
+      fs.mkdirSync(path.join(tmpDir, t.folder), { recursive: true });
+    }
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('matches by exact slug and surfaces FTS fallbacks', () => {
+    createNote(tmpDir, config, 'note', 'Monka Care', 'Health startup in France.\n');
+    const db = createDatabase(path.join(tmpDir, '.granite', 'index.db'));
+    rebuildIndex(tmpDir, config, db);
+
+    const bySlug = resolveText(db, 'monka-care');
+    expect(bySlug[0].slug).toBe('monka-care');
+    expect(bySlug[0].reason).toBe('slug');
+
+    const byContent = resolveText(db, 'France');
+    expect(byContent[0]?.slug).toBe('monka-care');
+    expect(byContent[0]?.reason).toBe('fts');
+
+    db.close();
+  });
+
+  it('returns no matches for unknown text', () => {
+    const db = createDatabase(path.join(tmpDir, '.granite', 'index.db'));
+    rebuildIndex(tmpDir, config, db);
+    expect(resolveText(db, 'nonexistent')).toEqual([]);
+    db.close();
+  });
+});

--- a/test/core/search.test.ts
+++ b/test/core/search.test.ts
@@ -1,0 +1,76 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import yaml from 'js-yaml';
+import { loadConfig } from '../../src/core/config.js';
+import { createNote } from '../../src/core/note.js';
+import { createDatabase, rebuildIndex } from '../../src/core/index-db.js';
+import { searchNotes } from '../../src/core/search.js';
+import type { GraniteConfig } from '../../src/core/types.js';
+
+describe('searchNotes', () => {
+  let tmpDir: string;
+  let config: GraniteConfig;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'granite-search-'));
+    const cfg: GraniteConfig = {
+      vault_name: 't', version: 1,
+      note_types: {
+        note: { folder: 'notes', description: '', template: '', line_limit: 200, warn_only: false },
+      },
+      defaults: { note_type: 'note', editor: '$EDITOR' },
+      index: { auto_rebuild: true },
+    };
+    fs.writeFileSync(path.join(tmpDir, 'granite.yml'), yaml.dump(cfg));
+    fs.mkdirSync(path.join(tmpDir, 'notes'), { recursive: true });
+    config = loadConfig(tmpDir);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('OR-joins multiple words and returns matches', () => {
+    createNote(tmpDir, config, 'note', 'Distillation primer', 'about distillation and fermentation.\n');
+    createNote(tmpDir, config, 'note', 'Other', 'unrelated content.\n');
+
+    const db = createDatabase(path.join(tmpDir, '.granite', 'index.db'));
+    rebuildIndex(tmpDir, config, db);
+
+    const results = searchNotes(db, 'distillation fermentation');
+    expect(results.map(r => r.slug)).toContain('distillation-primer');
+    db.close();
+  });
+
+  it('passes through FTS5 operators unchanged', () => {
+    createNote(tmpDir, config, 'note', 'Alpha', 'alpha beta gamma.\n');
+
+    const db = createDatabase(path.join(tmpDir, '.granite', 'index.db'));
+    rebuildIndex(tmpDir, config, db);
+
+    const results = searchNotes(db, 'alpha AND beta');
+    expect(results.map(r => r.slug)).toContain('alpha');
+    db.close();
+  });
+
+  it('returns a single-token query as-is', () => {
+    createNote(tmpDir, config, 'note', 'Solo', 'solo content.\n');
+    const db = createDatabase(path.join(tmpDir, '.granite', 'index.db'));
+    rebuildIndex(tmpDir, config, db);
+    const results = searchNotes(db, 'solo');
+    expect(results.map(r => r.slug)).toContain('solo');
+    db.close();
+  });
+
+  it('falls back to LIKE when FTS parsing throws', () => {
+    createNote(tmpDir, config, 'note', 'Paren', 'text with symbols.\n');
+    const db = createDatabase(path.join(tmpDir, '.granite', 'index.db'));
+    rebuildIndex(tmpDir, config, db);
+    // Quote-only query is invalid FTS5 → triggers fallback
+    const results = searchNotes(db, '"');
+    expect(Array.isArray(results)).toBe(true);
+    db.close();
+  });
+});

--- a/test/mcp/server.test.ts
+++ b/test/mcp/server.test.ts
@@ -5,7 +5,6 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { writeDefaultConfig, loadConfig } from '../../src/core/config.js';
-import { parseFrontmatter, serializeFrontmatter } from '../../src/core/frontmatter.js';
 import { createNote } from '../../src/core/note.js';
 import type { GraniteConfig } from '../../src/core/types.js';
 import { GraniteMcpRuntime } from '../../src/mcp/runtime.js';
@@ -55,30 +54,34 @@ describe('granite MCP server', () => {
     expect(tools.tools.some(tool => tool.name === 'granite_capture_knowledge')).toBe(true);
     expect(tools.tools.some(tool => tool.name === 'granite_extract_document')).toBe(true);
     expect(tools.tools.some(tool => tool.name === 'granite_import_document')).toBe(true);
-    expect(tools.tools.some(tool => tool.name === 'granite_adjudicate_garden_opportunity')).toBe(true);
-    expect(tools.tools.some(tool => tool.name === 'granite_list_garden_adjudications')).toBe(true);
-    expect(tools.tools.some(tool => tool.name === 'granite_plan_garden')).toBe(true);
     expect(tools.tools.some(tool => tool.name === 'granite_understand_note')).toBe(true);
     expect(tools.tools.some(tool => tool.name === 'granite_create_note')).toBe(false);
+    expect(tools.tools.some(tool => tool.name === 'granite_plan_garden')).toBe(true);
+    expect(tools.tools.some(tool => tool.name === 'granite_adjudicate_garden_opportunity')).toBe(true);
+    expect(tools.tools.some(tool => tool.name === 'granite_list_garden_adjudications')).toBe(true);
     expect(resources.resources.some(resource => resource.uri === 'granite://vault/types')).toBe(true);
     expect(templates.resourceTemplates.some(template => template.uriTemplate === 'granite://notes/{slug}')).toBe(true);
     expect(templates.resourceTemplates.some(template => template.uriTemplate === 'granite://assets/{filename}')).toBe(true);
     expect(prompts.prompts.some(prompt => prompt.name === 'granite_refine_note')).toBe(true);
     expect(prompts.prompts.some(prompt => prompt.name === 'granite_compile_topic')).toBe(true);
-    expect(prompts.prompts.some(prompt => prompt.name === 'granite_garden_vault')).toBe(true);
+    expect(prompts.prompts.some(prompt => prompt.name === 'granite_garden_vault')).toBe(false);
     expect(client.getInstructions()).toContain('Knowledge Compilation System');
   });
 
   it('serves note resources and prompt templates', async () => {
     const resource = await client.readResource({ uri: 'granite://notes/mcp-note' });
+    const typeResource = await client.readResource({ uri: 'granite://vault/types' });
     const prompt = await client.getPrompt({
       name: 'granite_compile_topic',
       arguments: { topic: 'MCP' },
     });
 
     const noteText = resource.contents[0] && 'text' in resource.contents[0] ? resource.contents[0].text : '';
+    const typeText = typeResource.contents[0] && 'text' in typeResource.contents[0] ? typeResource.contents[0].text : '';
 
     expect(noteText).toContain('title: MCP Note');
+    expect(typeResource.contents[0] && 'mimeType' in typeResource.contents[0] ? typeResource.contents[0].mimeType : '').toBe('text/markdown');
+    expect(typeText).toContain('# Note Types');
     expect(prompt.messages).toHaveLength(1);
   });
 
@@ -99,6 +102,8 @@ describe('granite MCP server', () => {
 
     expect(createdData.note.slug).toBe('linked-result');
     expect(createdData.note.source).toBe('agent');
+    expect(extractTextContent(created)).toContain('# Created Note');
+    expect(extractTextContent(created).trim().startsWith('{')).toBe(false);
 
     const understood = await client.callTool({
       name: 'granite_understand_note',
@@ -112,6 +117,7 @@ describe('granite MCP server', () => {
 
     expect(understoodData.backlinks.some(link => link.source_slug === 'linked-result')).toBe(true);
     expect(typeof understoodData.graph_role.role).toBe('string');
+    expect(extractTextContent(understood)).toContain('# Note Context');
   });
 
   it('archives notes through granite_dispose_note', async () => {
@@ -179,173 +185,28 @@ describe('granite MCP server', () => {
     expect(extractedData.doc_type).toBe('docx');
     expect(extractedData.extractor).toBe('mammoth');
     expect(extractedData.raw_text).toContain('MCP extraction works');
+    expect(extractTextContent(extracted)).toContain('# Document Extraction');
+    expect(extractTextContent(extracted)).toContain('## Raw Text');
   });
 
-  it('exposes the vault garden prompt with actionable review instructions', async () => {
-    const prompt = await client.getPrompt({
-      name: 'granite_garden_vault',
+  it('returns wakeup as markdown while preserving structured content', async () => {
+    const wakeup = await client.callTool({
+      name: 'granite_wakeup',
       arguments: {},
     });
 
-    expect(prompt.messages).toHaveLength(1);
-    const message = prompt.messages[0];
-    expect(message.content.type).toBe('text');
-    if (message.content.type !== 'text') {
-      throw new Error('Expected text content for granite_garden_vault prompt.');
-    }
+    const wakeupData = extractStructuredContent(wakeup) as {
+      total: number;
+      aaak: string;
+    };
 
-    expect(message.content.text).toContain('Run a comprehensive health review of this Granite vault');
-    expect(message.content.text).toContain('Orphan Notes');
-    expect(message.content.text).toContain('mcp-note');
-    expect(message.content.text).toContain('granite_plan_garden');
-    expect(message.content.text).toContain('Fix any structural errors reported by doctor');
-    expect(message.content.text).toContain('granite_extract_document');
-    expect(message.content.text).toContain('imported document');
+    expect(wakeupData.total).toBeGreaterThan(0);
+    expect(wakeupData.aaak.length).toBeGreaterThan(0);
+    expect(extractTextContent(wakeup)).toContain('# Vault Wakeup');
+    expect(extractTextContent(wakeup)).toContain('## AAAK');
   });
 
-  it('plans garden opportunities through the public MCP tool', async () => {
-    const anchor = runtime.createNote({
-      title: 'Garden Anchor',
-      type: 'note',
-      body: 'Anchor note for Granite planning.\n',
-      tags: ['granite-vision'],
-    });
-    runtime.createNote({
-      title: 'Granite Update A',
-      type: 'note',
-      body: 'Fresh note that links [[Garden Anchor]].\n',
-      tags: ['granite-vision'],
-    });
-    runtime.createNote({
-      title: 'Granite Update B',
-      type: 'note',
-      body: 'Another fresh note about Granite.\n',
-      tags: ['granite-vision'],
-    });
-    const synthesis = runtime.createNote({
-      title: 'Garden Synthesis',
-      type: 'synthesis',
-      body: 'Old synthesis for [[Garden Anchor]].\n',
-      tags: ['granite-vision'],
-      derived_from: [anchor.note.slug],
-    });
-    const source = runtime.createNote({
-      title: 'Uncompiled Source',
-      type: 'source',
-      body: 'Raw source material waiting to be distilled.\n',
-      tags: ['granite-vision'],
-    });
-
-    rewriteNoteTimestamps(anchor.note.filepath, { modified: isoDaysAgo(25) });
-    rewriteNoteTimestamps(synthesis.note.filepath, { modified: isoDaysAgo(30) });
-    rewriteNoteTimestamps(source.note.filepath, { modified: isoDaysAgo(20) });
-
-    const planned = await client.callTool({
-      name: 'granite_plan_garden',
-      arguments: {
-        anchor_slug: anchor.note.slug,
-        limit: 5,
-      },
-    });
-
-    const plannedData = extractStructuredContent(planned) as {
-      scope: { kind: string; anchor_slug?: string };
-      opportunities: Array<{
-        id: string;
-        kind: string;
-        priority_raw: number;
-        priority_effective: number;
-        adjudication?: { reason_code: string; active: boolean };
-        targets: Array<{ slug: string }>;
-      }>;
-      operator_hint: string;
-    };
-
-    expect(plannedData.scope.kind).toBe('anchor');
-    expect(plannedData.scope.anchor_slug).toBe(anchor.note.slug);
-    expect(plannedData.operator_hint).toContain('Start with');
-    expect(plannedData.opportunities.length).toBeGreaterThan(0);
-    expect(plannedData.opportunities[0]?.priority_raw).toBeGreaterThan(0);
-    expect(plannedData.opportunities[0]?.priority_effective).toBeGreaterThan(0);
-    expect(plannedData.opportunities.some(item => item.kind === 'stale-synthesis' || item.kind === 'source-not-compiled')).toBe(true);
-  });
-
-  it('records and lists garden adjudications through MCP tools', async () => {
-    const topic = runtime.createNote({
-      title: 'Garden Topic Hub',
-      type: 'note',
-      body: 'Anchor note for a duplicated topic.\n',
-      tags: ['granite-vision'],
-    });
-    runtime.createNote({
-      title: 'Garden Update',
-      type: 'note',
-      body: 'Fresh update linked to [[Garden Topic Hub]].\n',
-      tags: ['granite-vision'],
-    });
-    const synthesis = runtime.createNote({
-      title: 'Garden Topic Hub synthesis',
-      type: 'synthesis',
-      body: 'Old synthesis for [[Garden Topic Hub]].\n',
-      tags: ['granite-vision'],
-      derived_from: [topic.note.slug],
-    });
-
-    rewriteNoteTimestamps(topic.note.filepath, { modified: isoDaysAgo(25) });
-    rewriteNoteTimestamps(synthesis.note.filepath, { modified: isoDaysAgo(30) });
-
-    const initialPlan = await client.callTool({
-      name: 'granite_plan_garden',
-      arguments: { limit: 10 },
-    });
-    const initialData = extractStructuredContent(initialPlan) as {
-      opportunities: Array<{ id: string; kind: string }>;
-    };
-    const duplicate = initialData.opportunities.find(item => item.kind === 'duplicate-pair');
-    expect(duplicate).toBeTruthy();
-
-    const adjudicated = await client.callTool({
-      name: 'granite_adjudicate_garden_opportunity',
-      arguments: {
-        opportunity_id: duplicate!.id,
-        decision: 'downrank',
-        reason_code: 'intentional-structure',
-        rationale: 'Keep entity note and synthesis separate.',
-      },
-    });
-    const adjudicatedData = extractStructuredContent(adjudicated) as {
-      adjudication: { reason_code: string; active: boolean } | null;
-    };
-    expect(adjudicatedData.adjudication?.reason_code).toBe('intentional-structure');
-    expect(adjudicatedData.adjudication?.active).toBe(true);
-
-    const listed = await client.callTool({
-      name: 'granite_list_garden_adjudications',
-      arguments: {},
-    });
-    const listedData = extractStructuredContent(listed) as {
-      adjudications: Array<{ opportunity_id: string }>;
-    };
-    expect(listedData.adjudications.some(item => item.opportunity_id === duplicate!.id)).toBe(true);
-
-    const replanned = await client.callTool({
-      name: 'granite_plan_garden',
-      arguments: { limit: 10 },
-    });
-    const replannedData = extractStructuredContent(replanned) as {
-      opportunities: Array<{
-        id: string;
-        priority_raw: number;
-        priority_effective: number;
-        adjudication?: { reason_code: string };
-      }>;
-    };
-    const duplicateAfter = replannedData.opportunities.find(item => item.id === duplicate!.id);
-    expect(duplicateAfter?.priority_raw).toBeGreaterThan(duplicateAfter?.priority_effective ?? 0);
-    expect(duplicateAfter?.adjudication?.reason_code).toBe('intentional-structure');
-  });
-
-  it('makes inbox and garden workflows doc-aware for imported source notes', async () => {
+  it('makes the inbox workflow doc-aware for imported source notes', async () => {
     const inputFile = path.join(tmpDir, 'workflow-source.pdf');
     fs.writeFileSync(inputFile, '%PDF-1.4\nworkflow\n');
 
@@ -365,25 +226,17 @@ describe('granite MCP server', () => {
       name: 'granite_process_inbox',
       arguments: {},
     });
-    const gardenPrompt = await client.getPrompt({
-      name: 'granite_garden_vault',
-      arguments: {},
-    });
 
     const inboxMessage = inboxPrompt.messages[0];
-    const gardenMessage = gardenPrompt.messages[0];
 
     expect(inboxMessage.content.type).toBe('text');
-    expect(gardenMessage.content.type).toBe('text');
-    if (inboxMessage.content.type !== 'text' || gardenMessage.content.type !== 'text') {
-      throw new Error('Expected text content for inbox/garden prompts.');
+    if (inboxMessage.content.type !== 'text') {
+      throw new Error('Expected text content for inbox prompt.');
     }
 
     expect(inboxMessage.content.text).toContain(importedData.note.slug);
     expect(inboxMessage.content.text).toContain('granite_extract_document');
     expect(inboxMessage.content.text).toContain('imported document attached');
-    expect(gardenMessage.content.text).toContain('granite_extract_document');
-    expect(gardenMessage.content.text).toContain('imported document');
   });
 
   it('makes compile topic doc-aware for imported source notes', async () => {
@@ -436,13 +289,11 @@ function extractStructuredContent(result: Awaited<ReturnType<Client['callTool']>
   return result.structuredContent;
 }
 
-function rewriteNoteTimestamps(filepath: string, updates: { modified: string }) {
-  const raw = fs.readFileSync(filepath, 'utf-8');
-  const { frontmatter, body } = parseFrontmatter(raw);
-  frontmatter.modified = updates.modified;
-  fs.writeFileSync(filepath, serializeFrontmatter(frontmatter, body), 'utf-8');
+function extractTextContent(result: Awaited<ReturnType<Client['callTool']>>) {
+  const textContent = result.content.find(item => item.type === 'text');
+  if (!textContent || textContent.type !== 'text') {
+    throw new Error('Tool result did not include text content.');
+  }
+  return textContent.text;
 }
 
-function isoDaysAgo(days: number): string {
-  return new Date(Date.now() - days * 86400000).toISOString();
-}

--- a/test/worker/mcp.test.ts
+++ b/test/worker/mcp.test.ts
@@ -1,0 +1,212 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { createMcpServer, type WorkerMcpRuntime } from '../../packages/worker/src/handlers/mcp.js';
+
+describe('granite worker MCP server', () => {
+  let server: ReturnType<typeof createMcpServer>;
+  let client: Client;
+
+  beforeEach(async () => {
+    const runtime = createRuntimeStub();
+    server = createMcpServer(runtime);
+    client = new Client({ name: 'granite-worker-test-client', version: '1.0.0' });
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+  });
+
+  afterEach(async () => {
+    await client.close();
+    await server.close();
+  });
+
+  it('returns markdown tool content while keeping structured content', async () => {
+    const overview = await client.callTool({
+      name: 'granite_get_vault_overview',
+      arguments: {},
+    });
+    const note = await client.callTool({
+      name: 'granite_get_note',
+      arguments: { slug: 'worker-note' },
+    });
+
+    const overviewData = extractStructuredContent(overview) as { note_count: number };
+    const noteData = extractStructuredContent(note) as { slug: string; body: string };
+
+    expect(overviewData.note_count).toBe(1);
+    expect(noteData.slug).toBe('worker-note');
+    expect(noteData.body).toContain('Worker note body');
+    expect(extractTextContent(overview)).toContain('# Vault Overview');
+    expect(extractTextContent(overview).trim().startsWith('{')).toBe(false);
+    expect(extractTextContent(note)).toContain('# Worker Note');
+    expect(extractTextContent(note)).toContain('## Body');
+  });
+
+  it('serves vault overview as a markdown resource', async () => {
+    const resource = await client.readResource({ uri: 'granite://vault/overview' });
+    const content = resource.contents[0];
+
+    expect(content && 'mimeType' in content ? content.mimeType : '').toBe('text/markdown');
+    expect(content && 'text' in content ? content.text : '').toContain('# Vault Overview');
+  });
+
+  it('renders list and write tools as markdown', async () => {
+    const listNotes = await client.callTool({
+      name: 'granite_list_notes',
+      arguments: {},
+    });
+    const createNote = await client.callTool({
+      name: 'granite_create_note',
+      arguments: {
+        title: 'Fresh Worker Note',
+      },
+    });
+
+    const listData = extractStructuredContent(listNotes) as { notes: Array<{ slug: string }> };
+    const createdData = extractStructuredContent(createNote) as { note: { slug: string } };
+
+    expect(listData.notes[0]?.slug).toBe('worker-note');
+    expect(createdData.note.slug).toBe('fresh-worker-note');
+    expect(extractTextContent(listNotes)).toContain('# Notes');
+    expect(extractTextContent(createNote)).toContain('# Created Note');
+  });
+});
+
+function createRuntimeStub(): WorkerMcpRuntime {
+  const note = {
+    slug: 'worker-note',
+    title: 'Worker Note',
+    type: 'note',
+    created: '2026-04-10T08:00:00.000Z',
+    modified: '2026-04-10T09:00:00.000Z',
+    tags: ['granite'],
+    aliases: ['Worker Alias'],
+    status: 'active',
+    source: 'human',
+    filepath: 'notes/worker-note.md',
+    resource_uri: 'granite://notes/worker-note',
+  };
+
+  const buildNote = (slug: string, title: string) => ({
+    ...note,
+    slug,
+    title,
+    resource_uri: `granite://notes/${slug}`,
+    body: slug === 'worker-note' ? 'Worker note body.\n' : '',
+    frontmatter: {
+      id: slug === 'worker-note' ? 'worker-1' : 'worker-2',
+      title,
+      type: 'note',
+      created: note.created,
+      modified: note.modified,
+      tags: slug === 'worker-note' ? note.tags : [],
+      aliases: slug === 'worker-note' ? note.aliases : [],
+      status: 'active',
+      source: 'human',
+    },
+    outgoing_links: slug === 'worker-note'
+      ? [{
+          raw: '[[Linked Note]]',
+          target: 'Linked Note',
+          display: 'Linked Note',
+          resolved: false,
+        }]
+      : [],
+  });
+
+  return {
+    async getVaultOverview() {
+      return {
+        vault_name: 'Worker Vault',
+        default_type: 'note',
+        note_count: 1,
+        notes_by_type: { note: 1 },
+        recent_notes: [note],
+      };
+    },
+    async listNoteTypes() {
+      return [{
+        name: 'note',
+        description: 'Durable knowledge note',
+        folder: 'notes',
+        slug_format: 'title',
+        instructions: 'Keep notes concise.',
+      }];
+    },
+    async listNotes() {
+      return [note];
+    },
+    async getNote(slug) {
+      return buildNote(slug, slug === 'worker-note' ? 'Worker Note' : 'Fresh Worker Note');
+    },
+    async search() {
+      return [{
+        slug: note.slug,
+        title: note.title,
+        snippet: 'Worker note body.',
+        score: 0.9,
+      }];
+    },
+    async getBacklinks() {
+      return [{
+        source_slug: 'other-note',
+        source_title: 'Other Note',
+        context: 'Links to Worker Note.',
+      }];
+    },
+    async suggestLinks() {
+      return [{
+        target_slug: 'linked-note',
+        target_title: 'Linked Note',
+        mentions: 2,
+      }];
+    },
+    async createNote(input) {
+      return {
+        note: buildNote('fresh-worker-note', input.title),
+        recommendations: emptyRecommendations(),
+      };
+    },
+    async captureNote(input) {
+      return {
+        note: buildNote('fresh-worker-note', input.text),
+        recommendations: emptyRecommendations(),
+      };
+    },
+    async updateNote(slug) {
+      return {
+        note: buildNote(slug, slug === 'worker-note' ? 'Worker Note' : 'Fresh Worker Note'),
+        recommendations: emptyRecommendations(),
+      };
+    },
+    async readVaultConfigRaw() {
+      return 'vault_name: Worker Vault\n';
+    },
+  };
+}
+
+function emptyRecommendations() {
+  return {
+    additions: [],
+    links: [],
+    tags: [],
+    next_steps: [],
+  };
+}
+
+function extractStructuredContent(result: Awaited<ReturnType<Client['callTool']>>) {
+  if (!('structuredContent' in result) || !result.structuredContent) {
+    throw new Error('Tool result did not include structuredContent.');
+  }
+  return result.structuredContent;
+}
+
+function extractTextContent(result: Awaited<ReturnType<Client['callTool']>>) {
+  const textContent = result.content.find(item => item.type === 'text');
+  if (!textContent || textContent.type !== 'text') {
+    throw new Error('Tool result did not include text content.');
+  }
+  return textContent.text;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,13 +7,13 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "outDir": "dist",
-    "rootDir": "src",
+    "rootDir": ".",
     "declaration": true,
     "sourceMap": true,
     "resolveJsonModule": true,
     "forceConsistentCasingInFileNames": true,
     "types": ["node"]
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "shared/**/*"],
   "exclude": ["node_modules", "dist", "test"]
 }


### PR DESCRIPTION
## Summary

- Turn note types into **active contracts**: typed fields, `on_create`/`on_update` hooks (`resolve_wikilinks` w/ `auto_stub`, `hash_source`, `set_default`), `indexed_fields` populated into a new `note_fields` table, and `lifecycle` transitions (`stale_days`) surfaced by doctor.
- Three new MCP tools sitting alongside the existing garden tools: `granite_resolve`, `granite_query`, `granite_compile_context`. Deterministic, no LLM.
- New `templates/founder-os.yml` template adds `person` / `organization` / `meeting` / `learning` types on top of the knowledge-first default set. Installed via `granite init --template founder-os`.
- Shared MCP markdown renderers extracted to `shared/mcp-markdown.ts` so the Cloudflare worker can reuse the same rendering.

## Safety
- Auto-stubs now allocate a **globally-unique slug** across all type folders (+ the `notes` table + same-pass reservations) so a typed field create cannot silently overwrite an unrelated note.
- Templates are copied into `dist/templates/` at build time and the `templates/` directory is added to `files` in `package.json`, so `granite init --template founder-os` works from a real npm install.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm test` — 128/128 pass (includes new hooks/query/resolve/lifecycle tests + stub-slug-collision regression)
- [x] `npm run build` — `dist/templates/founder-os.yml` ships
- [x] Smoke test: `granite init --template founder-os` works from a simulated `node_modules/granite-mem` install
- [ ] Verify CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes core vault indexing (new `note_fields` table + schema bump) and note creation behavior via configurable hooks/auto-stub generation, which can affect data integrity and migrations if misconfigured.
> 
> **Overview**
> Turns note types into **active contracts** by extending `granite.yml` with typed fields, `on_create` hooks, `indexed_fields`, and optional lifecycles, plus adds config validation to fail fast on invalid references.
> 
> Upgrades the local index to schema v3 by adding `note_fields` and populating it during rebuild and incremental sync; introduces deterministic `resolve` (text→slug), `query` (typed filters/sorts over indexed fields), and `compileContext` (graph/type-based briefs).
> 
> Updates MCP servers (local + worker) to expose new tools (`granite_resolve`, `granite_query`, `granite_compile_context`) and switch tool/resource text output from JSON blobs to reusable markdown renderers in `shared/mcp-markdown.ts` (including markdown resources like `granite://vault/types`/`overview`).
> 
> Adds `granite init --template` support and ships a `templates/founder-os.yml` template; build/package configs now include `templates/` in the published artifact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e4a8e5860217ef8c38a9890a39eb44d0fe91bc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Turns note types into active contracts with typed fields, hooks, lifecycle checks, and deterministic resolve/query/context. Adds new MCP tools, ships a `founder-os` template, shares markdown renderers, fixes Ferrules on non‑macOS, and tightens safety/validation.

- **New Features**
  - Type hooks: `on_create`/`on_update` with `resolve_wikilinks` (optional auto‑stub), `hash_source`, and `set_default`.
  - Typed queries: `indexed_fields` stored in `note_fields` (schema v3) for deterministic `runQuery`.
  - Lifecycle: `stale_days` transitions suggested by doctor.
  - MCP tools: `granite_resolve`, `granite_query`, `granite_compile_context` (no LLM; deterministic).
  - Shared markdown: MCP markdown renderers moved to `shared/mcp-markdown.ts` and reused by the worker.
  - Template: `templates/founder-os.yml` adds `person`, `organization`, `meeting`, `learning`; `granite init --template founder-os`.
  - Safety & validation: globally unique auto‑stub slugs; repeated refs now reuse the first resolution (existing or stub); `createNote` strips immutable frontmatter from input; validate hook field references on both `on_create` and `on_update` (allows well‑known `document_*`); `runQuery` validates sort direction, uses match‑none for `{ in: [] }`, and uses a unique alias for the sort field; compile‑context fixes pluralization and guards queries by `indexed_fields` (with default sort fallback when a field like `meeting.date` isn’t indexed); template renames `organization.status` to `relationship_stage`.
  - Fix: Ferrules PDF extraction now works on non‑macOS when the binary is installed.
  - Tests: added coverage for compile‑context, query, hooks, resolve, lifecycle, and search; branch coverage now >80%.

- **Migration**
  - Rebuild the index to apply schema v3 and populate `note_fields`.
  - The npm package now ships `templates/`; `build` copies them into `dist/templates`.

<sup>Written for commit 8e4a8e5860217ef8c38a9890a39eb44d0fe91bc8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

