### PR TITLE
refactor(mcp): return markdown instead of structured content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 dist/
 .granite/
+coverage/
 *.tsbuildinfo
 
 # Local vault data (created by mem init)

--- a/packages/worker/src/handlers/mcp.ts
+++ b/packages/worker/src/handlers/mcp.ts
@@ -107,29 +107,6 @@ const vaultOverviewSchema = z.object({
   recent_notes: z.array(noteSummarySchema),
 });
 
-const noteTypesResultSchema = z.object({
-  note_types: z.array(noteTypeSchema),
-});
-
-const listNotesResultSchema = z.object({
-  notes: z.array(noteSummarySchema),
-});
-
-const searchResultSetSchema = z.object({
-  query: z.string(),
-  results: z.array(searchResultSchema),
-});
-
-const backlinksResultSchema = z.object({
-  slug: z.string(),
-  backlinks: z.array(backlinkSchema),
-});
-
-const linkSuggestionsResultSchema = z.object({
-  slug: z.string(),
-  suggestions: z.array(linkSuggestionSchema),
-});
-
 export interface WorkerMcpRuntime {
   getVaultOverview(recentLimit?: number): Promise<z.infer<typeof vaultOverviewSchema>>;
   listNoteTypes(): Promise<Array<z.infer<typeof noteTypeSchema>>>;

--- a/packages/worker/src/handlers/mcp.ts
+++ b/packages/worker/src/handlers/mcp.ts
@@ -184,10 +184,9 @@ function createRuntime(c: Context<{ Bindings: Env }>): CloudMcpRuntime {
   return new CloudMcpRuntime(storage, db, TIER_LIMITS[tier].maxStorageBytes);
 }
 
-function toolResult<T>(structuredContent: T, markdown: string) {
+function toolResult(markdown: string) {
   return {
     content: [{ type: 'text' as const, text: markdown }],
-    structuredContent,
   };
 }
 
@@ -203,19 +202,17 @@ export function createMcpServer(runtime: WorkerMcpRuntime): McpServer {
     inputSchema: {
       recent_limit: z.number().optional(),
     },
-    outputSchema: vaultOverviewSchema,
   }, async ({ recent_limit }) => {
     const overview = await runtime.getVaultOverview(recent_limit);
-    return toolResult(overview, renderVaultOverviewMarkdown(overview));
+    return toolResult(renderVaultOverviewMarkdown(overview));
   });
 
   server.registerTool('granite_list_note_types', {
     title: 'List Granite Note Types',
     description: 'List all configured note types.',
-    outputSchema: noteTypesResultSchema,
   }, async () => {
     const types = await runtime.listNoteTypes();
-    return toolResult({ note_types: types }, renderNoteTypesMarkdown(types));
+    return toolResult(renderNoteTypesMarkdown(types));
   });
 
   server.registerTool('granite_list_notes', {
@@ -228,10 +225,9 @@ export function createMcpServer(runtime: WorkerMcpRuntime): McpServer {
       since: z.string().optional(),
       limit: z.number().optional(),
     },
-    outputSchema: listNotesResultSchema,
   }, async (input) => {
     const notes = await runtime.listNotes(input);
-    return toolResult({ notes }, renderNotesMarkdown(notes));
+    return toolResult(renderNotesMarkdown(notes));
   });
 
   server.registerTool('granite_get_note', {
@@ -240,10 +236,9 @@ export function createMcpServer(runtime: WorkerMcpRuntime): McpServer {
     inputSchema: {
       slug: z.string(),
     },
-    outputSchema: noteDetailsSchema,
   }, async ({ slug }) => {
     const note = await runtime.getNote(slug);
-    return toolResult(note, renderNoteDetailsMarkdown(note));
+    return toolResult(renderNoteDetailsMarkdown(note));
   });
 
   server.registerTool('granite_search_notes', {
@@ -253,10 +248,9 @@ export function createMcpServer(runtime: WorkerMcpRuntime): McpServer {
       query: z.string(),
       limit: z.number().optional(),
     },
-    outputSchema: searchResultSetSchema,
   }, async ({ query, limit }) => {
     const results = await runtime.search(query, limit);
-    return toolResult({ query, results }, renderSearchResultsMarkdown(query, results));
+    return toolResult(renderSearchResultsMarkdown(query, results));
   });
 
   server.registerTool('granite_get_backlinks', {
@@ -265,10 +259,9 @@ export function createMcpServer(runtime: WorkerMcpRuntime): McpServer {
     inputSchema: {
       slug: z.string(),
     },
-    outputSchema: backlinksResultSchema,
   }, async ({ slug }) => {
     const backlinks = await runtime.getBacklinks(slug);
-    return toolResult({ slug, backlinks }, renderBacklinksMarkdown(slug, backlinks));
+    return toolResult(renderBacklinksMarkdown(slug, backlinks));
   });
 
   server.registerTool('granite_suggest_links', {
@@ -277,10 +270,9 @@ export function createMcpServer(runtime: WorkerMcpRuntime): McpServer {
     inputSchema: {
       slug: z.string(),
     },
-    outputSchema: linkSuggestionsResultSchema,
   }, async ({ slug }) => {
     const suggestions = await runtime.suggestLinks(slug);
-    return toolResult({ slug, suggestions }, renderLinkSuggestionsMarkdown(slug, suggestions));
+    return toolResult(renderLinkSuggestionsMarkdown(slug, suggestions));
   });
 
   server.registerTool('granite_create_note', {
@@ -295,10 +287,9 @@ export function createMcpServer(runtime: WorkerMcpRuntime): McpServer {
       status: z.enum(['inbox', 'active', 'archived']).optional(),
       source: z.enum(['human', 'agent', 'extraction']).optional(),
     },
-    outputSchema: noteMutationSchema,
   }, async (input) => {
     const result = await runtime.createNote(input);
-    return toolResult(result, renderMutationResultMarkdown('Created', result.note, result.recommendations));
+    return toolResult(renderMutationResultMarkdown('Created', result.note, result.recommendations));
   });
 
   server.registerTool('granite_capture_note', {
@@ -311,10 +302,9 @@ export function createMcpServer(runtime: WorkerMcpRuntime): McpServer {
       status: z.enum(['inbox', 'active', 'archived']).optional(),
       source: z.enum(['human', 'agent', 'extraction']).optional(),
     },
-    outputSchema: noteMutationSchema,
   }, async (input) => {
     const result = await runtime.captureNote(input);
-    return toolResult(result, renderMutationResultMarkdown('Captured', result.note, result.recommendations));
+    return toolResult(renderMutationResultMarkdown('Captured', result.note, result.recommendations));
   });
 
   server.registerTool('granite_update_note', {
@@ -330,10 +320,9 @@ export function createMcpServer(runtime: WorkerMcpRuntime): McpServer {
       status: z.enum(['inbox', 'active', 'archived']).optional(),
       source: z.enum(['human', 'agent', 'extraction']).optional(),
     },
-    outputSchema: noteMutationSchema,
   }, async ({ slug, ...input }) => {
     const result = await runtime.updateNote(slug, input);
-    return toolResult(result, renderMutationResultMarkdown('Updated', result.note, result.recommendations));
+    return toolResult(renderMutationResultMarkdown('Updated', result.note, result.recommendations));
   });
 
   server.resource(

--- a/scripts/verify-live-mcp.mjs
+++ b/scripts/verify-live-mcp.mjs
@@ -68,10 +68,10 @@ console.log('revise.type schema:', JSON.stringify(revProps.type));
 h('2. Instructions header contains TYPES pointer + signature?');
 console.log('instructions head:\n', (client.getInstructions() ?? '').split('\n').slice(0, 25).join('\n'));
 
-h('3. wakeup.aaak contains TYPES pointer?');
+h('3. wakeup markdown contains TYPES pointer?');
 const wk = await client.callTool({ name: 'granite_wakeup', arguments: {} });
-const wkStruct = wk.structuredContent;
-console.log('TYPES line in AAAK:', wkStruct.aaak.match(/^TYPES: .*/m)?.[0]);
+const wkText = wk.content?.find(c => c.type === 'text')?.text ?? '';
+console.log('TYPES line in wakeup markdown:', wkText.match(/^TYPES: .*/m)?.[0]);
 
 h('4. Strict meeting WITHOUT required fields → should be rejected');
 const missingResult = await client.callTool({
@@ -97,10 +97,9 @@ const okResult = await client.callTool({
   },
 });
 console.log('isError:', okResult.isError);
-const okStruct = okResult.structuredContent;
-console.log('note.frontmatter.date:', okStruct.note.frontmatter.date);
-console.log('validation.passed:', okStruct.validation?.passed);
-console.log('validation.errors:', okStruct.validation?.errors);
+const okText = okResult.content?.find(c => c.type === 'text')?.text ?? '';
+console.log('markdown contains date:', okText.includes('2026-04-17'));
+console.log('markdown contains validation-failure markers:', /missing_required_field|validation_failed/.test(okText));
 
 h('6. Revise that pushes strict body past line_limit → should throw, no mutation');
 const before = fs.readFileSync(path.join(tmp, 'meetings', 'sync-with-date.md'), 'utf-8');

--- a/shared/mcp-markdown.ts
+++ b/shared/mcp-markdown.ts
@@ -590,6 +590,46 @@ export function renderAdjudicationResultMarkdown(result: AdjudicationResultLike)
   return lines.join('\n');
 }
 
+interface QueryResultLike {
+  slug: string;
+  title: string;
+  type: string;
+  modified: string;
+  fields: Record<string, string | string[]>;
+}
+
+export function renderQueryResultsMarkdown(results: QueryResultLike[]): string {
+  const lines = [`# Query Results (${results.length})`, ''];
+  if (results.length === 0) {
+    lines.push('No matches.');
+    return lines.join('\n');
+  }
+
+  const fieldNames = Array.from(
+    new Set(results.flatMap(row => Object.keys(row.fields ?? {}))),
+  );
+  const header = ['title', 'slug', 'type', 'modified', ...fieldNames];
+  lines.push(`| ${header.join(' | ')} |`);
+  lines.push(`| ${header.map(() => '---').join(' | ')} |`);
+
+  for (const row of results) {
+    const cells = [
+      row.title,
+      row.slug,
+      row.type,
+      row.modified,
+      ...fieldNames.map(name => {
+        const value = row.fields?.[name];
+        if (value === undefined) return '';
+        return Array.isArray(value) ? value.join(', ') : String(value);
+      }),
+    ];
+    lines.push(`| ${cells.map(escapeCell).join(' | ')} |`);
+  }
+
+  return lines.join('\n');
+}
+
 export function renderImportDocumentMarkdown(result: ImportedDocumentLike): string {
   const lines = ['# Imported Document'];
   pushBullets(lines, [

--- a/shared/mcp-markdown.ts
+++ b/shared/mcp-markdown.ts
@@ -384,6 +384,17 @@ export function renderMutationResultMarkdown(
 ): string {
   const lines = [`# ${action} Note`];
   pushNoteMetadata(lines, note);
+
+  const extraFrontmatter = note.frontmatter
+    ? Object.entries(note.frontmatter).filter(([key]) => !STANDARD_FRONTMATTER_KEYS.has(key))
+    : [];
+  if (extraFrontmatter.length > 0) {
+    lines.push('', '## Extra Frontmatter');
+    for (const [key, value] of extraFrontmatter) {
+      lines.push(`- ${key}: ${formatUnknown(value)}`);
+    }
+  }
+
   appendValidation(lines, validation);
   appendRecommendations(lines, recommendations);
   return lines.join('\n');

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -5,6 +5,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js';
 import * as z from 'zod/v4';
 import {
+  renderAdjudicationResultMarkdown,
   renderDisposeNoteMarkdown,
   renderExtractDocumentMarkdown,
   renderGardenAdjudicationsMarkdown,
@@ -12,6 +13,7 @@ import {
   renderImportDocumentMarkdown,
   renderMutationResultMarkdown,
   renderNoteTypesMarkdown,
+  renderQueryResultsMarkdown,
   renderSearchResultsMarkdown,
   renderUnderstandNoteMarkdown,
   renderWakeupMarkdown,
@@ -34,272 +36,12 @@ const writeAnnotations = {
   openWorldHint: false,
 } as const;
 
-const fieldDefinitionSchema = z.object({
-  type: z.enum(['text', 'date', 'number', 'boolean', 'wikilink', 'list', 'enum']),
-  of: z.string().optional(),
-  options: z.array(z.string()).optional(),
-  required: z.boolean().optional(),
-  default: z.string().optional(),
-  description: z.string().optional(),
-});
-
-const noteTypeInfoSchema = z.object({
-  name: z.string(),
-  description: z.string(),
-  folder: z.string(),
-  line_limit: z.number(),
-  warn_only: z.boolean(),
-  slug_format: z.enum(['title', 'date']),
-  instructions: z.string().optional(),
-  fields: z.record(z.string(), fieldDefinitionSchema).optional(),
-  template: z.string().optional(),
-  body_sections: z.array(z.string()).optional(),
-  example_slug: z.string().optional(),
-  frontmatter_defaults: z.record(z.string(), z.unknown()).optional(),
-});
-
-const validationIssueSchema = z.object({
-  code: z.string(),
-  field: z.string().optional(),
-  message: z.string(),
-});
-
-const validationResultSchema = z.object({
-  passed: z.boolean(),
-  errors: z.array(validationIssueSchema),
-  warnings: z.array(validationIssueSchema),
-});
-
-const noteSummarySchema = z.object({
-  slug: z.string(),
-  title: z.string(),
-  type: z.string(),
-  created: z.string(),
-  modified: z.string(),
-  tags: z.array(z.string()),
-  aliases: z.array(z.string()),
-  status: z.enum(['inbox', 'active', 'archived']),
-  source: z.enum(['human', 'agent', 'extraction']),
-  review_state: z.enum(['draft', 'reviewed', 'locked']),
-  durability: z.enum(['canonical', 'working', 'ephemeral']),
-  derived_from: z.array(z.string()),
-  filepath: z.string(),
-  resource_uri: z.string(),
-});
-
-const wikiLinkSchema = z.object({
-  raw: z.string(),
-  target: z.string(),
-  display: z.string(),
-  resolved: z.boolean(),
-  resolved_slug: z.string().optional(),
-});
-
-const noteDetailsSchema = noteSummarySchema.extend({
-  body: z.string(),
-  frontmatter: z.record(z.string(), z.unknown()),
-  outgoing_links: z.array(wikiLinkSchema),
-});
-
-const importedDocumentAssetSchema = z.object({
-  file: z.string(),
-  path: z.string(),
-  relative_path: z.string(),
-  markdown: z.string(),
-  mime_type: z.string(),
-  sha256: z.string(),
-  resource_uri: z.string(),
-});
-
-const installInstructionsSchema = z.object({
-  platform: z.enum(['macos-arm64', 'macos-x64']),
-  steps: z.array(z.string()),
-  notes: z.array(z.string()),
-});
-
-const extractedDocumentSchema = z.object({
-  doc_type: z.enum(['pdf', 'docx', 'xlsx', 'pptx']),
-  status: z.enum(['ready', 'needs_dependency', 'failed']),
-  extractor: z.enum(['ferrules', 'mammoth', 'sheetjs', 'ooxml-pptx']),
-  reading_basis: z.enum(['text', 'ocr']),
-  raw_text: z.string(),
-  confidence: z.number(),
-  limits: z.array(z.string()),
-  title_hint: z.string(),
-  missing_dependency: z.literal('ferrules').optional(),
-  install_source_url: z.string().optional(),
-  install_instructions: installInstructionsSchema.optional(),
-  verify_command: z.string().optional(),
-  user_prompt: z.string().optional(),
-});
-
-const searchResultSchema = z.object({
-  slug: z.string(),
-  title: z.string(),
-  snippet: z.string(),
-  score: z.number(),
-});
-
-const backlinkSchema = z.object({
-  source_slug: z.string(),
-  source_title: z.string(),
-  context: z.string(),
-});
-
-const linkSuggestionSchema = z.object({
-  target_slug: z.string(),
-  target_title: z.string(),
-  mentions: z.number(),
-});
-
-const recommendationSchema = z.object({
-  additions: z.array(z.object({ text: z.string() })),
-  links: z.array(z.object({
-    slug: z.string(),
-    title: z.string(),
-    type: z.string(),
-    reason: z.string(),
-    source: z.enum(['mention', 'search']),
-  })),
-  tags: z.array(z.object({
-    tag: z.string(),
-    weight: z.number(),
-    source_slugs: z.array(z.string()),
-  })),
-  next_steps: z.array(z.object({
-    type: z.string(),
-    title_hint: z.string().optional(),
-    reason: z.string(),
-  })),
-});
-
-const graphRoleSchema = z.object({
-  role: z.enum(['hub', 'bridge', 'reference', 'isolated', 'draft', 'synthesis']),
-  reason: z.string(),
-  inbound_links: z.number(),
-  outbound_links: z.number(),
-  total_connections: z.number(),
-});
-
-const noteUnderstandingSchema = z.object({
-  note: noteDetailsSchema,
-  backlinks: z.array(backlinkSchema),
-  link_suggestions: z.array(linkSuggestionSchema),
-  recommendations: recommendationSchema,
-  graph_role: graphRoleSchema,
-});
-
-const gardenPlanNoteRefSchema = z.object({
-  slug: z.string(),
-  title: z.string(),
-  type: z.string(),
-  modified: z.string(),
-});
-
 const gardenAdjudicationReasonCodeSchema = z.enum([
   'intentional-structure',
   'already-current',
   'blocked',
   'low-value',
 ]);
-
-const gardenOpportunityAdjudicationSchema = z.object({
-  decision: z.enum(['downrank']),
-  reason_code: gardenAdjudicationReasonCodeSchema,
-  rationale: z.string().optional(),
-  recorded_at: z.string(),
-  active: z.boolean(),
-});
-
-const gardenPlanOpportunitySchema = z.object({
-  id: z.string(),
-  kind: z.enum([
-    'hot-cluster-cold-hub',
-    'stale-synthesis',
-    'source-not-compiled',
-    'draft-debt',
-    'orphan-with-candidates',
-    'thin-important-note',
-    'duplicate-pair',
-    'missing-synthesis-cluster',
-  ]),
-  priority: z.number(),
-  priority_raw: z.number(),
-  priority_effective: z.number(),
-  action_hint: z.enum(['revise', 'connect', 'merge', 'synthesize', 'review']),
-  targets: z.array(gardenPlanNoteRefSchema),
-  supporting: z.array(gardenPlanNoteRefSchema),
-  why_now: z.string(),
-  evidence: z.object({
-    signals: z.array(z.string()),
-    metrics: z.record(z.string(), z.number()),
-  }),
-  stop_when: z.string(),
-  adjudication: gardenOpportunityAdjudicationSchema.optional(),
-});
-
-const gardenPlanSchema = z.object({
-  scope: z.object({
-    kind: z.enum(['vault', 'anchor']),
-    anchor_slug: z.string().optional(),
-    generated_at: z.string(),
-    notes_considered: z.number(),
-    clusters_considered: z.number(),
-  }),
-  operator_hint: z.string(),
-  opportunities: z.array(gardenPlanOpportunitySchema),
-});
-
-const gardenAdjudicationBaselineSchema = z.object({
-  target_modified_at: z.record(z.string(), z.string()),
-  supporting_modified_at: z.record(z.string(), z.string()).optional(),
-});
-
-const gardenAdjudicationSummarySchema = z.object({
-  opportunity_id: z.string(),
-  kind: z.string(),
-  target_slugs: z.array(z.string()),
-  decision: z.enum(['downrank']),
-  reason_code: gardenAdjudicationReasonCodeSchema,
-  rationale: z.string().optional(),
-  recorded_at: z.string(),
-  updated_at: z.string(),
-  recheck_after_days: z.number().int().positive().optional(),
-  baseline: gardenAdjudicationBaselineSchema,
-  active: z.boolean(),
-});
-
-const adjudicateGardenOpportunityResultSchema = z.object({
-  opportunity_id: z.string(),
-  decision: z.enum(['downrank', 'clear']),
-  adjudication: gardenAdjudicationSummarySchema.nullable(),
-  cleared: z.boolean(),
-});
-
-const disposeNoteSchema = z.object({
-  slug: z.string(),
-  mode: z.enum(['archive', 'delete']),
-  backlinks_removed: z.number(),
-  derived_children: z.number(),
-  note: noteDetailsSchema.nullable(),
-});
-
-const doctorIssueSchema = z.object({
-  level: z.enum(['error', 'warning', 'info']),
-  file: z.string(),
-  message: z.string(),
-});
-
-const vaultOverviewSchema = z.object({
-  vault_root: z.string(),
-  vault_name: z.string(),
-  default_type: z.string(),
-  auto_rebuild: z.boolean(),
-  index_last_rebuild: z.string().optional(),
-  note_count: z.number(),
-  notes_by_type: z.record(z.string(), z.number()),
-  recent_notes: z.array(noteSummarySchema),
-});
 
 export interface GraniteMcpHttpServerOptions {
   host: string;
@@ -536,18 +278,14 @@ function registerTools(server: McpServer, runtime: GraniteMcpRuntime): void {
       throw new Error('recheck_after_days is only allowed when reason_code is "blocked".');
     }
 
-    runtime.adjudicateGardenOpportunity({
+    const result = runtime.adjudicateGardenOpportunity({
       opportunity_id,
       decision,
       reason_code,
       rationale,
       recheck_after_days,
     });
-    return toolResult(
-      decision === 'clear'
-        ? `Cleared garden adjudication for "${opportunity_id}".`
-        : `Recorded garden adjudication for "${opportunity_id}".`,
-    );
+    return toolResult(renderAdjudicationResultMarkdown(result));
   });
 
   server.registerTool('granite_list_garden_adjudications', {
@@ -723,32 +461,7 @@ function registerTools(server: McpServer, runtime: GraniteMcpRuntime): void {
       sort: sort_field ? { field: sort_field, dir: sort_dir ?? 'desc' } : undefined,
       limit,
     });
-    const fieldNames = Array.from(
-      new Set(result.results.flatMap(r => Object.keys(r.fields ?? {}))),
-    );
-    const lines = [`# Query Results (${result.results.length})`, ''];
-    if (result.results.length === 0) {
-      lines.push('No matches.');
-    } else {
-      const header = ['title', 'slug', 'type', 'modified', ...fieldNames];
-      lines.push(`| ${header.join(' | ')} |`);
-      lines.push(`| ${header.map(() => '---').join(' | ')} |`);
-      for (const row of result.results) {
-        const cells = [
-          row.title,
-          row.slug,
-          row.type,
-          row.modified,
-          ...fieldNames.map(name => {
-            const value = row.fields?.[name];
-            if (value === undefined) return '';
-            return Array.isArray(value) ? value.join(', ') : String(value);
-          }),
-        ];
-        lines.push(`| ${cells.map(c => c.replace(/\|/g, '\\|')).join(' | ')} |`);
-      }
-    }
-    return toolResult(lines.join('\n'));
+    return toolResult(renderQueryResultsMarkdown(result.results));
   });
 
   server.registerTool('granite_compile_context', {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -7,6 +7,8 @@ import * as z from 'zod/v4';
 import {
   renderDisposeNoteMarkdown,
   renderExtractDocumentMarkdown,
+  renderGardenAdjudicationsMarkdown,
+  renderGardenPlanMarkdown,
   renderImportDocumentMarkdown,
   renderMutationResultMarkdown,
   renderNoteTypesMarkdown,
@@ -480,24 +482,10 @@ function registerTools(server: McpServer, runtime: GraniteMcpRuntime): void {
   server.registerTool('granite_wakeup', {
     title: 'Granite Wakeup',
     description: 'Load a compressed AAAK snapshot of the entire vault into context. Call this at the start of every session to know what exists, how notes cluster, and what changed recently. Costs ~200-500 tokens instead of reading every note.',
-    outputSchema: z.object({
-      total: z.number(),
-      by_type: z.record(z.string(), z.number()),
-      modified: z.string(),
-      clusters: z.array(z.object({
-        tag: z.string(),
-        slugs: z.array(z.string()),
-        hub: z.string().nullable(),
-      })),
-      people: z.array(z.object({ slug: z.string(), title: z.string() })),
-      recent: z.array(z.object({ slug: z.string(), age: z.string() })),
-      stale: z.array(z.object({ slug: z.string(), reason: z.string() })),
-      aaak: z.string(),
-    }),
     annotations: readOnlyAnnotations,
   }, async () => {
     const result = runtime.wakeup();
-    return toolResult(result, renderWakeupMarkdown(result));
+    return toolResult(renderWakeupMarkdown(result));
   });
 
   server.registerTool('granite_research_topic', {
@@ -507,14 +495,10 @@ function registerTools(server: McpServer, runtime: GraniteMcpRuntime): void {
       query: z.string().describe('Topic, keyword set, or research angle to search for in the vault.'),
       limit: z.number().int().min(1).max(50).optional().describe('Maximum number of results to return. Defaults to 10.'),
     },
-    outputSchema: z.object({
-      query: z.string(),
-      results: z.array(searchResultSchema),
-    }),
     annotations: readOnlyAnnotations,
   }, async ({ query, limit }) => {
     const results = runtime.search(query, limit ?? 10);
-    return toolResult({ query, results }, renderSearchResultsMarkdown(query, results));
+    return toolResult(renderSearchResultsMarkdown(query, results));
   });
 
   server.registerTool('granite_plan_garden', {
@@ -524,17 +508,10 @@ function registerTools(server: McpServer, runtime: GraniteMcpRuntime): void {
       anchor_slug: z.string().optional().describe('Optional note slug. When provided, the plan focuses on the anchor note, its local graph neighborhood, and its cluster.'),
       limit: z.number().int().min(1).max(20).optional().describe('Maximum number of opportunities to return. Defaults to 5.'),
     },
-    outputSchema: gardenPlanSchema,
     annotations: readOnlyAnnotations,
   }, async ({ anchor_slug, limit }) => {
     const result = runtime.planGarden({ anchor_slug, limit });
-    const scopeLabel = result.scope.kind === 'anchor'
-      ? `around "${result.scope.anchor_slug}"`
-      : 'for the vault';
-    return toolResult(
-      result,
-      `Planned ${result.opportunities.length} garden opportunit${result.opportunities.length === 1 ? 'y' : 'ies'} ${scopeLabel}. ${result.operator_hint}`,
-    );
+    return toolResult(renderGardenPlanMarkdown(result));
   });
 
   server.registerTool('granite_adjudicate_garden_opportunity', {
@@ -547,7 +524,6 @@ function registerTools(server: McpServer, runtime: GraniteMcpRuntime): void {
       rationale: z.string().optional().describe('Optional operator rationale for auditability.'),
       recheck_after_days: z.number().int().min(1).max(365).optional().describe('Optional recheck window. Only allowed with reason_code "blocked"; defaults to 14 days.'),
     },
-    outputSchema: adjudicateGardenOpportunityResultSchema,
     annotations: writeAnnotations,
   }, async ({ opportunity_id, decision, reason_code, rationale, recheck_after_days }) => {
     if (decision === 'downrank' && !reason_code) {
@@ -560,7 +536,7 @@ function registerTools(server: McpServer, runtime: GraniteMcpRuntime): void {
       throw new Error('recheck_after_days is only allowed when reason_code is "blocked".');
     }
 
-    const result = runtime.adjudicateGardenOpportunity({
+    runtime.adjudicateGardenOpportunity({
       opportunity_id,
       decision,
       reason_code,
@@ -568,7 +544,6 @@ function registerTools(server: McpServer, runtime: GraniteMcpRuntime): void {
       recheck_after_days,
     });
     return toolResult(
-      result,
       decision === 'clear'
         ? `Cleared garden adjudication for "${opportunity_id}".`
         : `Recorded garden adjudication for "${opportunity_id}".`,
@@ -578,18 +553,10 @@ function registerTools(server: McpServer, runtime: GraniteMcpRuntime): void {
   server.registerTool('granite_list_garden_adjudications', {
     title: 'List Granite Garden Adjudications',
     description: 'Inspect the active operator adjudications that are currently influencing Granite garden planning.',
-    outputSchema: z.object({
-      adjudications: z.array(gardenAdjudicationSummarySchema),
-    }),
     annotations: readOnlyAnnotations,
   }, async () => {
     const adjudications = runtime.listGardenAdjudications();
-    return toolResult(
-      { adjudications },
-      adjudications.length === 0
-        ? 'No active garden adjudications.'
-        : `Listed ${adjudications.length} active garden adjudication${adjudications.length === 1 ? '' : 's'}.`,
-    );
+    return toolResult(renderGardenAdjudicationsMarkdown(adjudications));
   });
 
   server.registerTool('granite_capture_knowledge', {
@@ -609,11 +576,6 @@ function registerTools(server: McpServer, runtime: GraniteMcpRuntime): void {
       derived_from: z.array(z.string()).optional().describe('Source note IDs or slugs this note derives from.'),
       fields: z.record(z.string(), z.unknown()).optional().describe('Type-specific frontmatter fields (e.g. { date: "2026-04-17" } for meetings). Keys reserved by the system (id, title, type, created, modified, tags, aliases, status, source, review_state, durability, derived_from) are ignored here — use the dedicated inputs. See granite://vault/types for each type\'s required fields.'),
     },
-    outputSchema: z.object({
-      note: noteDetailsSchema,
-      recommendations: recommendationSchema,
-      validation: validationResultSchema.optional(),
-    }),
     annotations: writeAnnotations,
   }, async (args) => {
     if (args.title) {
@@ -630,7 +592,7 @@ function registerTools(server: McpServer, runtime: GraniteMcpRuntime): void {
         derived_from: args.derived_from,
         fields: args.fields,
       });
-      return toolResult(result, renderMutationResultMarkdown('Created', result.note, result.recommendations, result.validation));
+      return toolResult(renderMutationResultMarkdown('Created', result.note, result.recommendations, result.validation));
     }
 
     if (!args.text) {
@@ -649,7 +611,7 @@ function registerTools(server: McpServer, runtime: GraniteMcpRuntime): void {
       derived_from: args.derived_from,
       fields: args.fields,
     });
-    return toolResult(result, renderMutationResultMarkdown('Captured', result.note, result.recommendations, result.validation));
+    return toolResult(renderMutationResultMarkdown('Captured', result.note, result.recommendations, result.validation));
   });
 
   server.registerTool('granite_import_document', {
@@ -662,20 +624,14 @@ function registerTools(server: McpServer, runtime: GraniteMcpRuntime): void {
       tags: z.array(z.string()).optional().describe('Tags to add immediately to the source note.'),
       aliases: z.array(z.string()).optional().describe('Aliases to add immediately to the source note.'),
     },
-    outputSchema: z.object({
-      note: noteDetailsSchema,
-      document: importedDocumentAssetSchema,
-      recommendations: recommendationSchema,
-    }),
     annotations: writeAnnotations,
   }, async ({ file_path, content, title, tags, aliases }) => {
     const result = runtime.importDocument({ file_path, content, title, tags, aliases });
     const summary = renderImportDocumentMarkdown(result);
 
     return {
-      ...toolResult(result, summary),
       content: [
-        { type: 'text', text: summary },
+        { type: 'text' as const, text: summary },
         createNoteResourceLink(result.note.title, result.note.resource_uri),
         createAssetResourceLink(result.document.file, result.document.resource_uri, result.document.mime_type),
       ],
@@ -688,11 +644,10 @@ function registerTools(server: McpServer, runtime: GraniteMcpRuntime): void {
     inputSchema: {
       file_path: z.string().describe('Absolute path, or vault-relative path, to the local document file to extract.'),
     },
-    outputSchema: extractedDocumentSchema,
     annotations: readOnlyAnnotations,
   }, async ({ file_path }) => {
     const result = await runtime.extractDocument({ file_path });
-    return toolResult(result, renderExtractDocumentMarkdown(result));
+    return toolResult(renderExtractDocumentMarkdown(result));
   });
 
   server.registerTool('granite_understand_note', {
@@ -701,12 +656,10 @@ function registerTools(server: McpServer, runtime: GraniteMcpRuntime): void {
     inputSchema: {
       slug: z.string().describe('Slug of the note to inspect.'),
     },
-    outputSchema: noteUnderstandingSchema,
     annotations: readOnlyAnnotations,
   }, async ({ slug }) => {
     const result = runtime.understandNote(slug);
     return {
-      ...toolResult(result, renderUnderstandNoteMarkdown(result)),
       content: buildUnderstandNoteContent(result),
     };
   });
@@ -729,15 +682,10 @@ function registerTools(server: McpServer, runtime: GraniteMcpRuntime): void {
       derived_from: z.array(z.string()).optional().describe('New derived_from references.'),
       fields: z.record(z.string(), z.unknown()).optional().describe('Type-specific frontmatter fields to set or overwrite (e.g. { date: "2026-04-17" } when promoting to meeting). Keys reserved by the system are ignored — use the dedicated inputs for those. See granite://vault/types for each type\'s required fields.'),
     },
-    outputSchema: z.object({
-      note: noteDetailsSchema,
-      recommendations: recommendationSchema,
-      validation: validationResultSchema.optional(),
-    }),
     annotations: writeAnnotations,
   }, async ({ slug, ...updates }) => {
     const result = runtime.reviseNote(slug, updates);
-    return toolResult(result, renderMutationResultMarkdown('Revised', result.note, result.recommendations, result.validation));
+    return toolResult(renderMutationResultMarkdown('Revised', result.note, result.recommendations, result.validation));
   });
 
   server.registerTool('granite_resolve', {
@@ -748,27 +696,13 @@ function registerTools(server: McpServer, runtime: GraniteMcpRuntime): void {
       target_type: z.string().optional().describe('Restrict matches to a given note type (e.g. "person", "organization").'),
       limit: z.number().int().min(1).max(20).optional().describe('Maximum matches to return. Defaults to 5.'),
     },
-    outputSchema: z.object({
-      matches: z.array(z.object({
-        slug: z.string(),
-        title: z.string(),
-        type: z.string(),
-        score: z.number(),
-        reason: z.enum(['slug', 'title', 'alias', 'fts']),
-      })),
-      suggested_stub: z.object({
-        type: z.string(),
-        title: z.string(),
-        slug: z.string(),
-      }).optional(),
-    }),
     annotations: readOnlyAnnotations,
   }, async ({ text, target_type, limit }) => {
     const result = runtime.resolve(text, { target_type, limit });
     const summary = result.matches.length > 0
       ? `# Resolve Matches\n\n${result.matches.map(m => `- **${m.title}** (${m.slug}, ${m.type}) — ${m.reason} score=${m.score.toFixed(2)}`).join('\n')}`
       : `# Resolve Matches\n\nNo matches for "${text}".${result.suggested_stub ? `\n\nSuggested stub: ${result.suggested_stub.type} "${result.suggested_stub.title}" → ${result.suggested_stub.slug}` : ''}`;
-    return toolResult(result, summary);
+    return toolResult(summary);
   });
 
   server.registerTool('granite_query', {
@@ -781,15 +715,6 @@ function registerTools(server: McpServer, runtime: GraniteMcpRuntime): void {
       sort_dir: z.enum(['asc', 'desc']).optional().describe('Sort direction. Defaults to desc.'),
       limit: z.number().int().min(1).max(200).optional().describe('Maximum results. Defaults to 25.'),
     },
-    outputSchema: z.object({
-      results: z.array(z.object({
-        slug: z.string(),
-        title: z.string(),
-        type: z.string(),
-        modified: z.string(),
-        fields: z.record(z.string(), z.union([z.string(), z.array(z.string())])),
-      })),
-    }),
     annotations: readOnlyAnnotations,
   }, async ({ type, where, sort_field, sort_dir, limit }) => {
     const result = runtime.query({
@@ -798,8 +723,32 @@ function registerTools(server: McpServer, runtime: GraniteMcpRuntime): void {
       sort: sort_field ? { field: sort_field, dir: sort_dir ?? 'desc' } : undefined,
       limit,
     });
-    const summary = `# Query Results (${result.results.length})\n\n${result.results.map(r => `- **${r.title}** (${r.slug}, ${r.type})`).join('\n')}`;
-    return toolResult(result, summary);
+    const fieldNames = Array.from(
+      new Set(result.results.flatMap(r => Object.keys(r.fields ?? {}))),
+    );
+    const lines = [`# Query Results (${result.results.length})`, ''];
+    if (result.results.length === 0) {
+      lines.push('No matches.');
+    } else {
+      const header = ['title', 'slug', 'type', 'modified', ...fieldNames];
+      lines.push(`| ${header.join(' | ')} |`);
+      lines.push(`| ${header.map(() => '---').join(' | ')} |`);
+      for (const row of result.results) {
+        const cells = [
+          row.title,
+          row.slug,
+          row.type,
+          row.modified,
+          ...fieldNames.map(name => {
+            const value = row.fields?.[name];
+            if (value === undefined) return '';
+            return Array.isArray(value) ? value.join(', ') : String(value);
+          }),
+        ];
+        lines.push(`| ${cells.map(c => c.replace(/\|/g, '\\|')).join(' | ')} |`);
+      }
+    }
+    return toolResult(lines.join('\n'));
   });
 
   server.registerTool('granite_compile_context', {
@@ -810,19 +759,6 @@ function registerTools(server: McpServer, runtime: GraniteMcpRuntime): void {
       slug: z.string().optional().describe('Note slug to compile context for.'),
       limit: z.number().int().min(1).max(100).optional().describe('Max entries per section. Defaults to 20.'),
     },
-    outputSchema: z.object({
-      mode: z.enum(['topic', 'slug']),
-      title: z.string(),
-      sections: z.array(z.object({
-        heading: z.string(),
-        entries: z.array(z.object({
-          slug: z.string(),
-          title: z.string(),
-          type: z.string(),
-          reason: z.string(),
-        })),
-      })),
-    }),
     annotations: readOnlyAnnotations,
   }, async ({ topic, slug, limit }) => {
     const result = runtime.compileContext({ topic, slug, limit });
@@ -836,7 +772,7 @@ function registerTools(server: McpServer, runtime: GraniteMcpRuntime): void {
         '',
       ]),
     ].join('\n');
-    return toolResult(result, summary);
+    return toolResult(summary);
   });
 
   server.registerTool('granite_dispose_note', {
@@ -846,11 +782,10 @@ function registerTools(server: McpServer, runtime: GraniteMcpRuntime): void {
       slug: z.string().describe('Slug of the note to archive or delete.'),
       mode: z.enum(['archive', 'delete']).optional().describe('How to dispose of the note. Defaults to archive.'),
     },
-    outputSchema: disposeNoteSchema,
     annotations: writeAnnotations,
   }, async ({ slug, mode }) => {
     const result = runtime.disposeNote(slug, mode ?? 'archive');
-    return toolResult(result, renderDisposeNoteMarkdown(result));
+    return toolResult(renderDisposeNoteMarkdown(result));
   });
 }
 
@@ -1045,10 +980,9 @@ function registerPrompts(server: McpServer, runtime: GraniteMcpRuntime): void {
 
 }
 
-function toolResult<T>(structuredContent: T, summary: string) {
+function toolResult(summary: string) {
   return {
     content: [{ type: 'text' as const, text: summary }],
-    structuredContent: asStructuredContent(structuredContent),
   };
 }
 
@@ -1115,10 +1049,6 @@ function formatCompileTopicNote(note: { title: string; slug: string; type: strin
     note.body.slice(0, 500) + (note.body.length > 500 ? '...' : ''),
     '',
   ].join('\n');
-}
-
-function asStructuredContent<T>(value: T): Record<string, unknown> {
-  return JSON.parse(JSON.stringify(value)) as Record<string, unknown>;
 }
 
 function createGraniteMcpHttpApp(runtime: GraniteMcpRuntime, options: GraniteMcpHttpServerOptions): Hono {

--- a/test/mcp/server-validation.test.ts
+++ b/test/mcp/server-validation.test.ts
@@ -75,12 +75,9 @@ describe('granite MCP server — strict type validation end-to-end', () => {
       },
     });
     expect(result.isError).toBeFalsy();
-    const structured = (result as { structuredContent: unknown }).structuredContent as {
-      note: { frontmatter: Record<string, unknown> };
-      validation?: { passed: boolean };
-    };
-    expect(structured.note.frontmatter.date).toBe('2026-04-17');
-    expect(structured.validation?.passed).toBe(true);
+    const text = (result.content as Array<{ type: string; text?: string }>).find(c => c.type === 'text')?.text ?? '';
+    expect(text).toContain('2026-04-17');
+    expect(text).not.toMatch(/missing_required_field|validation_failed/);
   });
 
   it('exposes fields input in the granite_capture_knowledge tool schema', async () => {

--- a/test/mcp/server.test.ts
+++ b/test/mcp/server.test.ts
@@ -96,28 +96,19 @@ describe('granite MCP server', () => {
       },
     });
 
-    const createdData = extractStructuredContent(created) as {
-      note: { slug: string; source: string };
-    };
-
-    expect(createdData.note.slug).toBe('linked-result');
-    expect(createdData.note.source).toBe('agent');
-    expect(extractTextContent(created)).toContain('# Created Note');
-    expect(extractTextContent(created).trim().startsWith('{')).toBe(false);
+    const createdText = extractTextContent(created);
+    expect(createdText).toContain('# Created Note');
+    expect(createdText).toContain('linked-result');
+    expect(createdText.trim().startsWith('{')).toBe(false);
 
     const understood = await client.callTool({
       name: 'granite_understand_note',
       arguments: { slug: 'mcp-note' },
     });
 
-    const understoodData = extractStructuredContent(understood) as {
-      backlinks: Array<{ source_slug: string }>;
-      graph_role: { role: string };
-    };
-
-    expect(understoodData.backlinks.some(link => link.source_slug === 'linked-result')).toBe(true);
-    expect(typeof understoodData.graph_role.role).toBe('string');
-    expect(extractTextContent(understood)).toContain('# Note Context');
+    const understoodText = extractTextContent(understood);
+    expect(understoodText).toContain('# Note Context');
+    expect(understoodText).toContain('linked-result');
   });
 
   it('archives notes through granite_dispose_note', async () => {
@@ -126,13 +117,9 @@ describe('granite MCP server', () => {
       arguments: { slug: 'mcp-note' },
     });
 
-    const disposedData = extractStructuredContent(disposed) as {
-      mode: string;
-      note: { status: string } | null;
-    };
-
-    expect(disposedData.mode).toBe('archive');
-    expect(disposedData.note?.status).toBe('archived');
+    const disposedText = extractTextContent(disposed);
+    expect(disposedText).toMatch(/archive/i);
+    expect(disposedText).toContain('mcp-note');
   });
 
   it('imports documents and serves their asset resources through MCP', async () => {
@@ -147,16 +134,15 @@ describe('granite MCP server', () => {
       },
     });
 
-    const importedData = extractStructuredContent(imported) as {
-      note: { slug: string; body: string; frontmatter: Record<string, unknown> };
-      document: { file: string; resource_uri: string; mime_type: string };
-    };
+    const importedText = extractTextContent(imported);
+    expect(importedText).toContain('mcp-source');
+    expect(importedText).toContain('application/pdf');
 
-    expect(importedData.note.slug).toBe('mcp-source');
-    expect(importedData.note.frontmatter.document_file).toBe(importedData.document.file);
-    expect(importedData.note.body).toContain('MCP source content');
+    const assetLink = (imported.content as Array<{ type: string; uri?: string; mimeType?: string }>)
+      .find((c) => c.type === 'resource_link' && c.mimeType === 'application/pdf');
+    expect(assetLink?.uri).toBeDefined();
 
-    const resource = await client.readResource({ uri: importedData.document.resource_uri });
+    const resource = await client.readResource({ uri: assetLink!.uri! });
     const content = resource.contents[0];
 
     expect(content && 'mimeType' in content ? content.mimeType : '').toBe('application/pdf');
@@ -174,53 +160,37 @@ describe('granite MCP server', () => {
       },
     });
 
-    const extractedData = extractStructuredContent(extracted) as {
-      status: string;
-      doc_type: string;
-      extractor: string;
-      raw_text: string;
-    };
-
-    expect(extractedData.status).toBe('ready');
-    expect(extractedData.doc_type).toBe('docx');
-    expect(extractedData.extractor).toBe('mammoth');
-    expect(extractedData.raw_text).toContain('MCP extraction works');
-    expect(extractTextContent(extracted)).toContain('# Document Extraction');
-    expect(extractTextContent(extracted)).toContain('## Raw Text');
+    const extractedText = extractTextContent(extracted);
+    expect(extractedText).toContain('# Document Extraction');
+    expect(extractedText).toContain('## Raw Text');
+    expect(extractedText).toContain('MCP extraction works');
+    expect(extractedText).toMatch(/docx/);
+    expect(extractedText).toMatch(/mammoth/);
   });
 
-  it('returns wakeup as markdown while preserving structured content', async () => {
+  it('returns wakeup as markdown', async () => {
     const wakeup = await client.callTool({
       name: 'granite_wakeup',
       arguments: {},
     });
 
-    const wakeupData = extractStructuredContent(wakeup) as {
-      total: number;
-      aaak: string;
-    };
-
-    expect(wakeupData.total).toBeGreaterThan(0);
-    expect(wakeupData.aaak.length).toBeGreaterThan(0);
-    expect(extractTextContent(wakeup)).toContain('# Vault Wakeup');
-    expect(extractTextContent(wakeup)).toContain('## AAAK');
+    const wakeupText = extractTextContent(wakeup);
+    expect(wakeupText).toContain('# Vault Wakeup');
+    expect(wakeupText).toContain('## AAAK');
+    expect(wakeupText.trim().startsWith('{')).toBe(false);
   });
 
   it('makes the inbox workflow doc-aware for imported source notes', async () => {
     const inputFile = path.join(tmpDir, 'workflow-source.pdf');
     fs.writeFileSync(inputFile, '%PDF-1.4\nworkflow\n');
 
-    const imported = await client.callTool({
+    await client.callTool({
       name: 'granite_import_document',
       arguments: {
         file_path: inputFile,
         content: 'Workflow source content',
       },
     });
-
-    const importedData = extractStructuredContent(imported) as {
-      note: { slug: string };
-    };
 
     const inboxPrompt = await client.getPrompt({
       name: 'granite_process_inbox',
@@ -234,7 +204,7 @@ describe('granite MCP server', () => {
       throw new Error('Expected text content for inbox prompt.');
     }
 
-    expect(inboxMessage.content.text).toContain(importedData.note.slug);
+    expect(inboxMessage.content.text).toContain('workflow-source');
     expect(inboxMessage.content.text).toContain('granite_extract_document');
     expect(inboxMessage.content.text).toContain('imported document attached');
   });
@@ -269,6 +239,40 @@ describe('granite MCP server', () => {
     expect(message.content.text).toContain('imported document attached');
   });
 
+  it('renders garden plan markdown with opportunity IDs when any exist', async () => {
+    const plan = await client.callTool({
+      name: 'granite_plan_garden',
+      arguments: {},
+    });
+    const planText = extractTextContent(plan);
+    expect(planText).toContain('# Garden Plan');
+    expect(planText).toContain('Operator hint');
+    if (!planText.includes('- None')) {
+      expect(planText).toMatch(/Opportunity ID/);
+    }
+  });
+
+  it('renders garden adjudications markdown', async () => {
+    const list = await client.callTool({
+      name: 'granite_list_garden_adjudications',
+      arguments: {},
+    });
+    const listText = extractTextContent(list);
+    expect(listText).toContain('# Garden Adjudications');
+    expect(listText).toContain('Active adjudications:');
+  });
+
+  it('renders granite_query results with modified timestamps', async () => {
+    const queryResult = await client.callTool({
+      name: 'granite_query',
+      arguments: { type: 'note' },
+    });
+    const queryText = extractTextContent(queryResult);
+    expect(queryText).toContain('# Query Results');
+    expect(queryText).toContain('mcp-note');
+    expect(queryText).toContain('| title | slug | type | modified');
+  });
+
   it('closes cleanup hooks after an HTTP response body is consumed', async () => {
     let cleanupCount = 0;
     const response = new Response('granite');
@@ -281,13 +285,6 @@ describe('granite MCP server', () => {
     expect(cleanupCount).toBe(1);
   });
 });
-
-function extractStructuredContent(result: Awaited<ReturnType<Client['callTool']>>) {
-  if (!('structuredContent' in result) || !result.structuredContent) {
-    throw new Error('Tool result did not include structuredContent.');
-  }
-  return result.structuredContent;
-}
 
 function extractTextContent(result: Awaited<ReturnType<Client['callTool']>>) {
   const textContent = result.content.find(item => item.type === 'text');

--- a/test/worker/mcp.test.ts
+++ b/test/worker/mcp.test.ts
@@ -22,7 +22,7 @@ describe('granite worker MCP server', () => {
     await server.close();
   });
 
-  it('returns markdown tool content while keeping structured content', async () => {
+  it('returns markdown tool content', async () => {
     const overview = await client.callTool({
       name: 'granite_get_vault_overview',
       arguments: {},
@@ -32,16 +32,15 @@ describe('granite worker MCP server', () => {
       arguments: { slug: 'worker-note' },
     });
 
-    const overviewData = extractStructuredContent(overview) as { note_count: number };
-    const noteData = extractStructuredContent(note) as { slug: string; body: string };
+    const overviewText = extractTextContent(overview);
+    const noteText = extractTextContent(note);
 
-    expect(overviewData.note_count).toBe(1);
-    expect(noteData.slug).toBe('worker-note');
-    expect(noteData.body).toContain('Worker note body');
-    expect(extractTextContent(overview)).toContain('# Vault Overview');
-    expect(extractTextContent(overview).trim().startsWith('{')).toBe(false);
-    expect(extractTextContent(note)).toContain('# Worker Note');
-    expect(extractTextContent(note)).toContain('## Body');
+    expect(overviewText).toContain('# Vault Overview');
+    expect(overviewText.trim().startsWith('{')).toBe(false);
+    expect(noteText).toContain('# Worker Note');
+    expect(noteText).toContain('## Body');
+    expect(noteText).toContain('Worker note body');
+    expect(noteText).toContain('worker-note');
   });
 
   it('serves vault overview as a markdown resource', async () => {
@@ -64,13 +63,13 @@ describe('granite worker MCP server', () => {
       },
     });
 
-    const listData = extractStructuredContent(listNotes) as { notes: Array<{ slug: string }> };
-    const createdData = extractStructuredContent(createNote) as { note: { slug: string } };
+    const listText = extractTextContent(listNotes);
+    const createdText = extractTextContent(createNote);
 
-    expect(listData.notes[0]?.slug).toBe('worker-note');
-    expect(createdData.note.slug).toBe('fresh-worker-note');
-    expect(extractTextContent(listNotes)).toContain('# Notes');
-    expect(extractTextContent(createNote)).toContain('# Created Note');
+    expect(listText).toContain('# Notes');
+    expect(listText).toContain('worker-note');
+    expect(createdText).toContain('# Created Note');
+    expect(createdText).toContain('fresh-worker-note');
   });
 });
 
@@ -194,13 +193,6 @@ function emptyRecommendations() {
     tags: [],
     next_steps: [],
   };
-}
-
-function extractStructuredContent(result: Awaited<ReturnType<Client['callTool']>>) {
-  if (!('structuredContent' in result) || !result.structuredContent) {
-    throw new Error('Tool result did not include structuredContent.');
-  }
-  return result.structuredContent;
 }
 
 function extractTextContent(result: Awaited<ReturnType<Client['callTool']>>) {


### PR DESCRIPTION
## Summary
- Drop `outputSchema` + `structuredContent` across the Node and Worker MCP servers — Claude Code was pushing both the text and the JSON into LLM context, doubling token cost per tool call.
- Fold every previously-structured field into the markdown payload so nothing is lost: garden plan opportunities (with IDs required by `granite_adjudicate_garden_opportunity`), active adjudications (reason codes, rationale, recheck windows), `granite_query` results (table with `modified` + every indexed field value), and extra frontmatter (e.g. meeting `date`) on mutations.
- Ignore local `coverage/` output so generated artifacts stay out of diffs.

## Test plan
- [x] `npm test` — 185 tests pass (3 added: plan-garden IDs, adjudications markdown, query table w/ modified)
- [x] `npm run build` — clean build, `dist/index.js` has 0 occurrences of `structuredContent`/`outputSchema`
- [ ] Smoke test against a live vault after restarting Claude Code (MCP process picks up the new build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a breaking contract change for MCP consumers that relied on `structuredContent`/`outputSchema`, and correctness now depends on markdown containing all needed fields for downstream automation.
> 
> **Overview**
> MCP tool responses are refactored to **return markdown-only `content`** across both the Node server (`src/mcp/server.ts`) and Cloudflare Worker server (`packages/worker/src/handlers/mcp.ts`), removing all `outputSchema` declarations and eliminating `structuredContent` payloads.
> 
> To preserve previously-structured data, markdown rendering is expanded (e.g., mutation results now include *extra frontmatter*, `granite_query` renders a markdown table including `modified` + indexed fields, and garden planning/adjudication tools render full markdown summaries). Tests and the live verification script are updated to assert against markdown text/resource links rather than JSON, and `.gitignore` now excludes `coverage/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 972492da18fb86231d9c7805e9c131599d444e52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch MCP tool responses to markdown-only by removing `outputSchema` and `structuredContent` in both Node and Worker servers, cutting token use and simplifying the contract. Adds safer markdown rendering and fuller adjudication details.

- **New Features**
  - `granite_plan_garden`: renders full plan with opportunity IDs, targets, priorities, and evidence.
  - `granite_adjudicate_garden_opportunity`: returns full adjudication state (opportunity ID, decision, cleared flag, reason code, rationale, targets, timestamps).
  - `granite_list_garden_adjudications`: shows reason codes, rationale, recheck windows, and timestamps.
  - `granite_query`: returns a markdown table with `modified` plus all returned field columns; escapes pipes and newlines to keep the table intact.
  - Create/capture/revise mutations include extra frontmatter (e.g. meeting `date`).
  - `granite_import_document`: keeps resource links for note and attached asset.
  - Ignore local `coverage/` in `.gitignore`.

- **Migration**
  - Stop reading `structuredContent` or relying on `outputSchema`. Parse `content[].text` (markdown) and resource links instead.
  - For `granite_adjudicate_garden_opportunity`, read the opportunity ID from the `granite_plan_garden` markdown.

<sup>Written for commit 972492da18fb86231d9c7805e9c131599d444e52. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

