### PR TITLE
feat(mcp): expose vault type registry and enforce type contracts

### DIFF
--- a/scripts/verify-live-mcp.mjs
+++ b/scripts/verify-live-mcp.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+// Spawns the installed `granite mcp` binary over stdio against a throwaway vault
+// and exercises the new schemas + validation.
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import yaml from 'js-yaml';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+const GRANITE_BIN = '/Users/stan/.nvm/versions/node/v22.17.0/bin/granite';
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'granite-live-verify-'));
+
+// Minimal config with a STRICT meeting type that has a required field
+const cfg = {
+  vault_name: 'verify',
+  version: 1,
+  defaults: { note_type: 'note' },
+  note_types: {
+    note: {
+      folder: 'notes',
+      description: 'Atomic idea',
+      template: '## Summary\n\n## Details\n',
+      line_limit: 200,
+      warn_only: true,
+    },
+    meeting: {
+      folder: 'meetings',
+      description: 'Strict meeting',
+      template: '## Summary\n\n## Decisions\n\n## Action items\n',
+      line_limit: 300,
+      warn_only: false,
+      fields: {
+        date: { type: 'date', required: true, description: 'Meeting date' },
+      },
+      frontmatter_defaults: { durability: 'canonical' },
+    },
+  },
+  index: { auto_rebuild: true },
+};
+
+fs.writeFileSync(path.join(tmp, 'granite.yml'), yaml.dump(cfg));
+fs.mkdirSync(path.join(tmp, 'notes'), { recursive: true });
+fs.mkdirSync(path.join(tmp, 'meetings'), { recursive: true });
+
+const transport = new StdioClientTransport({
+  command: GRANITE_BIN,
+  args: ['mcp', '--vault', tmp],
+  stderr: 'inherit',
+});
+const client = new Client({ name: 'verify', version: '1.0' });
+await client.connect(transport);
+
+function h(title) { console.log('\n══', title, '══'); }
+
+h('1. listTools: does granite_capture_knowledge expose `fields` and enum type?');
+const tools = await client.listTools();
+const cap = tools.tools.find(t => t.name === 'granite_capture_knowledge');
+const rev = tools.tools.find(t => t.name === 'granite_revise_note');
+const capProps = cap.inputSchema.properties;
+const revProps = rev.inputSchema.properties;
+console.log('capture.fields schema present:', !!capProps.fields);
+console.log('capture.type schema:', JSON.stringify(capProps.type));
+console.log('revise.fields schema present:', !!revProps.fields);
+console.log('revise.type schema:', JSON.stringify(revProps.type));
+
+h('2. Instructions header contains TYPES pointer + signature?');
+console.log('instructions head:\n', (client.getInstructions() ?? '').split('\n').slice(0, 25).join('\n'));
+
+h('3. wakeup.aaak contains TYPES pointer?');
+const wk = await client.callTool({ name: 'granite_wakeup', arguments: {} });
+const wkStruct = wk.structuredContent;
+console.log('TYPES line in AAAK:', wkStruct.aaak.match(/^TYPES: .*/m)?.[0]);
+
+h('4. Strict meeting WITHOUT required fields → should be rejected');
+const missingResult = await client.callTool({
+  name: 'granite_capture_knowledge',
+  arguments: {
+    title: 'Sync without date',
+    type: 'meeting',
+    body: '## Summary\n## Decisions\n## Action items\n',
+  },
+});
+console.log('isError:', missingResult.isError);
+const missingText = missingResult.content?.find(c => c.type === 'text')?.text ?? '';
+console.log('message:', missingText.slice(0, 200));
+
+h('5. Strict meeting WITH fields.date → should succeed and carry validation');
+const okResult = await client.callTool({
+  name: 'granite_capture_knowledge',
+  arguments: {
+    title: 'Sync with date',
+    type: 'meeting',
+    body: '## Summary\n## Decisions\n## Action items\n',
+    fields: { date: '2026-04-17' },
+  },
+});
+console.log('isError:', okResult.isError);
+const okStruct = okResult.structuredContent;
+console.log('note.frontmatter.date:', okStruct.note.frontmatter.date);
+console.log('validation.passed:', okStruct.validation?.passed);
+console.log('validation.errors:', okStruct.validation?.errors);
+
+h('6. Revise that pushes strict body past line_limit → should throw, no mutation');
+const before = fs.readFileSync(path.join(tmp, 'meetings', 'sync-with-date.md'), 'utf-8');
+const huge = Array.from({ length: 400 }, (_, i) => `line ${i}`).join('\n');
+const revResult = await client.callTool({
+  name: 'granite_revise_note',
+  arguments: { slug: 'sync-with-date', append: huge },
+});
+console.log('isError:', revResult.isError);
+const revText = revResult.content?.find(c => c.type === 'text')?.text ?? '';
+console.log('message:', revText.slice(0, 200));
+const after = fs.readFileSync(path.join(tmp, 'meetings', 'sync-with-date.md'), 'utf-8');
+console.log('file bytes unchanged:', before.length === after.length);
+
+h('7. Read granite://vault/types — check for template/body_sections/example/defaults');
+const res = await client.readResource({ uri: 'granite://vault/types' });
+const text = res.contents[0]?.text ?? '';
+console.log('contains "Body template":', text.includes('### Body template'));
+console.log('contains "Body sections":', text.includes('### Body sections'));
+console.log('contains "Frontmatter defaults":', text.includes('### Frontmatter defaults'));
+
+await client.close();
+fs.rmSync(tmp, { recursive: true, force: true });
+console.log('\n✅ done');

--- a/shared/mcp-markdown.ts
+++ b/shared/mcp-markdown.ts
@@ -54,6 +54,18 @@ interface RecommendationLike {
   next_steps: Array<{ type: string; title_hint?: string; reason: string }>;
 }
 
+interface ValidationIssueLike {
+  code: string;
+  field?: string;
+  message: string;
+}
+
+interface ValidationLike {
+  passed: boolean;
+  errors: ValidationIssueLike[];
+  warnings: ValidationIssueLike[];
+}
+
 interface NoteTypeLike {
   name: string;
   description: string;
@@ -70,6 +82,10 @@ interface NoteTypeLike {
     default?: string;
     description?: string;
   }>;
+  template?: string;
+  body_sections?: string[];
+  example_slug?: string;
+  frontmatter_defaults?: Record<string, unknown>;
 }
 
 interface VaultOverviewLike {
@@ -241,7 +257,24 @@ export function renderNoteTypesMarkdown(noteTypes: NoteTypeLike[], defaultType?:
       ['Line limit', noteType.line_limit === undefined ? undefined : String(noteType.line_limit)],
       ['Warn only', noteType.warn_only === undefined ? undefined : yesNo(noteType.warn_only)],
       ['Instructions', noteType.instructions],
+      ['Example', noteType.example_slug ? `\`${noteType.example_slug}\` (granite://notes/${noteType.example_slug})` : undefined],
     ]);
+
+    if (noteType.body_sections && noteType.body_sections.length > 0) {
+      lines.push('', `### Body sections`);
+      lines.push(noteType.body_sections.map(s => `\`${escapeCell(s)}\``).join(' → '));
+    }
+
+    if (noteType.template && noteType.template.trim().length > 0) {
+      lines.push('', '### Body template', '```markdown', noteType.template.replace(/\n+$/, ''), '```');
+    }
+
+    if (noteType.frontmatter_defaults && Object.keys(noteType.frontmatter_defaults).length > 0) {
+      lines.push('', '### Frontmatter defaults');
+      for (const [key, value] of Object.entries(noteType.frontmatter_defaults)) {
+        lines.push(`- ${key}: ${formatUnknown(value)}`);
+      }
+    }
 
     if (noteType.fields && Object.keys(noteType.fields).length > 0) {
       lines.push('', '### Fields');
@@ -343,11 +376,36 @@ export function renderNoteDetailsMarkdown(note: NoteDetailsLike): string {
   return lines.join('\n');
 }
 
-export function renderMutationResultMarkdown(action: string, note: NoteDetailsLike, recommendations: RecommendationLike): string {
+export function renderMutationResultMarkdown(
+  action: string,
+  note: NoteDetailsLike,
+  recommendations: RecommendationLike,
+  validation?: ValidationLike,
+): string {
   const lines = [`# ${action} Note`];
   pushNoteMetadata(lines, note);
+  appendValidation(lines, validation);
   appendRecommendations(lines, recommendations);
   return lines.join('\n');
+}
+
+function appendValidation(lines: string[], validation?: ValidationLike): void {
+  if (!validation) return;
+  if (validation.passed && validation.warnings.length === 0) return;
+  lines.push('', '## Type Validation');
+  lines.push(`- Passed: ${yesNo(validation.passed)}`);
+  if (validation.errors.length > 0) {
+    lines.push('- Errors:');
+    for (const e of validation.errors) {
+      lines.push(`  - \`${e.code}\`${e.field ? ` (${e.field})` : ''}: ${e.message}`);
+    }
+  }
+  if (validation.warnings.length > 0) {
+    lines.push('- Warnings:');
+    for (const w of validation.warnings) {
+      lines.push(`  - \`${w.code}\`${w.field ? ` (${w.field})` : ''}: ${w.message}`);
+    }
+  }
 }
 
 export function renderUnderstandNoteMarkdown(result: NoteUnderstandingLike): string {

--- a/src/commands/wakeup.ts
+++ b/src/commands/wakeup.ts
@@ -4,7 +4,8 @@ import { listNotes } from '../core/note.js';
 import { ensureIndex } from '../core/index-db.js';
 import { getBacklinks } from '../core/backlinks.js';
 import { jsonSuccess } from '../core/json-output.js';
-import type { Note } from '../core/types.js';
+import { computeTypeRegistrySignature } from '../core/validate.js';
+import type { Note, GraniteConfig } from '../core/types.js';
 
 interface Cluster {
   tag: string;
@@ -83,6 +84,7 @@ function generateAaak(
   connectionCounts: Map<string, number>,
   people: Array<{ slug: string; title: string }>,
   recent: Array<{ slug: string; age: string }>,
+  config: GraniteConfig,
 ): string {
   const lines: string[] = [];
 
@@ -93,6 +95,12 @@ function generateAaak(
   const lastModified = notes.reduce((max, n) =>
     n.frontmatter.modified > max ? n.frontmatter.modified : max, '');
   lines.push(`VAULT: ${notes.length}n (${typeBreakdown}) | modified:${lastModified.slice(0, 10)}`);
+
+  // Types registry pointer — agents MUST read granite://vault/types before
+  // writing to ensure frontmatter fields and body sections match the type contract.
+  const typeCount = Object.keys(config.note_types).length;
+  const typeSig = computeTypeRegistrySignature(config);
+  lines.push(`TYPES: ${typeCount} (sig=${typeSig}) -> granite://vault/types`);
 
   // Clusters
   lines.push('CLUSTERS:');
@@ -202,7 +210,7 @@ export function wakeupCommand(options: { json?: boolean } = {}): void {
     .map(n => ({ slug: n.slug, reason: 'working+stale+disconnected' }));
 
   // Generate AAAK
-  const aaak = generateAaak(notes, byType, clusters, connectionCounts, people, recent);
+  const aaak = generateAaak(notes, byType, clusters, connectionCounts, people, recent, config);
 
   db.close();
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -22,6 +22,7 @@ export interface NoteTypeConfig {
   fields?: Record<string, FieldDefinition>;
   frontmatter_defaults?: NoteFrontmatterDefaults;
   body_sections?: string[];
+  example_slug?: string;
   on_create?: Hook[];
   on_update?: Hook[];
   indexed_fields?: string[];

--- a/src/core/validate.ts
+++ b/src/core/validate.ts
@@ -1,0 +1,128 @@
+import type { GraniteConfig, NoteFrontmatter, NoteTypeConfig } from './types.js';
+
+export interface ValidationIssue {
+  code: string;
+  field?: string;
+  message: string;
+}
+
+export interface NoteValidationResult {
+  passed: boolean;
+  errors: ValidationIssue[];
+  warnings: ValidationIssue[];
+}
+
+const RESERVED_FRONTMATTER_KEYS = new Set([
+  'id', 'title', 'type', 'created', 'modified',
+  'tags', 'aliases', 'status', 'source',
+  'review_state', 'durability', 'derived_from',
+]);
+
+export function deriveBodySections(template: string): string[] {
+  const matches = template.matchAll(/^##\s+(.+?)\s*$/gm);
+  return Array.from(matches, m => m[1].trim()).filter(Boolean);
+}
+
+export function getRequiredSections(typeConfig: NoteTypeConfig): string[] {
+  if (typeConfig.body_sections && typeConfig.body_sections.length > 0) {
+    return typeConfig.body_sections;
+  }
+  return deriveBodySections(typeConfig.template ?? '');
+}
+
+export function bodyHasSection(body: string, section: string): boolean {
+  const normalized = section.trim().toLowerCase();
+  const lineRegex = /^##\s+(.+?)\s*$/gm;
+  for (const m of body.matchAll(lineRegex)) {
+    if ((m[1] ?? '').trim().toLowerCase() === normalized) return true;
+  }
+  return false;
+}
+
+export function validateNoteAgainstType(
+  typeName: string,
+  frontmatter: NoteFrontmatter | Record<string, unknown>,
+  body: string,
+  config: GraniteConfig,
+): NoteValidationResult {
+  const errors: ValidationIssue[] = [];
+  const warnings: ValidationIssue[] = [];
+
+  const typeConfig = config.note_types[typeName];
+  if (!typeConfig) {
+    const valid = Object.keys(config.note_types).join(', ');
+    errors.push({
+      code: 'unknown_type',
+      message: `Unknown note type "${typeName}". Valid types: ${valid}.`,
+    });
+    return { passed: false, errors, warnings };
+  }
+
+  for (const [fieldName, fieldDef] of Object.entries(typeConfig.fields ?? {})) {
+    if (!fieldDef.required) continue;
+    const value = (frontmatter as Record<string, unknown>)[fieldName];
+    const missing = value === undefined
+      || value === null
+      || (typeof value === 'string' && value.trim() === '')
+      || (Array.isArray(value) && value.length === 0);
+    if (missing) {
+      (typeConfig.warn_only ? warnings : errors).push({
+        code: 'missing_required_field',
+        field: fieldName,
+        message: `Required frontmatter field "${fieldName}" is missing for type "${typeName}".`,
+      });
+    }
+  }
+
+  const requiredSections = getRequiredSections(typeConfig);
+  const missingSections = requiredSections.filter(s => !bodyHasSection(body, s));
+  if (missingSections.length > 0 && body.trim().length > 0) {
+    warnings.push({
+      code: 'missing_sections',
+      message: `Body is missing expected ${missingSections.length === 1 ? 'section' : 'sections'} for type "${typeName}": ${missingSections.join(', ')}.`,
+    });
+  }
+
+  if (typeConfig.line_limit && body.split('\n').length > typeConfig.line_limit) {
+    (typeConfig.warn_only ? warnings : errors).push({
+      code: 'line_limit_exceeded',
+      message: `Body exceeds line_limit ${typeConfig.line_limit} for type "${typeName}".`,
+    });
+  }
+
+  return { passed: errors.length === 0, errors, warnings };
+}
+
+/**
+ * Stable short signature of the type registry — bumps when any type's
+ * shape (fields, template, body_sections, warn_only, line_limit) changes.
+ */
+export function computeTypeRegistrySignature(config: GraniteConfig): string {
+  const parts: string[] = [];
+  const sortedNames = Object.keys(config.note_types).sort();
+  for (const name of sortedNames) {
+    const t = config.note_types[name];
+    const fields = Object.entries(t.fields ?? {}).sort(([a], [b]) => a.localeCompare(b))
+      .map(([fn, fd]) => `${fn}:${fd.type}${fd.required ? '!' : ''}`)
+      .join(',');
+    const sections = getRequiredSections(t).join('|');
+    parts.push(`${name}[${fields};${sections};wo=${t.warn_only ? 1 : 0};ll=${t.line_limit ?? 0}]`);
+  }
+  return hashString(parts.join('\n')).slice(0, 8);
+}
+
+function hashString(input: string): string {
+  let h = 5381;
+  for (let i = 0; i < input.length; i++) {
+    h = ((h << 5) + h + input.charCodeAt(i)) | 0;
+  }
+  // unsigned 32-bit hex
+  return (h >>> 0).toString(16).padStart(8, '0');
+}
+
+export function renderPreflightError(typeName: string, errors: ValidationIssue[]): string {
+  const body = errors.map(e => `- ${e.code}${e.field ? ` (${e.field})` : ''}: ${e.message}`).join('\n');
+  return `Cannot write note of type "${typeName}" — validation failed:\n${body}`;
+}
+
+export { RESERVED_FRONTMATTER_KEYS };

--- a/src/mcp/runtime.ts
+++ b/src/mcp/runtime.ts
@@ -23,6 +23,14 @@ import { findNoteBySlug, listNotes, createNote, readNote } from '../core/note.js
 import { getRecommendations } from '../core/recommendations.js';
 import { searchNotes } from '../core/search.js';
 import { suggestLinks } from '../core/suggest.js';
+import {
+  computeTypeRegistrySignature,
+  getRequiredSections,
+  renderPreflightError,
+  RESERVED_FRONTMATTER_KEYS,
+  validateNoteAgainstType,
+  type NoteValidationResult,
+} from '../core/validate.js';
 import type {
   BacklinkEntry,
   DoctorIssue,
@@ -87,6 +95,10 @@ export interface NoteTypeInfo {
   slug_format: 'title' | 'date';
   instructions?: string;
   fields?: GraniteConfig['note_types'][string]['fields'];
+  template?: string;
+  body_sections?: string[];
+  example_slug?: string;
+  frontmatter_defaults?: Record<string, unknown>;
 }
 
 export interface VaultOverview {
@@ -229,6 +241,7 @@ export interface CaptureNoteInput {
   review_state?: ReviewState;
   durability?: Durability;
   derived_from?: string[];
+  fields?: Record<string, unknown>;
 }
 
 export interface UpdateNoteInput {
@@ -243,6 +256,7 @@ export interface UpdateNoteInput {
   review_state?: ReviewState;
   durability?: Durability;
   derived_from?: string[];
+  fields?: Record<string, unknown>;
 }
 
 export interface ListNotesInput {
@@ -256,6 +270,7 @@ export interface ListNotesInput {
 export interface NoteMutationResult {
   note: NoteDetails;
   recommendations: NoteRecommendations;
+  validation?: NoteValidationResult;
 }
 
 export interface ImportedDocumentAsset {
@@ -342,6 +357,7 @@ export class GraniteMcpRuntime {
   }
 
   listNoteTypes(): NoteTypeInfo[] {
+    const recentByType = this.recentSlugByType();
     return Object.entries(this.config.note_types).map(([name, typeConfig]) => ({
       name,
       description: typeConfig.description,
@@ -351,11 +367,47 @@ export class GraniteMcpRuntime {
       slug_format: typeConfig.slug_format ?? 'title',
       instructions: typeConfig.instructions,
       fields: typeConfig.fields,
+      template: typeConfig.template,
+      body_sections: getRequiredSections(typeConfig),
+      example_slug: typeConfig.example_slug ?? recentByType.get(name),
+      frontmatter_defaults: typeConfig.frontmatter_defaults as Record<string, unknown> | undefined,
     }));
+  }
+
+  listNoteTypeNames(): string[] {
+    return Object.keys(this.config.note_types);
+  }
+
+  getTypeRegistrySignature(): string {
+    return computeTypeRegistrySignature(this.config);
   }
 
   getDefaultNoteType(): string {
     return this.config.defaults.note_type;
+  }
+
+  private preflightValidate(
+    typeName: string,
+    extraFields: Record<string, unknown>,
+    body: string | undefined,
+  ): NoteValidationResult {
+    const bodyForCheck = body ?? this.config.note_types[typeName]?.template ?? '';
+    return validateNoteAgainstType(typeName, extraFields, bodyForCheck, this.config);
+  }
+
+  private recentSlugByType(): Map<string, string> {
+    const latest = new Map<string, { slug: string; modified: string }>();
+    for (const note of this.readAllNotes()) {
+      if (note.frontmatter.status === 'archived') continue;
+      const t = note.frontmatter.type;
+      const existing = latest.get(t);
+      if (!existing || note.frontmatter.modified > existing.modified) {
+        latest.set(t, { slug: note.slug, modified: note.frontmatter.modified });
+      }
+    }
+    const out = new Map<string, string>();
+    for (const [t, v] of latest) out.set(t, v.slug);
+    return out;
   }
 
   listNotes(input: ListNotesInput = {}): NoteSummary[] {
@@ -582,7 +634,13 @@ export class GraniteMcpRuntime {
     // AAAK
     const typeBreak = Object.entries(byType).map(([t, c]) => `${c}${t.slice(0, 3)}`).join(',');
     const lastMod = sorted[0]?.frontmatter.modified?.slice(0, 10) ?? '';
-    const lines = [`VAULT: ${notes.length}n (${typeBreak}) | modified:${lastMod}`, 'CLUSTERS:'];
+    const typeCount = Object.keys(this.config.note_types).length;
+    const typeSig = this.getTypeRegistrySignature();
+    const lines = [
+      `VAULT: ${notes.length}n (${typeBreak}) | modified:${lastMod}`,
+      `TYPES: ${typeCount} (sig=${typeSig}) -> granite://vault/types`,
+      'CLUSTERS:',
+    ];
     for (const cl of clusters) {
       const slugList = cl.slugs.map(s => {
         const c = cx.get(s) ?? 0;
@@ -748,7 +806,15 @@ export class GraniteMcpRuntime {
     const resolvedType = input.type ?? this.config.defaults.note_type;
     const typeConfig = this.config.note_types[resolvedType];
     if (!typeConfig) {
-      throw new Error(`Unknown note type: "${resolvedType}"`);
+      const valid = Object.keys(this.config.note_types).join(', ');
+      throw new Error(`Unknown note type "${resolvedType}". Valid types in this vault: ${valid}.`);
+    }
+
+    if (!typeConfig.warn_only) {
+      const preCheck = this.preflightValidate(resolvedType, input.fields ?? {}, input.body);
+      if (preCheck.errors.length > 0) {
+        throw new Error(renderPreflightError(resolvedType, preCheck.errors));
+      }
     }
 
     const bodyOverride = input.body !== undefined
@@ -798,6 +864,7 @@ export class GraniteMcpRuntime {
       review_state: input.review_state,
       durability: input.durability,
       derived_from: input.derived_from,
+      fields: input.fields,
     });
   }
 
@@ -861,7 +928,8 @@ export class GraniteMcpRuntime {
     if (input.type !== undefined) {
       const nextType = this.config.note_types[input.type];
       if (!nextType) {
-        throw new Error(`Unknown note type: "${input.type}"`);
+        const valid = Object.keys(this.config.note_types).join(', ');
+        throw new Error(`Unknown note type "${input.type}". Valid types in this vault: ${valid}.`);
       }
 
       if (frontmatter.type !== input.type) {
@@ -913,12 +981,28 @@ export class GraniteMcpRuntime {
       frontmatter.derived_from = [...input.derived_from];
     }
 
+    if (input.fields) {
+      for (const [key, value] of Object.entries(input.fields)) {
+        if (RESERVED_FRONTMATTER_KEYS.has(key)) continue;
+        (frontmatter as Record<string, unknown>)[key] = value;
+      }
+    }
+
     if (input.body !== undefined) {
       body = ensureTrailingNewline(input.body);
     }
 
     if (input.append !== undefined) {
       body = `${body.trimEnd()}\n${input.append}\n`;
+    }
+
+    const targetType = frontmatter.type;
+    const typeConfig = this.config.note_types[targetType];
+    if (typeConfig && !typeConfig.warn_only) {
+      const pre = validateNoteAgainstType(targetType, frontmatter, body, this.config);
+      if (pre.errors.length > 0) {
+        throw new Error(renderPreflightError(targetType, pre.errors));
+      }
     }
 
     frontmatter.modified = new Date().toISOString();
@@ -1619,10 +1703,17 @@ export class GraniteMcpRuntime {
     }
 
     const note = this.requireNote(slug);
+    const validation = validateNoteAgainstType(
+      note.frontmatter.type,
+      note.frontmatter,
+      note.body,
+      this.config,
+    );
 
     return {
       note: this.getNote(note.slug),
       recommendations: getRecommendations(this.db, note, this.config),
+      validation,
     };
   }
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -50,6 +50,22 @@ const noteTypeInfoSchema = z.object({
   slug_format: z.enum(['title', 'date']),
   instructions: z.string().optional(),
   fields: z.record(z.string(), fieldDefinitionSchema).optional(),
+  template: z.string().optional(),
+  body_sections: z.array(z.string()).optional(),
+  example_slug: z.string().optional(),
+  frontmatter_defaults: z.record(z.string(), z.unknown()).optional(),
+});
+
+const validationIssueSchema = z.object({
+  code: z.string(),
+  field: z.string().optional(),
+  message: z.string(),
+});
+
+const validationResultSchema = z.object({
+  passed: z.boolean(),
+  errors: z.array(validationIssueSchema),
+  warnings: z.array(validationIssueSchema),
 });
 
 const noteSummarySchema = z.object({
@@ -290,6 +306,73 @@ export interface GraniteMcpHttpServerOptions {
   jsonResponse?: boolean;
 }
 
+function buildServerInstructions(runtime: GraniteMcpRuntime): string {
+  const types = runtime.listNoteTypes();
+  const signature = runtime.getTypeRegistrySignature();
+  const defaultType = runtime.getDefaultNoteType();
+
+  const lines: string[] = [
+    '# Granite — Knowledge Compilation System',
+    '',
+    'You are operating a local-first markdown knowledge base. You are the primary writer and gardener of this vault — the human rarely edits notes directly.',
+    '',
+    '## Public Interface',
+    '',
+    'Granite exposes a small public MCP surface:',
+    '',
+    '- **granite_wakeup** — load the map of the vault before doing work',
+    '- **granite_research_topic** — discover relevant notes for a topic',
+    '- **granite_resolve** — deterministically resolve free text to a note slug before linking',
+    '- **granite_query** — run structured queries over typed notes and indexed fields',
+    '- **granite_compile_context** — compile a typed brief for a topic or slug using the graph',
+    '- **granite_plan_garden** — compute the highest-leverage notes or clusters to revisit next',
+    '- **granite_adjudicate_garden_opportunity** — explicitly downrank or clear a garden opportunity the operator has adjudicated',
+    '- **granite_list_garden_adjudications** — inspect the active operator adjudications influencing garden planning',
+    '- **granite_capture_knowledge** — capture new knowledge into the vault',
+    '- **granite_extract_document** — read a local document into raw extracted text without importing it',
+    '- **granite_import_document** — attach a file and create a linked source note with caller-provided content',
+    '- **granite_understand_note** — inspect a note in context, not in isolation',
+    '- **granite_revise_note** — make targeted edits when workflow prompts are insufficient',
+    '- **granite_dispose_note** — archive by default, delete only when intentional',
+    '',
+    'Use prompts for the higher-level workflows: refine notes, compile topics, and process the inbox.',
+    '',
+    `## Note Types (vault registry, sig=${signature})`,
+    '',
+    `This vault declares ${types.length} type${types.length === 1 ? '' : 's'}. Default: \`${defaultType}\`. Full contracts (frontmatter fields, body sections, templates, canonical examples) are in the \`granite://vault/types\` resource — fetch it before writing if unsure.`,
+    '',
+  ];
+
+  for (const t of types) {
+    const requiredFields = Object.entries(t.fields ?? {})
+      .filter(([, f]) => f.required)
+      .map(([name]) => name);
+    const sectionList = (t.body_sections ?? []).join(' / ');
+    const headline = [
+      `- **${t.name}** (\`${t.folder}\`, max ${t.line_limit} lines${t.warn_only ? ', advisory' : ', strict'})`,
+      t.description ? `— ${t.description}` : '',
+    ].filter(Boolean).join(' ');
+    lines.push(headline);
+    if (sectionList) lines.push(`  - Body sections: ${sectionList}`);
+    if (requiredFields.length > 0) lines.push(`  - Required fields: ${requiredFields.join(', ')}`);
+    if (t.example_slug) lines.push(`  - Example: \`${t.example_slug}\` (granite://notes/${t.example_slug})`);
+  }
+
+  lines.push(
+    '',
+    '## Working Principles',
+    '',
+    '- **Read in context.** Prefer granite_understand_note over piecing together note, backlinks, and suggestions manually.',
+    '- **Capture first, refine second.** Capture quickly, then use workflow prompts to turn captures into durable knowledge.',
+    '- **Link aggressively.** Use [[wikilinks]] in note bodies and follow recommendations after each revision.',
+    '- **Archive before delete.** Knowledge systems should prefer reversible lifecycle transitions.',
+    '- **Respect the type registry.** Every note\'s type must exist in the vault config; write tools reject unknown types and report validation issues in their response.',
+    '- **Prefer explicit extraction for documents.** Use granite://notes/{slug} for markdown, granite://vault/types for type contracts, and granite_extract_document before summarizing imported documents.',
+  );
+
+  return lines.join('\n');
+}
+
 export function createGraniteMcpServer(runtime: GraniteMcpRuntime): McpServer {
   const server = new McpServer(
     {
@@ -299,49 +382,7 @@ export function createGraniteMcpServer(runtime: GraniteMcpRuntime): McpServer {
     },
     {
       capabilities: { logging: {} },
-      instructions: [
-        '# Granite — Knowledge Compilation System',
-        '',
-        'You are operating a local-first markdown knowledge base. You are the primary writer and gardener of this vault — the human rarely edits notes directly.',
-        '',
-        '## Public Interface',
-        '',
-        'Granite exposes a small public MCP surface:',
-        '',
-        '- **granite_wakeup** — load the map of the vault before doing work',
-        '- **granite_research_topic** — discover relevant notes for a topic',
-        '- **granite_resolve** — deterministically resolve free text to a note slug before linking',
-        '- **granite_query** — run structured queries over typed notes and indexed fields',
-        '- **granite_compile_context** — compile a typed brief for a topic or slug using the graph',
-        '- **granite_plan_garden** — compute the highest-leverage notes or clusters to revisit next',
-        '- **granite_adjudicate_garden_opportunity** — explicitly downrank or clear a garden opportunity the operator has adjudicated',
-        '- **granite_list_garden_adjudications** — inspect the active operator adjudications influencing garden planning',
-        '- **granite_capture_knowledge** — capture new knowledge into the vault',
-        '- **granite_extract_document** — read a local document into raw extracted text without importing it',
-        '- **granite_import_document** — attach a file and create a linked source note with caller-provided content',
-        '- **granite_understand_note** — inspect a note in context, not in isolation',
-        '- **granite_revise_note** — make targeted edits when workflow prompts are insufficient',
-        '- **granite_dispose_note** — archive by default, delete only when intentional',
-        '',
-        'Use prompts for the higher-level workflows: refine notes, compile topics, and process the inbox.',
-        '',
-        '## Note Types',
-        '',
-        '- **note**: Atomic, durable ideas — one idea per note, well-linked. The backbone of the vault.',
-        '- **source**: Imported material kept close to the original. Capture provenance, summarize essentials.',
-        '- **synthesis**: Compiled knowledge connecting multiple notes or sources. The most valuable type.',
-        '- **output**: Situational deliverables (reports, briefs). Ephemeral by default, always derived_from something durable.',
-        '',
-        'The natural flow is: source → note → synthesis → output',
-        '',
-        '## Working Principles',
-        '',
-        '- **Read in context.** Prefer granite_understand_note over piecing together note, backlinks, and suggestions manually.',
-        '- **Capture first, refine second.** Capture quickly, then use workflow prompts to turn captures into durable knowledge.',
-        '- **Link aggressively.** Use [[wikilinks]] in note bodies and follow recommendations after each revision.',
-        '- **Archive before delete.** Knowledge systems should prefer reversible lifecycle transitions.',
-        '- **Prefer explicit extraction for documents.** Use granite://notes/{slug} for markdown, granite://vault/types for type contracts, and granite_extract_document before summarizing imported documents.',
-      ].join('\n'),
+      instructions: buildServerInstructions(runtime),
     },
   );
 
@@ -423,6 +464,16 @@ export async function withResponseCleanup(
     statusText: response.statusText,
     headers: response.headers,
   });
+}
+
+function buildTypeSchema(runtime: GraniteMcpRuntime, describe: string) {
+  const names = runtime.listNoteTypeNames();
+  if (names.length === 0) {
+    return z.string().optional().describe(describe);
+  }
+  return z.enum(names as [string, ...string[]]).optional().describe(
+    `${describe} Valid types in this vault: ${names.join(', ')}.`,
+  );
 }
 
 function registerTools(server: McpServer, runtime: GraniteMcpRuntime): void {
@@ -548,7 +599,7 @@ function registerTools(server: McpServer, runtime: GraniteMcpRuntime): void {
       text: z.string().optional().describe('Raw text to capture. Required unless title and body are both provided.'),
       title: z.string().optional().describe('Optional explicit title when creating a more deliberate draft.'),
       body: z.string().optional().describe('Optional explicit body when creating a more deliberate draft.'),
-      type: z.string().optional().describe('Optional note type. Defaults to the vault default type.'),
+      type: buildTypeSchema(runtime, 'Optional note type. Defaults to the vault default type. Must be one of the vault-configured types (see granite://vault/types for each type\'s body sections and required fields).'),
       tags: z.array(z.string()).optional().describe('Tags to add immediately.'),
       aliases: z.array(z.string()).optional().describe('Aliases to add immediately.'),
       status: z.enum(['inbox', 'active', 'archived']).optional().describe('Initial note status.'),
@@ -556,10 +607,12 @@ function registerTools(server: McpServer, runtime: GraniteMcpRuntime): void {
       review_state: z.enum(['draft', 'reviewed', 'locked']).optional().describe('Initial review state.'),
       durability: z.enum(['canonical', 'working', 'ephemeral']).optional().describe('Initial durability.'),
       derived_from: z.array(z.string()).optional().describe('Source note IDs or slugs this note derives from.'),
+      fields: z.record(z.string(), z.unknown()).optional().describe('Type-specific frontmatter fields (e.g. { date: "2026-04-17" } for meetings). Keys reserved by the system (id, title, type, created, modified, tags, aliases, status, source, review_state, durability, derived_from) are ignored here — use the dedicated inputs. See granite://vault/types for each type\'s required fields.'),
     },
     outputSchema: z.object({
       note: noteDetailsSchema,
       recommendations: recommendationSchema,
+      validation: validationResultSchema.optional(),
     }),
     annotations: writeAnnotations,
   }, async (args) => {
@@ -575,8 +628,9 @@ function registerTools(server: McpServer, runtime: GraniteMcpRuntime): void {
         review_state: args.review_state,
         durability: args.durability,
         derived_from: args.derived_from,
+        fields: args.fields,
       });
-      return toolResult(result, renderMutationResultMarkdown('Created', result.note, result.recommendations));
+      return toolResult(result, renderMutationResultMarkdown('Created', result.note, result.recommendations, result.validation));
     }
 
     if (!args.text) {
@@ -593,8 +647,9 @@ function registerTools(server: McpServer, runtime: GraniteMcpRuntime): void {
       review_state: args.review_state,
       durability: args.durability,
       derived_from: args.derived_from,
+      fields: args.fields,
     });
-    return toolResult(result, renderMutationResultMarkdown('Captured', result.note, result.recommendations));
+    return toolResult(result, renderMutationResultMarkdown('Captured', result.note, result.recommendations, result.validation));
   });
 
   server.registerTool('granite_import_document', {
@@ -661,7 +716,7 @@ function registerTools(server: McpServer, runtime: GraniteMcpRuntime): void {
     description: 'Make a targeted revision to an existing note. Use this when a workflow prompt tells you exactly what to change, or when you need a precise manual intervention.',
     inputSchema: {
       slug: z.string().describe('Slug of the note to revise.'),
-      type: z.string().optional().describe('Optional new note type. Use this to promote a note into source, synthesis, or output.'),
+      type: buildTypeSchema(runtime, 'Optional new note type. Use this to promote a note between vault types (e.g. note → synthesis). Must be one of the vault-configured types.'),
       title: z.string().optional().describe('Replace the note title.'),
       body: z.string().optional().describe('Replace the entire note body.'),
       append: z.string().optional().describe('Append text to the existing note body.'),
@@ -672,15 +727,17 @@ function registerTools(server: McpServer, runtime: GraniteMcpRuntime): void {
       review_state: z.enum(['draft', 'reviewed', 'locked']).optional().describe('New review state.'),
       durability: z.enum(['canonical', 'working', 'ephemeral']).optional().describe('New durability.'),
       derived_from: z.array(z.string()).optional().describe('New derived_from references.'),
+      fields: z.record(z.string(), z.unknown()).optional().describe('Type-specific frontmatter fields to set or overwrite (e.g. { date: "2026-04-17" } when promoting to meeting). Keys reserved by the system are ignored — use the dedicated inputs for those. See granite://vault/types for each type\'s required fields.'),
     },
     outputSchema: z.object({
       note: noteDetailsSchema,
       recommendations: recommendationSchema,
+      validation: validationResultSchema.optional(),
     }),
     annotations: writeAnnotations,
   }, async ({ slug, ...updates }) => {
     const result = runtime.reviseNote(slug, updates);
-    return toolResult(result, renderMutationResultMarkdown('Revised', result.note, result.recommendations));
+    return toolResult(result, renderMutationResultMarkdown('Revised', result.note, result.recommendations, result.validation));
   });
 
   server.registerTool('granite_resolve', {

--- a/test/core/validate.test.ts
+++ b/test/core/validate.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest';
+import {
+  bodyHasSection,
+  computeTypeRegistrySignature,
+  deriveBodySections,
+  getRequiredSections,
+  renderPreflightError,
+  validateNoteAgainstType,
+} from '../../src/core/validate.js';
+import type { GraniteConfig, NoteFrontmatter } from '../../src/core/types.js';
+
+function baseFrontmatter(overrides: Partial<NoteFrontmatter> = {}): NoteFrontmatter {
+  return {
+    id: 'id',
+    title: 'T',
+    type: 'meeting',
+    created: '2026-04-17T00:00:00Z',
+    modified: '2026-04-17T00:00:00Z',
+    tags: [],
+    aliases: [],
+    status: 'active',
+    source: 'agent',
+    review_state: 'draft',
+    durability: 'canonical',
+    derived_from: [],
+    ...overrides,
+  };
+}
+
+function configWith(meetingWarnOnly: boolean): GraniteConfig {
+  return {
+    vault_name: 'V',
+    version: 1,
+    note_types: {
+      note: {
+        folder: 'notes',
+        description: 'd',
+        template: '## Summary\n\n## Details\n',
+        line_limit: 200,
+        warn_only: true,
+      },
+      meeting: {
+        folder: 'meetings',
+        description: 'd',
+        template: '## Summary\n\n## Decisions\n\n## Action items\n',
+        line_limit: 300,
+        warn_only: meetingWarnOnly,
+        fields: {
+          date: { type: 'date', required: true, description: 'date' },
+          attendees: { type: 'list', of: 'wikilink', description: 'a' },
+        },
+      },
+    },
+    defaults: { note_type: 'note', editor: '' },
+    index: { auto_rebuild: true },
+  };
+}
+
+describe('deriveBodySections', () => {
+  it('extracts H2 headings from a template', () => {
+    expect(deriveBodySections('## Summary\n\n## Decisions\n\ntext\n## Links\n'))
+      .toEqual(['Summary', 'Decisions', 'Links']);
+  });
+
+  it('returns an empty array for templates without H2 headings', () => {
+    expect(deriveBodySections('Just prose\n')).toEqual([]);
+  });
+});
+
+describe('getRequiredSections', () => {
+  it('prefers explicit body_sections over template-derived sections', () => {
+    const result = getRequiredSections({
+      folder: 'x',
+      description: '',
+      template: '## A\n## B\n',
+      line_limit: 100,
+      warn_only: true,
+      body_sections: ['Foo', 'Bar'],
+    });
+    expect(result).toEqual(['Foo', 'Bar']);
+  });
+});
+
+describe('bodyHasSection', () => {
+  it('matches case-insensitively and trims whitespace', () => {
+    const body = '## Summary\nhi\n## action Items \n';
+    expect(bodyHasSection(body, 'summary')).toBe(true);
+    expect(bodyHasSection(body, 'Action Items')).toBe(true);
+    expect(bodyHasSection(body, 'Missing')).toBe(false);
+  });
+});
+
+describe('validateNoteAgainstType', () => {
+  it('returns unknown_type error when the type is not in the registry', () => {
+    const config = configWith(false);
+    const fm = baseFrontmatter({ type: 'retro' });
+    const r = validateNoteAgainstType('retro', fm, '', config);
+    expect(r.passed).toBe(false);
+    expect(r.errors[0].code).toBe('unknown_type');
+  });
+
+  it('flags missing required fields as errors when warn_only=false', () => {
+    const config = configWith(false);
+    const fm = baseFrontmatter({ type: 'meeting' });
+    const r = validateNoteAgainstType('meeting', fm, '## Summary\n## Decisions\n## Action items\n', config);
+    expect(r.passed).toBe(false);
+    expect(r.errors.map(e => e.code)).toContain('missing_required_field');
+    expect(r.errors.find(e => e.code === 'missing_required_field')?.field).toBe('date');
+  });
+
+  it('downgrades missing required fields to warnings when warn_only=true', () => {
+    const config = configWith(true);
+    const fm = baseFrontmatter({ type: 'meeting' });
+    const r = validateNoteAgainstType('meeting', fm, '## Summary\n## Decisions\n## Action items\n', config);
+    expect(r.passed).toBe(true);
+    expect(r.warnings.map(w => w.code)).toContain('missing_required_field');
+  });
+
+  it('warns on missing body sections but does not error', () => {
+    const config = configWith(true);
+    const fm = baseFrontmatter({ type: 'meeting', date: '2026-04-17' } as never);
+    const r = validateNoteAgainstType('meeting', fm, '## Summary\nonly a summary, no decisions\n', config);
+    expect(r.warnings.map(w => w.code)).toContain('missing_sections');
+  });
+
+  it('passes cleanly when all required fields and sections are present', () => {
+    const config = configWith(false);
+    const fm = baseFrontmatter({ type: 'meeting', date: '2026-04-17' } as never);
+    const r = validateNoteAgainstType('meeting', fm, '## Summary\n## Decisions\n## Action items\n', config);
+    expect(r.passed).toBe(true);
+    expect(r.errors).toHaveLength(0);
+  });
+});
+
+describe('computeTypeRegistrySignature', () => {
+  it('changes when a required field is added', () => {
+    const a = configWith(false);
+    const b = configWith(false);
+    b.note_types.meeting.fields!.location = { type: 'text', required: true };
+    expect(computeTypeRegistrySignature(a)).not.toBe(computeTypeRegistrySignature(b));
+  });
+
+  it('is stable for semantically identical configs', () => {
+    expect(computeTypeRegistrySignature(configWith(false))).toBe(computeTypeRegistrySignature(configWith(false)));
+  });
+});
+
+describe('renderPreflightError', () => {
+  it('formats all errors with codes and messages', () => {
+    const msg = renderPreflightError('meeting', [
+      { code: 'missing_required_field', field: 'date', message: 'date required' },
+    ]);
+    expect(msg).toContain('meeting');
+    expect(msg).toContain('missing_required_field');
+    expect(msg).toContain('date required');
+  });
+});

--- a/test/mcp/runtime-validation.test.ts
+++ b/test/mcp/runtime-validation.test.ts
@@ -1,0 +1,161 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import yaml from 'js-yaml';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { loadConfig, writeDefaultConfig } from '../../src/core/config.js';
+import { GraniteMcpRuntime } from '../../src/mcp/runtime.js';
+
+describe('GraniteMcpRuntime validation & type registry exposure', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'granite-validate-'));
+    writeDefaultConfig(tmpDir);
+    // Add a strict `meeting` type with a required field to the vault config
+    const raw = yaml.load(fs.readFileSync(path.join(tmpDir, 'granite.yml'), 'utf-8')) as any;
+    raw.note_types.meeting = {
+      folder: 'notes/meetings',
+      description: 'Meetings with decisions and action items',
+      template: '## Summary\n\n## Decisions\n\n## Action items\n',
+      line_limit: 300,
+      warn_only: false,
+      fields: {
+        date: { type: 'date', required: true, description: 'Meeting date' },
+      },
+      frontmatter_defaults: { durability: 'canonical' },
+    };
+    fs.writeFileSync(path.join(tmpDir, 'granite.yml'), yaml.dump(raw));
+    const config = loadConfig(tmpDir);
+    for (const typeConfig of Object.values(config.note_types)) {
+      fs.mkdirSync(path.join(tmpDir, typeConfig.folder), { recursive: true });
+    }
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('listNoteTypeNames returns all configured types', () => {
+    const runtime = new GraniteMcpRuntime(tmpDir, { indexCheckIntervalMs: 0 });
+    const names = runtime.listNoteTypeNames();
+    expect(names).toContain('note');
+    expect(names).toContain('meeting');
+    runtime.close();
+  });
+
+  it('listNoteTypes exposes template, body_sections, and frontmatter_defaults', () => {
+    const runtime = new GraniteMcpRuntime(tmpDir, { indexCheckIntervalMs: 0 });
+    const types = runtime.listNoteTypes();
+    const meeting = types.find(t => t.name === 'meeting');
+    expect(meeting).toBeDefined();
+    expect(meeting!.template).toContain('## Summary');
+    expect(meeting!.body_sections).toEqual(['Summary', 'Decisions', 'Action items']);
+    expect(meeting!.frontmatter_defaults).toMatchObject({ durability: 'canonical' });
+    runtime.close();
+  });
+
+  it('listNoteTypes resolves example_slug to the most recent note of each type', () => {
+    const runtime = new GraniteMcpRuntime(tmpDir, { indexCheckIntervalMs: 0 });
+    runtime.createNote({ title: 'One', type: 'note', body: 'x\n' });
+    const types = runtime.listNoteTypes();
+    const noteT = types.find(t => t.name === 'note');
+    expect(noteT!.example_slug).toBe('one');
+    runtime.close();
+  });
+
+  it('throws a structured error for unknown types on createNote', () => {
+    const runtime = new GraniteMcpRuntime(tmpDir, { indexCheckIntervalMs: 0 });
+    expect(() => runtime.createNote({ title: 'X', type: 'retro' as never, body: 'y\n' }))
+      .toThrow(/Unknown note type "retro"/);
+    runtime.close();
+  });
+
+  it('rejects creation of a strict-type note missing a required field', () => {
+    const runtime = new GraniteMcpRuntime(tmpDir, { indexCheckIntervalMs: 0 });
+    expect(() => runtime.createNote({
+      title: 'Monka sync',
+      type: 'meeting' as never,
+      body: '## Summary\n## Decisions\n## Action items\n',
+    })).toThrow(/missing_required_field/);
+    runtime.close();
+  });
+
+  it('accepts creation when required fields are supplied via extra frontmatter', () => {
+    const runtime = new GraniteMcpRuntime(tmpDir, { indexCheckIntervalMs: 0 });
+    const result = runtime.createNote({
+      title: 'Monka sync',
+      type: 'meeting' as never,
+      body: '## Summary\n## Decisions\n## Action items\n',
+      fields: { date: '2026-04-17' },
+    });
+    expect(result.validation?.passed).toBe(true);
+    expect(result.note.frontmatter.date).toBe('2026-04-17');
+    runtime.close();
+  });
+
+  it('captured result includes validation warnings for warn_only types', () => {
+    const runtime = new GraniteMcpRuntime(tmpDir, { indexCheckIntervalMs: 0 });
+    const result = runtime.captureNote({ text: 'A line with no standard sections', type: 'note' });
+    // `note` is strict (warn_only=false); but there's no required field nor section check for prose captures
+    expect(result.validation).toBeDefined();
+    runtime.close();
+  });
+
+  it('rejects reviseNote that promotes a note to a strict type without required fields', () => {
+    const runtime = new GraniteMcpRuntime(tmpDir, { indexCheckIntervalMs: 0 });
+    const created = runtime.createNote({ title: 'Promote me', type: 'note', body: '## Summary\n## Details\n' });
+    expect(() => runtime.reviseNote(created.note.slug, { type: 'meeting' as never }))
+      .toThrow(/missing_required_field/);
+    runtime.close();
+  });
+
+  it('accepts reviseNote promotion when required fields are supplied via fields', () => {
+    const runtime = new GraniteMcpRuntime(tmpDir, { indexCheckIntervalMs: 0 });
+    const created = runtime.createNote({ title: 'Promote me', type: 'note', body: '## Summary\n## Details\n' });
+    const revised = runtime.reviseNote(created.note.slug, {
+      type: 'meeting' as never,
+      fields: { date: '2026-04-17' },
+      body: '## Summary\n## Decisions\n## Action items\n',
+    });
+    expect(revised.validation?.passed).toBe(true);
+    expect(revised.note.frontmatter.type).toBe('meeting');
+    expect(revised.note.frontmatter.date).toBe('2026-04-17');
+    runtime.close();
+  });
+
+  it('rejects reviseNote that pushes a strict-type body past line_limit and does not write', () => {
+    const runtime = new GraniteMcpRuntime(tmpDir, { indexCheckIntervalMs: 0 });
+    const created = runtime.createNote({
+      title: 'Sync',
+      type: 'meeting' as never,
+      body: '## Summary\n## Decisions\n## Action items\n',
+      fields: { date: '2026-04-17' },
+    });
+    const originalBody = created.note.body;
+    const hugeAppend = Array.from({ length: 400 }, (_, i) => `line ${i}`).join('\n');
+    expect(() => runtime.reviseNote(created.note.slug, { append: hugeAppend }))
+      .toThrow(/line_limit_exceeded/);
+    // Verify the file was not mutated.
+    const reread = runtime.getNote(created.note.slug);
+    expect(reread.body).toBe(originalBody);
+    runtime.close();
+  });
+
+  it('getTypeRegistrySignature is stable across runtime recreations for unchanged config', () => {
+    const r1 = new GraniteMcpRuntime(tmpDir, { indexCheckIntervalMs: 0 });
+    const sig1 = r1.getTypeRegistrySignature();
+    r1.close();
+    const r2 = new GraniteMcpRuntime(tmpDir, { indexCheckIntervalMs: 0 });
+    expect(r2.getTypeRegistrySignature()).toBe(sig1);
+    r2.close();
+  });
+
+  it('wakeup AAAK contains the TYPES pointer with signature and resource URI', () => {
+    const runtime = new GraniteMcpRuntime(tmpDir, { indexCheckIntervalMs: 0 });
+    runtime.createNote({ title: 'Seed', type: 'note', body: 'x\n' });
+    const wk = runtime.wakeup();
+    expect(wk.aaak).toMatch(/TYPES: \d+ \(sig=[0-9a-f]{8}\) -> granite:\/\/vault\/types/);
+    runtime.close();
+  });
+});

--- a/test/mcp/server-validation.test.ts
+++ b/test/mcp/server-validation.test.ts
@@ -1,0 +1,101 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import yaml from 'js-yaml';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { loadConfig, writeDefaultConfig } from '../../src/core/config.js';
+import { GraniteMcpRuntime } from '../../src/mcp/runtime.js';
+import { createGraniteMcpServer } from '../../src/mcp/server.js';
+
+describe('granite MCP server — strict type validation end-to-end', () => {
+  let tmpDir: string;
+  let runtime: GraniteMcpRuntime;
+  let server: ReturnType<typeof createGraniteMcpServer>;
+  let client: Client;
+
+  beforeEach(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'granite-mcp-validate-'));
+    writeDefaultConfig(tmpDir);
+    const raw = yaml.load(fs.readFileSync(path.join(tmpDir, 'granite.yml'), 'utf-8')) as any;
+    raw.note_types.meeting = {
+      folder: 'notes/meetings',
+      description: 'Meetings with decisions',
+      template: '## Summary\n\n## Decisions\n\n## Action items\n',
+      line_limit: 300,
+      warn_only: false,
+      fields: {
+        date: { type: 'date', required: true, description: 'Meeting date' },
+      },
+    };
+    fs.writeFileSync(path.join(tmpDir, 'granite.yml'), yaml.dump(raw));
+    const config = loadConfig(tmpDir);
+    for (const typeConfig of Object.values(config.note_types)) {
+      fs.mkdirSync(path.join(tmpDir, typeConfig.folder), { recursive: true });
+    }
+
+    runtime = new GraniteMcpRuntime(tmpDir, { indexCheckIntervalMs: 0 });
+    server = createGraniteMcpServer(runtime);
+    client = new Client({ name: 'granite-validation-client', version: '1.0.0' });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+  });
+
+  afterEach(async () => {
+    await client.close();
+    await server.close();
+    runtime.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('rejects granite_capture_knowledge for a strict type when required fields are missing', async () => {
+    const result = await client.callTool({
+      name: 'granite_capture_knowledge',
+      arguments: {
+        title: 'Monka sync',
+        type: 'meeting',
+        body: '## Summary\n## Decisions\n## Action items\n',
+      },
+    });
+    expect(result.isError).toBe(true);
+    const text = result.content?.find((c: any) => c.type === 'text') as { text: string } | undefined;
+    expect(text?.text ?? '').toMatch(/missing_required_field/);
+  });
+
+  it('accepts granite_capture_knowledge for a strict type when fields are supplied', async () => {
+    const result = await client.callTool({
+      name: 'granite_capture_knowledge',
+      arguments: {
+        title: 'Monka sync',
+        type: 'meeting',
+        body: '## Summary\n## Decisions\n## Action items\n',
+        fields: { date: '2026-04-17' },
+      },
+    });
+    expect(result.isError).toBeFalsy();
+    const structured = (result as { structuredContent: unknown }).structuredContent as {
+      note: { frontmatter: Record<string, unknown> };
+      validation?: { passed: boolean };
+    };
+    expect(structured.note.frontmatter.date).toBe('2026-04-17');
+    expect(structured.validation?.passed).toBe(true);
+  });
+
+  it('exposes fields input in the granite_capture_knowledge tool schema', async () => {
+    const tools = await client.listTools();
+    const capture = tools.tools.find(t => t.name === 'granite_capture_knowledge');
+    expect(capture).toBeDefined();
+    const schemaProps = (capture?.inputSchema as any)?.properties ?? {};
+    expect(schemaProps.fields).toBeDefined();
+  });
+
+  it('exposes fields input in the granite_revise_note tool schema', async () => {
+    const tools = await client.listTools();
+    const revise = tools.tools.find(t => t.name === 'granite_revise_note');
+    expect(revise).toBeDefined();
+    const schemaProps = (revise?.inputSchema as any)?.properties ?? {};
+    expect(schemaProps.fields).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Granite MCP now surfaces the full vault type registry to agents and enforces type contracts on every write, so new types (person, organization, meeting, learning, ...) are discoverable and enforced without shipping a new binary
- Four exposure channels: dynamic MCP `instructions`, tool-input `type` enum + `fields` record, enriched `granite://vault/types` resource (template, body sections, defaults, auto-resolved `example_slug`), and a `TYPES: N (sig=...) -> granite://vault/types` pointer in the wakeup AAAK
- Central `validateNoteAgainstType` covers unknown_type, missing_required_field, missing_sections, line_limit_exceeded — respects per-type `warn_only` to downgrade errors to warnings for advisory types
- `reviseNote` now builds the full in-memory candidate (fields, body, append, type move) and validates before writing — strict failures abort without touching disk (fixes Codex review finding that same-type strict revises bypassed validation)
- `granite_capture_knowledge` / `granite_revise_note` accept a typed `fields` input threaded through `CaptureNoteInput` / `UpdateNoteInput` so MCP clients can actually create strict notes (fixes Codex review finding that agent-facing path had no way to supply required fields)

## Test plan

- [x] `npx vitest run` — 182/182 passing (28 new: 12 validate, 12 runtime-validation, 4 MCP client end-to-end)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean (`dist/index.js` 266.62 KB)
- [x] `scripts/verify-live-mcp.mjs` against the installed binary — 7/7 checks pass (enum on `type`, `fields` on capture/revise, TYPES pointer in AAAK, strict reject w/o required fields, strict accept with fields, revise aborts on line_limit without mutation, resource exposes template/sections/defaults)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core write paths (`createNote`/`reviseNote`) and MCP tool schemas, which can block note mutations if validation logic or type enums are incorrect.
> 
> **Overview**
> Granite MCP now **surfaces the vault’s note-type registry and signature** to agents via dynamic server `instructions`, a `TYPES: N (sig=...) -> granite://vault/types` line in wakeup AAAK, and enriched note-type metadata (template-derived `body_sections`, `frontmatter_defaults`, and `example_slug`). Tool schemas for `granite_capture_knowledge` and `granite_revise_note` now **enumerate valid `type` values** and accept a generic `fields` map for type-specific frontmatter.
> 
> Writes are now **preflight-validated against type contracts** via new `src/core/validate.ts` (unknown type, missing required fields, missing sections, line limits; honoring `warn_only`), with `createNote`/`reviseNote` rejecting strict violations before touching disk and returning a `validation` result in mutation responses/markdown. Adds extensive unit + end-to-end MCP tests and a live verification script (`scripts/verify-live-mcp.mjs`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9eec3da13d8717627f7ce555bbbbb70ee05388bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose the vault’s full type registry to MCP clients and enforce type contracts on every write, so agents discover types and invalid writes are blocked without shipping a new binary.

- **New Features**
  - Dynamic MCP instructions list all types with an 8‑char registry signature; `granite_wakeup` adds `TYPES: N (sig=...) -> granite://vault/types`.
  - `granite://vault/types` now shows body template, body sections, frontmatter defaults, and an `example_slug`.
  - `granite_capture_knowledge` and `granite_revise_note` accept a `fields` object for type-specific frontmatter; `type` is a schema enum of vault types.
  - Central validator checks `unknown_type`, `missing_required_field`, `missing_sections`, and `line_limit_exceeded`, honoring per‑type `warn_only`.
  - All write results include a `validation` block so clients can surface advisory warnings.

- **Bug Fixes**
  - `reviseNote` now validates the full candidate (type moves, fields, body/append) before writing; strict failures abort without touching disk.
  - MCP clients can create strict notes by supplying required `fields` (previously not possible).

<sup>Written for commit 9eec3da13d8717627f7ce555bbbbb70ee05388bd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

