### PR TITLE
feat(cloud): improve auth and API key dashboard

### DIFF
--- a/docs/CLOUD_MCP.md
+++ b/docs/CLOUD_MCP.md
@@ -121,6 +121,7 @@ Required Cloudflare bindings:
 - `CLOUDFLARE_ACCOUNT_ID`: set in the environment for non-interactive deploys when the local Wrangler session has multiple accounts.
 
 Never commit Neon database URLs or Stripe secrets. If a database URL is pasted into chat or logs, rotate it before production.
+Deployments use `wrangler deploy --keep-vars` so Cloudflare dashboard-managed environment variables are preserved.
 
 Stripe webhook endpoint:
 

--- a/packages/cloudflare-mcp/package.json
+++ b/packages/cloudflare-mcp/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "wrangler dev",
-    "deploy": "wrangler deploy",
+    "deploy": "wrangler deploy --keep-vars",
     "db:schema": "cat schema.sql",
     "lint": "tsc --noEmit"
   },

--- a/packages/cloudflare-mcp/src/billing.ts
+++ b/packages/cloudflare-mcp/src/billing.ts
@@ -11,6 +11,13 @@ export interface BillingPortalResult {
   url: string;
 }
 
+export interface CheckoutSyncResult {
+  billingStatus: 'active' | 'past_due' | 'canceled' | 'unpaid' | 'pending_checkout';
+  subscriptionId: string | null;
+  currentPeriodEnd: number | null;
+  cancelAtPeriodEnd: boolean;
+}
+
 export interface StripeBilling {
   createCustomer(user: User): Promise<string>;
   createVaultCheckout(input: {
@@ -20,6 +27,7 @@ export interface StripeBilling {
     name: string;
   }): Promise<CheckoutSessionResult>;
   createPortal(input: { customerId: string; returnUrl: string }): Promise<BillingPortalResult>;
+  syncCheckoutSession(sessionId: string): Promise<CheckoutSyncResult>;
   parseWebhook(body: string, signature: string): Promise<Stripe.Event>;
 }
 
@@ -92,6 +100,21 @@ class StripeBillingClient implements StripeBilling {
       return_url: input.returnUrl,
     });
     return { url: session.url };
+  }
+
+  async syncCheckoutSession(sessionId: string): Promise<CheckoutSyncResult> {
+    const session = await this.stripe.checkout.sessions.retrieve(sessionId, {
+      expand: ['subscription'],
+    });
+    const subscription = typeof session.subscription === 'object' && session.subscription && !('deleted' in session.subscription)
+      ? session.subscription as any
+      : null;
+    return {
+      billingStatus: subscription ? subscriptionStatus(subscription.status) : 'pending_checkout',
+      subscriptionId: typeof session.subscription === 'string' ? session.subscription : subscription?.id ?? null,
+      currentPeriodEnd: typeof subscription?.current_period_end === 'number' ? subscription.current_period_end : null,
+      cancelAtPeriodEnd: Boolean(subscription?.cancel_at_period_end),
+    };
   }
 
   async parseWebhook(body: string, signature: string): Promise<Stripe.Event> {

--- a/packages/cloudflare-mcp/src/routes/auth.ts
+++ b/packages/cloudflare-mcp/src/routes/auth.ts
@@ -15,11 +15,21 @@ const AUTH_RATE_LIMIT_CLEANUP_MS = 300_000;
 let lastAuthRateLimitCleanup = 0;
 
 auth.post('/auth/neon/session', async (c) => {
-  const token = await tokenFromRequest(c.req.raw);
+  const { token, cliSession } = await tokenAndCliSessionFromRequest(c.req.raw);
   if (!token) return c.json({ error: 'Missing Neon Auth token.' }, 400);
   try {
     const user = await upsertNeonUser(database(c.env), await verifyNeonJwt(c.env, token));
-    return c.json({ user }, 200, { 'Set-Cookie': await createWebSession(c, user) });
+    const cookie = await createWebSession(c, user);
+    if (cliSession) {
+      const verificationCode = await completeCliLogin(c.env, cliSession, user.id);
+      if (!verificationCode) return c.json({ user, cli_expired: true }, 200, { 'Set-Cookie': cookie });
+      return c.json(
+        { verification_code: verificationCode, username: user.display_name ?? user.email ?? user.id },
+        200,
+        { 'Set-Cookie': cookie },
+      );
+    }
+    return c.json({ user }, 200, { 'Set-Cookie': cookie });
   } catch {
     return c.json({ error: 'Invalid Neon Auth token.' }, 401);
   }
@@ -159,6 +169,19 @@ async function tokenFromRequest(request: Request): Promise<string> {
   if (scheme?.toLowerCase() === 'bearer') return rest.join(' ').trim();
   const body = await request.json().catch(() => null) as { token?: unknown } | null;
   return typeof body?.token === 'string' ? body.token : '';
+}
+
+async function tokenAndCliSessionFromRequest(request: Request): Promise<{ token: string; cliSession: string }> {
+  const auth = request.headers.get('Authorization') ?? '';
+  const [scheme, ...rest] = auth.split(/\s+/);
+  if (scheme?.toLowerCase() === 'bearer') {
+    return { token: rest.join(' ').trim(), cliSession: '' };
+  }
+  const body = await request.json().catch(() => null) as { token?: unknown; cli_session?: unknown } | null;
+  return {
+    token: typeof body?.token === 'string' ? body.token : '',
+    cliSession: typeof body?.cli_session === 'string' ? body.cli_session.trim() : '',
+  };
 }
 
 async function neonEmailAuth(c: Context<Bindings>, endpoint: 'sign-in/email' | 'sign-up/email'): Promise<Response> {

--- a/packages/cloudflare-mcp/src/routes/dashboard.ts
+++ b/packages/cloudflare-mcp/src/routes/dashboard.ts
@@ -4,18 +4,24 @@ import type { AppVariables, Env, VaultRow } from '../env.js';
 import { database } from '../db.js';
 import { currentWebUser } from '../neon-auth.js';
 import { ensureStripeCustomer, stripeBilling } from '../billing.js';
+import { generateApiKey, getKeyPrefix, hashApiKey } from '../lib/api-key.js';
 
 type Bindings = { Bindings: Env; Variables: AppVariables };
 
 const dashboard = new Hono<Bindings>();
 
 dashboard.get('/app/login', async (c) => {
-  return c.html(page('Login', loginPage(c.req.query('cli_session') ?? '')));
+  return c.html(page('Login', loginPage(c.req.query('cli_session') ?? '', c.env.NEON_AUTH_BASE_URL ?? '')));
 });
 
 dashboard.get('/app', async (c) => {
   const user = await currentWebUser(c);
   if (!user) return c.redirect('/app/login');
+  const checkout = c.req.query('checkout') ?? '';
+  const checkoutVaultId = c.req.query('vault_id') ?? '';
+  const checkoutSync = checkout === 'success' && checkoutVaultId
+    ? await syncCheckoutReturn(c.env, user.id, checkoutVaultId)
+    : null;
   const vaults = await database(c.env).query<VaultRow>(`
     SELECT vault_id, user_id, vault_name, billing_status, stripe_subscription_id,
       stripe_checkout_session_id, stripe_price_id, current_period_end, cancel_at_period_end,
@@ -24,9 +30,24 @@ dashboard.get('/app', async (c) => {
     WHERE user_id = $1
     ORDER BY created_at DESC
   `, [user.id]);
-  const checkout = c.req.query('checkout') ?? '';
+  const apiKeys = await database(c.env).query<{
+    key_prefix: string;
+    name: string;
+    created_at: string | Date;
+    last_used_at: string | Date | null;
+    revoked_at: string | Date | null;
+  }>(`
+    SELECT key_prefix, name, created_at, last_used_at, revoked_at
+    FROM api_keys
+    WHERE user_id = $1
+    ORDER BY created_at DESC
+  `, [user.id]);
   const checkoutMessage = checkout === 'success'
-    ? '<p class="notice success" role="status">Checkout complete. Your vault will become writable as soon as Stripe confirms the subscription.</p>'
+    ? checkoutSync === 'active'
+      ? '<p class="notice success" role="status">Checkout complete. Your vault is active.</p>'
+      : checkoutSync === 'error'
+        ? '<p class="notice warning" role="alert">Checkout complete, but Granite could not refresh billing yet. Refresh this page in a moment.</p>'
+        : '<p class="notice success" role="status">Checkout complete. Your vault will become writable as soon as Stripe confirms the subscription.</p>'
     : checkout === 'canceled'
       ? '<p class="notice warning" role="alert">Checkout was canceled. Create a vault again when you are ready.</p>'
       : '';
@@ -42,9 +63,91 @@ dashboard.get('/app', async (c) => {
         <h2>Vaults</h2>
         ${vaults.length ? vaults.map(vault => vaultCard(vault, c.env.BASE_URL)).join('') : '<p>No vaults yet.</p>'}
       </section>
+      <section>
+        <h2>API keys</h2>
+        <form method="post" action="/app/keys">
+          <label>Key name <input name="name" value="mcp-client" maxlength="80"></label>
+          <button type="submit">Create API key</button>
+        </form>
+        ${apiKeys.length ? apiKeys.map(key => apiKeyCard(key)).join('') : '<p>No API keys yet.</p>'}
+      </section>
     </main>
   `));
 });
+
+dashboard.post('/app/keys', async (c) => {
+  const user = await currentWebUser(c);
+  if (!user) return c.redirect('/app/login');
+  const form = await c.req.parseBody();
+  const name = safeKeyName(typeof form.name === 'string' ? form.name : undefined);
+  const apiKey = generateApiKey();
+  const keyPrefix = getKeyPrefix(apiKey);
+  await database(c.env).execute(`
+    INSERT INTO api_keys (key_hash, user_id, key_prefix, name)
+    VALUES ($1, $2, $3, $4)
+  `, [await hashApiKey(apiKey), user.id, keyPrefix, name]);
+  return c.html(page('API key created', `
+    <main>
+      <h1>API key created</h1>
+      ${apiKeyCreatedNotice(apiKey, name)}
+      <p><a href="/app">Back to dashboard</a></p>
+    </main>
+  `), 201, { 'Cache-Control': 'no-store', 'Referrer-Policy': 'no-referrer' });
+});
+
+dashboard.post('/app/keys/:prefix/revoke', async (c) => {
+  const user = await currentWebUser(c);
+  if (!user) return c.redirect('/app/login');
+  await database(c.env).execute(`
+    UPDATE api_keys
+    SET revoked_at = now()
+    WHERE user_id = $1 AND key_prefix = $2 AND revoked_at IS NULL
+  `, [user.id, c.req.param('prefix')]);
+  return c.redirect('/app', 303);
+});
+
+async function syncCheckoutReturn(env: Env, userId: string, vaultId: string): Promise<'active' | 'pending' | 'error'> {
+  const db = database(env);
+  const vault = await db.first<VaultRow>(`
+    SELECT vault_id, user_id, vault_name, billing_status, stripe_subscription_id,
+      stripe_checkout_session_id, stripe_price_id, current_period_end, cancel_at_period_end,
+      storage_limit_bytes, storage_used_bytes, activated_at, created_at, updated_at
+    FROM vaults
+    WHERE vault_id = $1 AND user_id = $2
+  `, [vaultId, userId]);
+  if (!vault?.stripe_checkout_session_id || vault.billing_status === 'active') {
+    return vault?.billing_status === 'active' ? 'active' : 'pending';
+  }
+
+  try {
+    const billing = await stripeBilling(env).syncCheckoutSession(vault.stripe_checkout_session_id);
+    const updated = await db.first<{ billing_status: VaultRow['billing_status'] }>(`
+      UPDATE vaults
+      SET billing_status = $3,
+        stripe_subscription_id = COALESCE($4, stripe_subscription_id),
+        current_period_end = CASE WHEN $5::bigint IS NULL THEN current_period_end ELSE to_timestamp($5::bigint) END,
+        cancel_at_period_end = $6,
+        activated_at = CASE WHEN $3 = 'active' THEN COALESCE(activated_at, now()) ELSE activated_at END,
+        updated_at = now()
+      WHERE vault_id = $1
+        AND user_id = $2
+        AND stripe_checkout_session_id = $7
+      RETURNING billing_status
+    `, [
+      vaultId,
+      userId,
+      billing.billingStatus,
+      billing.subscriptionId,
+      billing.currentPeriodEnd,
+      billing.cancelAtPeriodEnd,
+      vault.stripe_checkout_session_id,
+    ]);
+    return updated?.billing_status === 'active' ? 'active' : 'pending';
+  } catch (error) {
+    console.error('Failed to sync Stripe checkout return', error);
+    return 'error';
+  }
+}
 
 dashboard.post('/app/vaults', async (c) => {
   const user = await currentWebUser(c);
@@ -86,6 +189,38 @@ function vaultCard(vault: VaultRow, baseUrl: string): string {
   `;
 }
 
+function apiKeyCreatedNotice(apiKey: string, name: string): string {
+  return `
+    <p class="notice success" role="status">API key created${name ? ` for ${escapeHtml(name)}` : ''}. Copy it now; it will not be shown again.</p>
+    <code>${escapeHtml(apiKey)}</code>
+  `;
+}
+
+function apiKeyCard(key: {
+  key_prefix: string;
+  name: string;
+  created_at: string | Date;
+  last_used_at: string | Date | null;
+  revoked_at: string | Date | null;
+}): string {
+  const status = key.revoked_at ? 'revoked' : 'active';
+  const lastUsed = key.last_used_at ? ` · last used ${escapeHtml(shortDate(key.last_used_at))}` : '';
+  const revoke = key.revoked_at
+    ? ''
+    : `<form method="post" action="/app/keys/${encodeURIComponent(key.key_prefix)}/revoke" onsubmit="return confirm('Revoke this API key? Existing MCP clients using it will stop working.');"><button class="secondary" type="submit">Revoke</button></form>`;
+  return `
+    <article>
+      <h3>${escapeHtml(key.name || key.key_prefix)}</h3>
+      <p>${escapeHtml(key.key_prefix)} · ${status} · created ${escapeHtml(shortDate(key.created_at))}${lastUsed}</p>
+      ${revoke}
+    </article>
+  `;
+}
+
+function shortDate(value: string | Date): string {
+  return value instanceof Date ? value.toISOString().slice(0, 10) : String(value).slice(0, 10);
+}
+
 function page(title: string, body: string): string {
   return `<!doctype html>
 <html lang="en">
@@ -96,7 +231,8 @@ function page(title: string, body: string): string {
   <style>
     :root { color-scheme: light; }
     * { box-sizing: border-box; }
-    body { font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 0; color: #151515; background: #f7f7f4; }
+    [hidden] { display: none !important; }
+    body { font-family: Charter, "Iowan Old Style", Georgia, serif; margin: 0; color: #1d211b; background: #f4f1ea; }
     main { max-width: 840px; margin: 0 auto; padding: 40px 20px; }
     form, article, .auth-panel { background: white; border: 1px solid #ddd; border-radius: 8px; padding: 16px; margin: 16px 0; }
     input, button { display: block; width: 100%; margin-top: 8px; padding: 10px; font: inherit; }
@@ -106,87 +242,272 @@ function page(title: string, body: string): string {
     label { display: block; margin-top: 14px; font-weight: 600; }
     input { border: 1px solid #bdbdb8; border-radius: 6px; background: #fff; }
     code { display: block; overflow-wrap: anywhere; background: #f1f1ec; padding: 8px; border-radius: 6px; }
-    .auth-shell { min-height: 100vh; display: grid; place-items: center; padding: 28px; }
-    .auth-card { width: min(440px, 100%); }
-    .brand { display: flex; align-items: center; gap: 10px; margin-bottom: 22px; }
-    .mark { width: 32px; height: 32px; border-radius: 7px; background: #111; color: white; display: grid; place-items: center; font-weight: 800; }
-    .eyebrow { margin: 0; color: #696a61; font-size: 14px; }
-    .title { margin: 4px 0 0; font-size: 28px; line-height: 1.1; }
-    .tabs { display: grid; grid-template-columns: 1fr 1fr; gap: 6px; padding: 4px; background: #eef0ea; border-radius: 8px; margin: 18px 0; }
-    .tabs button { width: 100%; margin: 0; background: transparent; color: #333; }
-    .tabs button.active { background: white; color: #111; box-shadow: 0 1px 2px rgba(0,0,0,.08); }
-    .actions { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-top: 18px; }
-    .link-button { background: transparent; color: #3758c8; padding: 0; margin: 0; border: 0; width: auto; }
-    .alert { display: none; margin-top: 14px; padding: 10px 12px; border-radius: 6px; background: #fff2d8; color: #5d3d00; }
-    .alert.error { background: #ffe5e2; color: #7a1f13; }
+    .auth-page {
+      min-height: 100vh;
+      max-width: none;
+      padding: clamp(18px, 4vw, 48px);
+      display: grid;
+      place-items: center;
+      background:
+        linear-gradient(90deg, rgba(29,33,27,.045) 1px, transparent 1px) 0 0 / 28px 28px,
+        linear-gradient(180deg, rgba(29,33,27,.035) 1px, transparent 1px) 0 0 / 28px 28px,
+        radial-gradient(circle at 18% 14%, rgba(34,78,91,.16), transparent 28%),
+        radial-gradient(circle at 90% 82%, rgba(174,80,42,.12), transparent 30%),
+        #f4f1ea;
+    }
+    .auth-layout {
+      width: min(1040px, 100%);
+      min-height: min(720px, calc(100vh - 48px));
+      display: grid;
+      grid-template-columns: minmax(0, 1.08fr) minmax(360px, .92fr);
+      border: 1px solid rgba(29,33,27,.16);
+      border-radius: 8px;
+      overflow: hidden;
+      background: rgba(253,252,247,.9);
+      box-shadow: 0 28px 80px rgba(29,33,27,.18);
+    }
+    .auth-story {
+      position: relative;
+      padding: clamp(28px, 5vw, 64px);
+      color: #f8f2e5;
+      background:
+        linear-gradient(145deg, rgba(8,13,12,.86), rgba(20,45,45,.76)),
+        linear-gradient(90deg, rgba(231,168,74,.28) 0 1px, transparent 1px 24px),
+        #162a2a;
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      isolation: isolate;
+    }
+    .auth-story::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background:
+        linear-gradient(120deg, transparent 0 18%, rgba(238,219,174,.15) 18% 18.4%, transparent 18.4% 100%),
+        repeating-linear-gradient(0deg, rgba(255,255,255,.055) 0 1px, transparent 1px 12px);
+      mix-blend-mode: screen;
+      pointer-events: none;
+      z-index: -1;
+    }
+    .brand { display: flex; align-items: center; gap: 12px; margin: 0; }
+    .mark {
+      width: 38px;
+      height: 38px;
+      border-radius: 8px;
+      background: #e5b657;
+      color: #142126;
+      display: grid;
+      place-items: center;
+      font: 900 20px/1 ui-serif, Georgia, serif;
+      box-shadow: inset 0 -2px 0 rgba(20,33,38,.18);
+    }
+    .brand-word { margin: 0; font: 700 17px/1.1 ui-serif, Georgia, serif; letter-spacing: 0; }
+    .story-kicker, .eyebrow { margin: 0; color: #6d766c; font: 700 12px/1.4 ui-sans-serif, system-ui, sans-serif; letter-spacing: .08em; text-transform: uppercase; }
+    .auth-story .story-kicker { color: rgba(248,242,229,.7); }
+    .story-title {
+      max-width: 9ch;
+      margin: 68px 0 0;
+      font-size: clamp(44px, 7vw, 78px);
+      line-height: .9;
+      letter-spacing: 0;
+    }
+    .story-copy { max-width: 440px; margin: 24px 0 0; color: rgba(248,242,229,.78); font: 18px/1.55 ui-sans-serif, system-ui, sans-serif; }
+    .auth-proof { display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; margin-top: 44px; }
+    .proof-item { border-top: 1px solid rgba(248,242,229,.28); padding-top: 12px; }
+    .proof-value { display: block; font: 700 20px/1.1 ui-serif, Georgia, serif; }
+    .proof-label { display: block; margin-top: 4px; color: rgba(248,242,229,.66); font: 12px/1.35 ui-sans-serif, system-ui, sans-serif; }
+    .auth-form-panel { padding: clamp(26px, 5vw, 58px); display: flex; flex-direction: column; justify-content: center; background: #fbfaf6; }
+    .title { margin: 8px 0 0; font-size: clamp(32px, 4vw, 48px); line-height: .98; letter-spacing: 0; }
+    .subtitle { margin: 14px 0 0; color: #596154; font: 15px/1.6 ui-sans-serif, system-ui, sans-serif; }
+    .auth-panel { margin: 28px 0 0; padding: 0; border: 0; background: transparent; }
+    .tabs { display: grid; grid-template-columns: 1fr 1fr; gap: 4px; padding: 4px; background: #e7e2d5; border-radius: 8px; margin: 0 0 22px; }
+    .tabs button { width: 100%; margin: 0; min-height: 42px; background: transparent; color: #4c554b; font: 700 14px/1 ui-sans-serif, system-ui, sans-serif; }
+    .tabs button.active { background: #fbfaf6; color: #162a2a; box-shadow: 0 1px 4px rgba(29,33,27,.14); }
+    .social-action {
+      width: 100%;
+      min-height: 48px;
+      margin: 0 0 16px;
+      border: 1px solid #c8c1b4;
+      border-radius: 8px;
+      background: #fffefb;
+      color: #1d211b;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 10px;
+      font: 800 14px/1 ui-sans-serif, system-ui, sans-serif;
+      box-shadow: 0 8px 18px rgba(29,33,27,.08);
+      transition: border-color .18s ease, transform .18s ease, box-shadow .18s ease;
+    }
+    .social-action:hover { transform: translateY(-1px); border-color: #245c63; box-shadow: 0 12px 24px rgba(29,33,27,.12); }
+    .google-mark { width: 18px; height: 18px; display: inline-block; }
+    .auth-divider { display: flex; align-items: center; gap: 10px; margin: 0 0 16px; color: #858a80; font: 700 11px/1 ui-sans-serif, system-ui, sans-serif; letter-spacing: .08em; text-transform: uppercase; }
+    .auth-divider::before, .auth-divider::after { content: ""; height: 1px; flex: 1; background: #ded8cb; }
+    .field { margin-top: 15px; color: #2f352d; font: 700 13px/1.35 ui-sans-serif, system-ui, sans-serif; }
+    .field input {
+      min-height: 48px;
+      margin-top: 7px;
+      padding: 12px 13px;
+      border: 1px solid #c8c1b4;
+      border-radius: 8px;
+      background: #fffefb;
+      color: #1d211b;
+      font: 16px/1.3 ui-sans-serif, system-ui, sans-serif;
+      outline: none;
+      transition: border-color .18s ease, box-shadow .18s ease, background .18s ease;
+    }
+    .field input:focus { border-color: #245c63; box-shadow: 0 0 0 4px rgba(36,92,99,.14); background: #fff; }
+    .field-note { margin: 7px 0 0; color: #747b70; font: 12px/1.45 ui-sans-serif, system-ui, sans-serif; }
+    .actions { display: grid; grid-template-columns: 1fr auto; align-items: center; gap: 14px; margin-top: 22px; }
+    .primary-action {
+      width: 100%;
+      min-height: 48px;
+      margin: 0;
+      border-radius: 8px;
+      background: #162a2a;
+      color: #fff8e8;
+      font: 800 15px/1 ui-sans-serif, system-ui, sans-serif;
+      box-shadow: 0 12px 26px rgba(22,42,42,.22);
+      transition: transform .18s ease, box-shadow .18s ease, background .18s ease;
+    }
+    .primary-action:hover { transform: translateY(-1px); background: #224e5b; box-shadow: 0 16px 32px rgba(22,42,42,.25); }
+    .primary-action:disabled { transform: none; box-shadow: none; }
+    .link-button { background: transparent; color: #7a432e; padding: 0; margin: 0; border: 0; width: auto; font: 700 13px/1.2 ui-sans-serif, system-ui, sans-serif; text-align: right; }
+    .alert { display: none; margin-top: 16px; padding: 12px 13px; border-radius: 8px; background: #fff1cd; color: #66450a; font: 14px/1.45 ui-sans-serif, system-ui, sans-serif; }
+    .alert.error { background: #ffe9e0; color: #7a2518; }
+    .cli-note {
+      display: none;
+      margin: 18px 0 0;
+      padding: 12px 13px;
+      border: 1px solid rgba(36,92,99,.22);
+      border-radius: 8px;
+      background: #eef6f1;
+      color: #254137;
+      font: 13px/1.45 ui-sans-serif, system-ui, sans-serif;
+    }
+    .cli-note.is-visible { display: block; }
+    .auth-footnote { margin: 22px 0 0; color: #71786e; font: 12px/1.55 ui-sans-serif, system-ui, sans-serif; }
     .notice, .success { margin-top: 14px; padding: 12px; border-radius: 6px; }
     .notice.success, .success { background: #e8f5ee; color: #163f2a; }
     .notice.warning { background: #fff2d8; color: #5d3d00; }
     .success { display: none; }
+    .success code { margin-top: 8px; background: #d9eee3; color: #163f2a; font: 700 20px/1.2 ui-monospace, SFMono-Regular, Menlo, monospace; letter-spacing: .08em; text-align: center; }
+    @media (max-width: 820px) {
+      .auth-page { padding: 0; place-items: stretch; }
+      .auth-layout { min-height: 100vh; grid-template-columns: 1fr; border: 0; border-radius: 0; }
+      .auth-story { min-height: 260px; padding: 28px; }
+      .story-title { max-width: 11ch; margin-top: 44px; font-size: clamp(40px, 13vw, 62px); }
+      .story-copy { font-size: 15px; }
+      .auth-proof { grid-template-columns: 1fr 1fr 1fr; margin-top: 28px; }
+      .proof-value { font-size: 17px; }
+      .auth-form-panel { padding: 28px; justify-content: start; }
+    }
+    @media (max-width: 480px) {
+      .auth-proof { display: none; }
+      .actions { grid-template-columns: 1fr; }
+      .link-button { text-align: left; }
+    }
   </style>
 </head>
 <body>${body}</body>
 </html>`;
 }
 
-function loginPage(cliSession: string): string {
+function loginPage(cliSession: string, neonAuthBaseUrl: string): string {
   return `
-    <main class="auth-shell">
-      <section class="auth-card">
-        <div class="brand">
-          <div class="mark">G</div>
+    <main class="auth-page">
+      <section class="auth-layout" aria-label="Granite Cloud authentication">
+        <div class="auth-story" aria-hidden="true">
+          <div class="brand">
+            <div class="mark">G</div>
+            <p class="brand-word">Granite Cloud</p>
+          </div>
           <div>
-            <p class="eyebrow">Granite Cloud</p>
-            <h1 class="title">Sign in</h1>
+            <p class="story-kicker">Private MCP vaults</p>
+            <h1 class="story-title">Local knowledge, hosted carefully.</h1>
+            <p class="story-copy">Sign in to manage paid cloud vaults, import markdown archives, and connect Granite to remote MCP clients without giving up explicit vault boundaries.</p>
+          </div>
+          <div class="auth-proof">
+            <span class="proof-item"><span class="proof-value">R2</span><span class="proof-label">vault storage</span></span>
+            <span class="proof-item"><span class="proof-value">DO</span><span class="proof-label">per-vault runtime</span></span>
+            <span class="proof-item"><span class="proof-value">MCP</span><span class="proof-label">private endpoint</span></span>
           </div>
         </div>
-        <div class="auth-panel">
+        <div class="auth-form-panel">
+          <p class="eyebrow">Granite Cloud</p>
+          <h2 class="title" id="auth-title">Sign in</h2>
+          <p class="subtitle">Use your email and password. Accounts are backed by Neon Auth's Better Auth email/password flow.</p>
+          <div id="cli-note" class="cli-note">After signing in, paste the verification code shown here back into the Granite CLI.</div>
+          <div class="auth-panel">
           <div class="tabs" role="tablist" aria-label="Auth mode">
             <button id="tab-signin" class="active" type="button" role="tab" aria-selected="true" aria-controls="auth-form">Sign in</button>
             <button id="tab-signup" type="button" role="tab" aria-selected="false" aria-controls="auth-form" tabindex="-1">Create account</button>
           </div>
-          <form id="auth-form">
-            <label id="name-label" hidden>Name
-              <input id="name" name="name" autocomplete="name">
+          <button id="google-auth" class="social-action" type="button">
+            <svg class="google-mark" viewBox="0 0 18 18" aria-hidden="true">
+              <path fill="#4285f4" d="M17.64 9.2c0-.64-.06-1.25-.16-1.84H9v3.48h4.84a4.14 4.14 0 0 1-1.8 2.72v2.26h2.91c1.7-1.57 2.69-3.88 2.69-6.62z"/>
+              <path fill="#34a853" d="M9 18c2.43 0 4.47-.8 5.96-2.18l-2.91-2.26c-.8.54-1.83.86-3.05.86-2.34 0-4.32-1.58-5.03-3.71H.96v2.33A9 9 0 0 0 9 18z"/>
+              <path fill="#fbbc05" d="M3.97 10.71A5.41 5.41 0 0 1 3.69 9c0-.59.1-1.16.28-1.71V4.96H.96A9 9 0 0 0 0 9c0 1.45.35 2.82.96 4.04l3.01-2.33z"/>
+              <path fill="#ea4335" d="M9 3.58c1.32 0 2.51.45 3.44 1.35l2.58-2.58C13.46.9 11.42 0 9 0A9 9 0 0 0 .96 4.96l3.01 2.33C4.68 5.16 6.66 3.58 9 3.58z"/>
+            </svg>
+            Continue with Google
+          </button>
+          <div class="auth-divider">or use email</div>
+          <form id="auth-form" aria-labelledby="auth-title">
+            <label id="name-label" class="field" hidden>Name
+              <input id="name" name="name" autocomplete="name" placeholder="Ada Lovelace">
             </label>
-            <label>Email
-              <input id="email" name="email" type="email" autocomplete="email" required>
+            <label class="field">Email
+              <input id="email" name="email" type="email" autocomplete="email" inputmode="email" placeholder="you@company.com" required>
             </label>
-            <label>Password
-              <input id="password" name="password" type="password" autocomplete="current-password" required>
+            <label class="field">Password
+              <input id="password" name="password" type="password" autocomplete="current-password" placeholder="At least 8 characters" required>
             </label>
+            <p id="password-note" class="field-note" hidden>Better Auth requires a password of at least 8 characters for new accounts.</p>
             <div class="actions">
-              <button id="submit" type="submit">Sign in</button>
+              <button id="submit" class="primary-action" type="submit">Sign in</button>
               <button id="reset" class="link-button" type="button">Reset password</button>
             </div>
             <p id="alert" class="alert" role="alert"></p>
             <div id="success" class="success" role="status" aria-live="polite"></div>
           </form>
         </div>
+          <p class="auth-footnote">Passwords and reset emails are handled by the configured Neon Auth project. Granite stores only the resulting web session and API-key metadata.</p>
+        </div>
       </section>
     </main>
     <script>
       const cliSession = ${scriptJson(cliSession)};
+      const neonAuthBaseUrl = ${scriptJson(neonAuthBaseUrl)};
       let mode = 'signin';
+      const authTitle = document.getElementById('auth-title');
       const form = document.getElementById('auth-form');
       const tabSignin = document.getElementById('tab-signin');
       const tabSignup = document.getElementById('tab-signup');
+      const googleAuth = document.getElementById('google-auth');
+      const cliNote = document.getElementById('cli-note');
       const nameLabel = document.getElementById('name-label');
       const nameInput = document.getElementById('name');
       const emailInput = document.getElementById('email');
       const passwordInput = document.getElementById('password');
+      const passwordNote = document.getElementById('password-note');
       const submit = document.getElementById('submit');
       const reset = document.getElementById('reset');
       const alertBox = document.getElementById('alert');
       const successBox = document.getElementById('success');
       const requiredNodes = [
+        authTitle,
         form,
         tabSignin,
         tabSignup,
+        googleAuth,
+        cliNote,
         nameLabel,
         nameInput,
         emailInput,
         passwordInput,
+        passwordNote,
         submit,
         reset,
         alertBox,
@@ -200,8 +521,11 @@ function loginPage(cliSession: string): string {
         tabSignup.addEventListener('click', () => setMode('signup'));
         tabSignin.addEventListener('keydown', handleTabKey);
         tabSignup.addEventListener('keydown', handleTabKey);
+        googleAuth.addEventListener('click', signInWithGoogle);
         reset.addEventListener('click', requestReset);
         form.addEventListener('submit', submitAuth);
+        cliNote.classList.toggle('is-visible', Boolean(cliSession));
+        if (!showOAuthCallbackError()) completeNeonRedirectSession();
       }
 
       function handleTabKey(event) {
@@ -225,6 +549,8 @@ function loginPage(cliSession: string): string {
         nameInput.required = signup;
         passwordInput.autocomplete = signup ? 'new-password' : 'current-password';
         passwordInput.minLength = signup ? 8 : 0;
+        passwordNote.hidden = !signup;
+        authTitle.textContent = signup ? 'Create account' : 'Sign in';
         submit.textContent = signup ? 'Create account' : 'Sign in';
         clearMessage();
       }
@@ -273,6 +599,98 @@ function loginPage(cliSession: string): string {
         }
       }
 
+      async function signInWithGoogle() {
+        clearMessage();
+        if (!neonAuthBaseUrl) return showError('Google sign-in is not configured.');
+        googleAuth.disabled = true;
+        try {
+          const authUrl = trimTrailingSlash(neonAuthBaseUrl) + '/sign-in/social';
+          const response = await fetch(authUrl, {
+            method: 'POST',
+            credentials: 'include',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              provider: 'google',
+              callbackURL: cleanAuthCallbackPath(),
+              errorCallbackURL: '/app/login',
+              newUserCallbackURL: cleanAuthCallbackPath()
+            })
+          });
+          if (!response.ok) throw new Error(await errorMessage(response));
+          const body = await response.json();
+          if (body && body.url) {
+            window.location.assign(body.url);
+            return;
+          }
+          throw new Error('Google sign-in did not return a redirect URL.');
+        } catch (error) {
+          googleAuth.disabled = false;
+          showError(error instanceof Error ? error.message : String(error));
+        }
+      }
+
+      async function completeNeonRedirectSession() {
+        if (!neonAuthBaseUrl) return;
+        try {
+          const hasVerifier = new URLSearchParams(window.location.search).has('neon_auth_session_verifier');
+          const tokenResponse = await fetch(neonSessionUrl(), {
+            credentials: 'include',
+            headers: { Accept: 'application/json' }
+          });
+          if (!tokenResponse.ok) {
+            if (hasVerifier) throw new Error(await errorMessage(tokenResponse));
+            return;
+          }
+          const token = tokenResponse.headers.get('set-auth-jwt') || await tokenFromJson(tokenResponse.clone());
+          if (!token) {
+            if (hasVerifier) throw new Error('Could not establish a Google session. Please try again.');
+            return;
+          }
+          const graniteResponse = await fetch('/auth/neon/session', {
+            method: 'POST',
+            credentials: 'include',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ token, cli_session: cliSession })
+          });
+          if (!graniteResponse.ok) throw new Error(await errorMessage(graniteResponse));
+          if (cliSession) {
+            const cli = await graniteResponse.json();
+            if (cli.cli_expired) {
+              showError('CLI login session expired. Run granite cloud login again.');
+              return;
+            }
+            if (cli.verification_code) {
+              successBox.style.display = 'block';
+              successBox.innerHTML = '<strong>CLI verification code</strong><code>' + escapeHtml(cli.verification_code) + '</code>';
+              return;
+            }
+          }
+          clearAuthCallbackParams();
+          window.location.assign('/app');
+        } catch (error) {
+          showError(error instanceof Error ? error.message : String(error));
+        }
+      }
+
+      function showOAuthCallbackError() {
+        const params = new URLSearchParams(window.location.search);
+        if (!params.has('error') && !params.has('error_description')) return false;
+        const description = params.get('error_description') || params.get('error') || 'Google sign-in failed.';
+        showError('Google sign-in failed: ' + description);
+        clearAuthCallbackParams();
+        return true;
+      }
+
+      async function tokenFromJson(response) {
+        try {
+          const body = await response.json();
+          for (const key of ['token', 'jwt', 'accessToken', 'access_token']) {
+            if (body && typeof body[key] === 'string' && body[key]) return body[key];
+          }
+        } catch {}
+        return '';
+      }
+
       async function requestReset() {
         clearMessage();
         if (!emailInput.value.trim()) return showError('Enter your email first.');
@@ -316,6 +734,33 @@ function loginPage(cliSession: string): string {
         successBox.style.display = 'none';
       }
 
+      function trimTrailingSlash(value) {
+        return String(value).replace(/\\/+$/, '');
+      }
+
+      function neonSessionUrl() {
+        const base = trimTrailingSlash(neonAuthBaseUrl);
+        const verifier = new URLSearchParams(window.location.search).get('neon_auth_session_verifier');
+        if (!verifier) return base + '/token';
+        return base + '/get-session?neon_auth_session_verifier=' + encodeURIComponent(verifier);
+      }
+
+      function cleanAuthCallbackPath() {
+        const url = new URL(window.location.href);
+        url.searchParams.delete('neon_auth_session_verifier');
+        url.searchParams.delete('error');
+        url.searchParams.delete('error_description');
+        return url.pathname + url.search;
+      }
+
+      function clearAuthCallbackParams() {
+        const url = new URL(window.location.href);
+        url.searchParams.delete('neon_auth_session_verifier');
+        url.searchParams.delete('error');
+        url.searchParams.delete('error_description');
+        window.history.replaceState({}, '', url.pathname + url.search);
+      }
+
       function showError(message) {
         alertBox.className = 'alert error';
         alertBox.textContent = message;
@@ -337,6 +782,10 @@ function loginPage(cliSession: string): string {
 
 function safeName(value: string | undefined): string {
   return (value?.trim() || 'Cloud Vault').slice(0, 100);
+}
+
+function safeKeyName(value: string | undefined): string {
+  return (value?.trim() || 'mcp-client').slice(0, 80);
 }
 
 function escapeHtml(value: string): string {

--- a/test/cloudflare-mcp/worker.test.ts
+++ b/test/cloudflare-mcp/worker.test.ts
@@ -21,11 +21,15 @@ describe('granite cloudflare worker routes', () => {
     expect(response.status).toBe(200);
     expect(html).toContain('Granite Cloud');
     expect(html).toContain('Create account');
+    expect(html).toContain('Continue with Google');
+    expect(html).toContain('https://neon.test/auth');
     expect(html).toContain('Reset password');
     expect(html).toContain('cli_1');
     expect(html).toContain('role="status" aria-live="polite"');
     expect(html).toContain('role="tablist"');
     expect(html).toContain('role="tab"');
+    expect(html).toContain('/get-session?neon_auth_session_verifier=');
+    expect(html).toContain('showOAuthCallbackError');
     expect(html).not.toContain('Neon Auth JWT');
     expect(html).not.toContain('<textarea');
   });
@@ -52,7 +56,67 @@ describe('granite cloudflare worker routes', () => {
 
     expect(response.status).toBe(200);
     expect(html).toContain('https://granite.test/mcp?vault_id=v_a');
+    expect(html).toContain('API keys');
+    expect(html).toContain('Create API key');
+    expect(html).toContain('gsk_existing');
+    expect(html).toContain('created 2026-05-14');
+    expect(html).toContain('last used 2026-05-14');
+    expect(html).toContain('Revoke this API key?');
     expect(html).not.toContain('https://granite.thevibecompany.co/mcp?vault_id=v_a');
+  });
+
+  it('creates dashboard API keys for MCP clients', async () => {
+    const { env, apiKeyInserts } = await createEnv();
+
+    const response = await fetchWorker(env, new Request('https://granite.test/app/keys', {
+      method: 'POST',
+      headers: {
+        Cookie: 'granite_session=session_1',
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: new URLSearchParams({ name: 'cursor' }),
+    }));
+
+    const html = await response.text();
+
+    expect(response.status).toBe(201);
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+    expect(response.headers.get('Referrer-Policy')).toBe('no-referrer');
+    expect(response.headers.get('Location')).toBeNull();
+    expect(html).toContain('API key created for cursor');
+    expect(html).toContain('gsk_');
+    expect(html).toContain('Back to dashboard');
+    expect(apiKeyInserts).toHaveLength(1);
+    expect(apiKeyInserts[0]?.[1]).toBe('u_1');
+    expect(apiKeyInserts[0]?.[2]).toMatch(/^gsk_/);
+    expect(apiKeyInserts[0]?.[3]).toBe('cursor');
+    expect(apiKeyInserts[0]?.[0]).not.toBe(apiKeyInserts[0]?.[2]);
+  });
+
+  it('redirects unauthenticated dashboard API key writes to login', async () => {
+    const { env } = await createEnv();
+
+    const response = await fetchWorker(env, new Request('https://granite.test/app/keys', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({ name: 'cursor' }),
+    }));
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get('Location')).toBe('/app/login');
+  });
+
+  it('revokes dashboard API keys from the signed-in dashboard', async () => {
+    const { env, dashboardRevocations } = await createEnv();
+
+    const response = await fetchWorker(env, new Request('https://granite.test/app/keys/gsk_existing/revoke', {
+      method: 'POST',
+      headers: { Cookie: 'granite_session=session_1' },
+    }));
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get('Location')).toBe('/app');
+    expect(dashboardRevocations).toEqual([['u_1', 'gsk_existing']]);
   });
 
   it('renders checkout return state messages on the dashboard', async () => {
@@ -67,6 +131,45 @@ describe('granite cloudflare worker routes', () => {
 
     await expect(success.text()).resolves.toContain('Checkout complete');
     await expect(canceled.text()).resolves.toContain('Checkout was canceled');
+  });
+
+  it('syncs a successful checkout return before rendering vault status', async () => {
+    const { env } = await createEnv();
+
+    const response = await fetchWorker(env, new Request('https://granite.test/app?vault_id=v_pending&checkout=success', {
+      headers: { Cookie: 'granite_session=session_1' },
+    }));
+    const html = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(html).toContain('Checkout complete. Your vault is active.');
+    expect(html).toContain('v_pending · active');
+  });
+
+  it('keeps checkout returns pending when Stripe has no active subscription', async () => {
+    const { env } = await createEnv({ checkoutSyncStatus: 'pending_checkout' });
+
+    const response = await fetchWorker(env, new Request('https://granite.test/app?vault_id=v_pending&checkout=success', {
+      headers: { Cookie: 'granite_session=session_1' },
+    }));
+    const html = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(html).toContain('will become writable as soon as Stripe confirms the subscription');
+    expect(html).toContain('v_pending · pending_checkout');
+  });
+
+  it('shows a dashboard warning when checkout return sync fails', async () => {
+    const { env } = await createEnv({ checkoutSyncThrows: true });
+
+    const response = await fetchWorker(env, new Request('https://granite.test/app?vault_id=v_pending&checkout=success', {
+      headers: { Cookie: 'granite_session=session_1' },
+    }));
+    const html = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(html).toContain('could not refresh billing yet');
+    expect(html).toContain('v_pending · pending_checkout');
   });
 
   it('generates CLI API keys only after verification succeeds', async () => {
@@ -365,9 +468,13 @@ async function createEnv(options: {
   cliLoginExpired?: boolean;
   cliConsumeSucceeds?: boolean;
   missingStripePrice?: boolean;
+  checkoutSyncStatus?: 'active' | 'past_due' | 'canceled' | 'unpaid' | 'pending_checkout';
+  checkoutSyncThrows?: boolean;
 } = {}) {
   const validHash = await hashApiKey('gsk_valid');
   const routedVaults: string[] = [];
+  const apiKeyInserts: unknown[][] = [];
+  const dashboardRevocations: unknown[][] = [];
   const user = {
     id: 'u_1',
     neon_user_id: 'neon_1',
@@ -414,13 +521,39 @@ async function createEnv(options: {
         seenEvents.add(id);
         return { event_id: id };
       }
+      if (sql.includes('UPDATE vaults') && sql.includes('RETURNING billing_status')) {
+        const vault = vaults.get(String(args[0]));
+        if (!vault || args[1] !== user.id || args[6] !== vault.stripe_checkout_session_id) return null;
+        vault.billing_status = args[2] as any;
+        vault.stripe_subscription_id = args[3] as any;
+        vault.cancel_at_period_end = Boolean(args[5]);
+        vault.activated_at = vault.billing_status === 'active' ? '2026-05-14T00:00:00.000Z' : vault.activated_at;
+        return { billing_status: vault.billing_status };
+      }
       return null;
     },
     async query(sql: string, args: unknown[] = []) {
       if (sql.includes('FROM vaults') && sql.includes('WHERE user_id = $1')) {
         return [...vaults.values()].filter(v => v.user_id === args[0]);
       }
-      if (sql.includes('FROM api_keys')) return [];
+      if (sql.includes('FROM api_keys')) {
+        return [
+          {
+            key_prefix: 'gsk_existing',
+            name: 'cursor',
+            created_at: new Date('2026-05-14T00:00:00.000Z'),
+            last_used_at: '2026-05-14T01:02:03.000Z',
+            revoked_at: null,
+          },
+          {
+            key_prefix: 'gsk_revoked',
+            name: 'old client',
+            created_at: '2026-05-13T00:00:00.000Z',
+            last_used_at: null,
+            revoked_at: '2026-05-14T00:00:00.000Z',
+          },
+        ];
+      }
       return [];
     },
     async execute(sql: string, args: unknown[] = []) {
@@ -429,7 +562,12 @@ async function createEnv(options: {
         vaults.set(vaultId, vaultRow(vaultId, String(args[1]), 'pending_checkout'));
         return { rowCount: 1 };
       }
+      if (sql.includes('INSERT INTO api_keys')) {
+        apiKeyInserts.push(args);
+        return { rowCount: 1 };
+      }
       if (sql.includes('SET revoked_at')) {
+        dashboardRevocations.push(args);
         return { rowCount: options.revokeChanges ?? 1 };
       }
       if (sql.includes('UPDATE vaults') && sql.includes("billing_status = 'active'")) {
@@ -447,6 +585,15 @@ async function createEnv(options: {
       async createCustomer() { return 'cus_1'; },
       async createVaultCheckout() { return { id: 'cs_1', url: 'https://stripe.test/checkout' }; },
       async createPortal() { return { url: 'https://stripe.test/portal' }; },
+      async syncCheckoutSession() {
+        if (options.checkoutSyncThrows) throw new Error('Stripe unavailable');
+        return {
+          billingStatus: options.checkoutSyncStatus ?? 'active',
+          subscriptionId: options.checkoutSyncStatus === 'pending_checkout' ? null : 'sub_1',
+          currentPeriodEnd: 1798761600,
+          cancelAtPeriodEnd: false,
+        };
+      },
       async parseWebhook() {
         return { id: 'evt_1', type: 'checkout.session.completed', data: { object: { metadata: { granite_vault_id: 'v_a' }, subscription: 'sub_1' } } };
       },
@@ -473,12 +620,14 @@ async function createEnv(options: {
     },
     VAULT_BUCKET: {},
     BASE_URL: 'https://granite.test',
+    NEON_AUTH_BASE_URL: 'https://neon.test/auth',
     NEON_AUTH_JWKS_URL: 'https://neon.test/jwks.json',
     STRIPE_VAULT_1GB_PRICE_ID: options.missingStripePrice ? undefined : 'price_1gb',
   };
 
-  return { env: env as any, routedVaults };
+  return { env: env as any, routedVaults, apiKeyInserts, dashboardRevocations };
 }
+
 
 function vaultRow(vaultId: string, userId: string, status: string) {
   return {
@@ -487,7 +636,7 @@ function vaultRow(vaultId: string, userId: string, status: string) {
     vault_name: vaultId,
     billing_status: status,
     stripe_subscription_id: null,
-    stripe_checkout_session_id: null,
+    stripe_checkout_session_id: `cs_${vaultId}`,
     stripe_price_id: 'price_1gb',
     current_period_end: null,
     cancel_at_period_end: false,


### PR DESCRIPTION
## Summary
- polish the Granite Cloud login page and add Google sign-in through the Neon Auth Better Auth social flow
- add dashboard API key creation/revocation without putting one-time keys in URLs
- sync Stripe Checkout returns before dashboard render and preserve Cloudflare dashboard vars during deploys

## Verification
- npm run lint
- cd packages/cloudflare-mcp && npm run lint
- npx vitest run test/cloudflare-mcp/worker.test.ts test/cloudflare-mcp/runtime.test.ts test/cloudflare-mcp/mcp.test.ts test/commands/cloud.test.ts
- deployed Worker version b685265a-9daa-45a3-899a-a5706e5e166a and smoke tested /health, /app, /app/login, unauthenticated /mcp, authenticated cloud status/vault/list/search, and MCP initialize

## Notes
- /run-review was executed and the reported URL API-key leak was fixed.
- Impeccable audit: product UI pass with notes; remaining polish is mostly tokenization/design-system cleanup, no release blocker.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves Granite Cloud auth and dashboard: adds Google sign-in and smoother CLI login, plus dashboard API key create/revoke. The dashboard now syncs Stripe checkout before rendering vaults, and deploys preserve Cloudflare dashboard env vars.

- **New Features**
  - Login: polished UI and Google sign-in via Neon Auth (Better Auth). Handles OAuth callback, creates a Granite session, and returns a CLI verification code when `cli_session` is provided.
  - API keys: create and revoke from `/app`. The new key is shown once on a confirmation page (not in URLs). Dashboard lists key prefixes, status, and usage. Server stores a hash and prefix only.
  - Billing: on `/app?checkout=success&vault_id=...`, syncs the Stripe Checkout session and updates vault status. Shows clear success, pending, or failure messages.

- **Migration**
  - `packages/cloudflare-mcp` deploy uses `wrangler deploy --keep-vars` to preserve Cloudflare dashboard-managed env vars. Update any CI scripts that call deploy directly.

<sup>Written for commit 8d71dea87e718eac4e08fa95e4676a9ef7533676. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

