### PR TITLE
feat(conductor): add turnkey config

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -1,0 +1,7 @@
+{
+  "scripts": {
+    "setup": "set -e\nnpm install\nif [ ! -f \"$HOME/.granite/granite.yml\" ]; then\n  npm run dev -- init\nfi",
+    "run": "npm run dev -- daemon --vault \"$HOME/.granite\" --host 127.0.0.1 --web-port \"$CONDUCTOR_PORT\" --mcp-port \"$((CONDUCTOR_PORT + 1))\""
+  },
+  "runScriptMode": "nonconcurrent"
+}


### PR DESCRIPTION
Adds a repo-level `conductor.json` that bootstraps `~/.granite` on first setup and runs the Granite daemon with Conductor-managed web and MCP ports.
This makes the repo turnkey in Conductor without requiring manual vault initialization or ad hoc run commands.
It uses `runScriptMode: "nonconcurrent"` so reruns replace the previous daemon cleanly.
Validated with JSON parsing, setup bootstrap/reuse checks, daemon endpoint checks, and `npm test` (31 files, 180 tests).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new Conductor configuration file that only affects Conductor-run setup/daemon launch and does not change application code paths.
> 
> **Overview**
> Adds a new `conductor.json` that makes the repo turnkey in Conductor by providing `setup` and `run` scripts.
> 
> `setup` installs dependencies and auto-initializes `~/.granite` only if `granite.yml` is missing, while `run` starts the daemon against that vault on `127.0.0.1` using `$CONDUCTOR_PORT` (web) and `$CONDUCTOR_PORT + 1` (MCP).
> 
> Sets `runScriptMode: "nonconcurrent"` so re-runs replace the previous daemon instead of running concurrently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c23e2defdf5495d46522b740137d2967cf9bedb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a repo-level `conductor.json` to make the project turnkey in Conductor: auto-bootstraps `~/.granite` on first setup and runs the Granite daemon with Conductor-managed web/MCP ports. Re-runs replace the previous daemon via `runScriptMode: "nonconcurrent"`.

- **New Features**
  - Added `conductor.json` with `setup` and `run` scripts.
  - `setup`: runs `npm install` and initializes `~/.granite` only if `granite.yml` is missing.
  - `run`: starts the daemon using `--vault ~/.granite`, `--host 127.0.0.1`, `--web-port $CONDUCTOR_PORT`, and `--mcp-port $CONDUCTOR_PORT+1`.
  - Sets `"runScriptMode": "nonconcurrent"` to avoid concurrent daemons.

<sup>Written for commit 1c23e2defdf5495d46522b740137d2967cf9bedb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

