### PR TITLE
feat(sync): add readonly vault access control

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,10 +183,17 @@ Granite sync is direct machine-to-machine. Run it over LAN, Tailscale, or a priv
 
 ```bash
 # Machine A
+granite sync access grant ipad --role read
+granite sync access grant desktop --role write
 granite sync serve --host 0.0.0.0 --port 8765
 
-# Machine B
-granite sync remote add macbook http://100.x.y.z:8765 --token <machine-a-token>
+# Read-only Machine B
+granite sync remote add macbook http://100.x.y.z:8765 --token <read-token>
+granite sync pull macbook
+granite sync watch macbook --direction pull --interval 30
+
+# Write-capable Machine C
+granite sync remote add macbook http://100.x.y.z:8765 --token <write-token>
 granite sync run macbook
 granite sync watch macbook --interval 30
 ```
@@ -195,6 +202,13 @@ Conflicts default to manual preservation with `.conflict.<device>.<timestamp>.md
 
 ```bash
 granite sync config --policy primary-wins --primary-this-device
+```
+
+MCP is scoped to one vault per server. Launch a read-only MCP server when an agent should inspect a synced vault without mutating it:
+
+```bash
+granite mcp --vault ~/.granite --role read
+granite mcp --vault ~/.granite --role write
 ```
 
 For the full CLI, run `granite --help`. For development, see [CLAUDE.md](CLAUDE.md).

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { spawn } from 'node:child_process';
 import { requireVaultRoot, getGraniteDir } from '../core/vault.js';
 import { startGraniteMcpHttpServer, startGraniteMcpStdioServer } from '../mcp/server.js';
+import type { McpAccessRole } from '../mcp/server.js';
 import { GraniteMcpRuntime } from '../mcp/runtime.js';
 
 interface McpCommandOptions {
@@ -13,6 +14,7 @@ interface McpCommandOptions {
   allowOrigin?: string[];
   jsonResponse?: boolean;
   background?: boolean;
+  role?: string;
 }
 
 // ---- PID / URL file helpers ------------------------------------------------
@@ -56,6 +58,7 @@ function cleanupFiles(vaultRoot: string): void {
 
 export async function mcpCommand(options: McpCommandOptions): Promise<void> {
   const transport = parseTransport(options.transport);
+  const role = parseMcpRole(options.role);
   const vaultRoot = resolveVaultRoot(options.vault);
 
   // --background: re-spawn ourselves as a detached child
@@ -120,6 +123,7 @@ export async function mcpCommand(options: McpCommandOptions): Promise<void> {
       port,
       allowedOrigins: options.allowOrigin ?? [],
       jsonResponse: options.jsonResponse ?? false,
+      role,
     });
 
     if (isDaemon) writeDaemonState(vaultRoot, process.pid, localUrl);
@@ -127,7 +131,7 @@ export async function mcpCommand(options: McpCommandOptions): Promise<void> {
     return;
   }
 
-  await startGraniteMcpStdioServer(runtime);
+  await startGraniteMcpStdioServer(runtime, { role });
 }
 
 export function mcpStopCommand(options: { vault?: string }): void {
@@ -185,4 +189,10 @@ export function parsePort(value?: string): number {
     throw new Error(`Invalid MCP port: ${raw}`);
   }
   return parsed;
+}
+
+export function parseMcpRole(value?: string): McpAccessRole {
+  const role = value ?? 'write';
+  if (role === 'read' || role === 'write') return role;
+  throw new Error(`Invalid MCP role: ${role}. Expected "read" or "write".`);
 }

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { Hono } from 'hono';
 import { serve } from '@hono/node-server';
+import type { ServerType } from '@hono/node-server';
 import { loadConfig } from '../core/config.js';
 import { openDatabase, rebuildIndex } from '../core/index-db.js';
 import { requireVaultRoot } from '../core/vault.js';
@@ -11,6 +12,7 @@ import {
   applyIncomingFile,
   buildSyncManifest,
   detectLocalDeletions,
+  grantSyncAccess,
   getSyncFileHash,
   getSyncStatePath,
   loadSyncState,
@@ -18,9 +20,12 @@ import {
   normalizeSyncPath,
   normalizeRemoteUrl,
   readSyncFilePayload,
+  resolveSyncAccessRole,
+  revokeSyncAccess,
   saveSyncState,
   setSyncConflictPolicy,
   suggestedRemoteName,
+  type SyncAccessRole,
   type SyncApplyAction,
   type SyncApplyResult,
   type SyncConflictPolicy,
@@ -61,6 +66,11 @@ interface SyncRemoteOptions extends CommonOptions {
 
 interface SyncWatchOptions extends CommonOptions {
   interval?: string;
+  direction?: string;
+}
+
+interface SyncAccessGrantOptions extends CommonOptions {
+  role?: string;
 }
 
 interface SyncSummary {
@@ -85,7 +95,8 @@ export function syncStatusCommand(options: CommonOptions = {}): void {
       state_file: getSyncStatePath(vaultRoot),
       device_id: state.device_id,
       device_name: state.device_name,
-      local_token: state.local_token,
+      local_token_hint: maskToken(state.local_token),
+      access_tokens: listSafeAccessTokens(state),
       conflict_policy: state.conflict_policy,
       primary_device_id: state.primary_device_id,
       remotes: state.remotes,
@@ -98,8 +109,9 @@ export function syncStatusCommand(options: CommonOptions = {}): void {
   console.log('Granite sync');
   console.log(`  Vault:          ${vaultRoot}`);
   console.log(`  Device:         ${state.device_name} (${state.device_id})`);
-  console.log(`  Token:          ${state.local_token}`);
+  console.log(`  Write token:    ${maskToken(getDefaultWriteGrant(state)?.token ?? '')}`);
   console.log(`  Policy:         ${formatPolicy(state)}`);
+  console.log(`  Access grants:  ${Object.keys(state.access_tokens).length}`);
   console.log(`  Files:          ${manifest.files.length}`);
   if (manifest.deletions.length > 0) {
     console.log(`  Pending deletes:${manifest.deletions.length}`);
@@ -167,6 +179,63 @@ export function syncRemoteListCommand(options: CommonOptions = {}): void {
   }
 }
 
+export function syncAccessListCommand(options: CommonOptions = {}): void {
+  const vaultRoot = resolveVaultRoot(options.vault);
+  const state = loadSyncState(vaultRoot);
+  const grants = listSafeAccessTokens(state);
+
+  if (options.json) {
+    console.log(jsonSuccess(grants));
+    return;
+  }
+
+  if (grants.length === 0) {
+    console.log('No sync access grants configured.');
+    return;
+  }
+
+  for (const grant of grants) {
+    console.log(`${grant.name}\t${grant.role}\t${grant.token_hint}\t${grant.created_at}`);
+  }
+}
+
+export function syncAccessGrantCommand(
+  name: string,
+  options: SyncAccessGrantOptions = {},
+): void {
+  const vaultRoot = resolveVaultRoot(options.vault);
+  const state = loadSyncState(vaultRoot);
+  const grant = grantSyncAccess(state, name, parseAccessRole(options.role));
+  saveSyncState(vaultRoot, state);
+
+  if (options.json) {
+    console.log(jsonSuccess(grant));
+    return;
+  }
+
+  console.log(`Granted ${grant.role} sync access "${grant.name}"`);
+  console.log(`Token: ${grant.token}`);
+}
+
+export function syncAccessRevokeCommand(name: string, options: CommonOptions = {}): void {
+  const vaultRoot = resolveVaultRoot(options.vault);
+  const state = loadSyncState(vaultRoot);
+
+  if (!revokeSyncAccess(state, name)) {
+    console.error(`Unknown sync access grant: ${name}`);
+    process.exit(1);
+  }
+
+  saveSyncState(vaultRoot, state);
+
+  if (options.json) {
+    console.log(jsonSuccess({ revoked: name }));
+    return;
+  }
+
+  console.log(`Revoked sync access "${name}"`);
+}
+
 export function syncRemoteAddCommand(
   nameOrAddress: string,
   addressMaybe?: string,
@@ -215,7 +284,7 @@ export function syncRemoteRemoveCommand(name: string, options: CommonOptions = {
   console.log(`Removed remote "${name}"`);
 }
 
-export function syncServeCommand(options: SyncServeOptions = {}): void {
+export function syncServeCommand(options: SyncServeOptions = {}): ServerType {
   const vaultRoot = resolveVaultRoot(options.vault);
   const state = loadSyncState(vaultRoot);
   const host = options.host ?? '0.0.0.0';
@@ -226,12 +295,16 @@ export function syncServeCommand(options: SyncServeOptions = {}): void {
   console.log(`  Vault:    ${vaultRoot}`);
   console.log(`  Device:   ${state.device_name} (${state.device_id})`);
   console.log(`  Listen:   http://${host}:${port}/sync`);
-  console.log(`  Token:    ${state.local_token}`);
+  console.log(`  Grants:   ${Object.keys(state.access_tokens).length}`);
   console.log('');
-  console.log('On the other machine:');
-  console.log(`  granite sync remote add ${state.device_name} http://<tailscale-ip-or-dns>:${port} --token ${state.local_token}`);
+  console.log('Create a token to share:');
+  console.log('  granite sync access grant <name> --role read   # pull-only replicas');
+  console.log('  granite sync access grant <name> --role write  # bidirectional sync');
+  console.log('');
+  console.log('Then on the other machine:');
+  console.log(`  granite sync remote add ${state.device_name} http://<tailscale-ip-or-dns>:${port} --token <token>`);
 
-  serve({ fetch: app.fetch, hostname: host, port });
+  return serve({ fetch: app.fetch, hostname: host, port });
 }
 
 export async function syncPullCommand(remoteName: string, options: SyncRemoteOptions = {}): Promise<SyncSummary> {
@@ -350,10 +423,15 @@ export async function syncRunCommand(remoteName: string, options: SyncRemoteOpti
 
 export async function syncWatchCommand(remoteName: string, options: SyncWatchOptions = {}): Promise<void> {
   const intervalSeconds = parsePort(options.interval, 30);
-  console.error(`Granite sync watch running every ${intervalSeconds}s for remote "${remoteName}".`);
+  const direction = parseWatchDirection(options.direction);
+  console.error(`Granite sync watch ${direction} running every ${intervalSeconds}s for remote "${remoteName}".`);
   while (true) {
     try {
-      await syncRunCommand(remoteName, { ...options, json: false });
+      if (direction === 'pull') {
+        await syncPullCommand(remoteName, { ...options, json: false });
+      } else {
+        await syncRunCommand(remoteName, { ...options, json: false });
+      }
     } catch (error) {
       console.error(`Sync failed: ${error instanceof Error ? error.message : String(error)}`);
     }
@@ -378,8 +456,12 @@ export function createSyncApp(vaultRoot: string): Hono {
   app.use('/sync/*', async (c, next) => {
     const state = loadSyncState(vaultRoot);
     const token = readBearerToken(c.req.header('authorization'));
-    if (!state.local_token || !token || token !== state.local_token) {
+    const role = resolveSyncAccessRole(state, token);
+    if (!role) {
       return c.json({ error: 'Unauthorized' }, 401);
+    }
+    if (c.req.method !== 'GET' && c.req.method !== 'HEAD' && role !== 'write') {
+      return c.json({ error: 'Forbidden: write sync access is required' }, 403);
     }
     await next();
   });
@@ -460,11 +542,52 @@ function parsePolicy(value: string): SyncConflictPolicy {
   throw new Error('Invalid sync policy. Expected manual or primary-wins.');
 }
 
+export function parseAccessRole(value?: string): SyncAccessRole {
+  const role = value ?? 'read';
+  if (role === 'read' || role === 'write') return role;
+  throw new Error('Invalid sync access role. Expected read or write.');
+}
+
+export function parseWatchDirection(value?: string): 'pull' | 'run' {
+  const direction = value ?? 'run';
+  if (direction === 'pull' || direction === 'run') return direction;
+  throw new Error('Invalid sync watch direction. Expected pull or run.');
+}
+
 function formatPolicy(state: SyncState): string {
   if (state.conflict_policy === 'primary_wins') {
     return `primary-wins (${state.primary_device_id})`;
   }
   return 'manual';
+}
+
+function listSafeAccessTokens(state: SyncState): Array<{
+  name: string;
+  role: SyncAccessRole;
+  created_at: string;
+  token_hint: string;
+}> {
+  return Object.values(state.access_tokens)
+    .map(grant => ({
+      name: grant.name,
+      role: grant.role,
+      created_at: grant.created_at,
+      token_hint: maskToken(grant.token),
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function getDefaultWriteGrant(state: SyncState): { token: string } | null {
+  const defaultGrant = state.access_tokens.default;
+  if (defaultGrant?.role === 'write') return defaultGrant;
+  return Object.values(state.access_tokens)
+    .find(grant => grant.role === 'write') ?? null;
+}
+
+function maskToken(token: string): string {
+  if (!token) return '(none)';
+  if (token.length <= 8) return '********';
+  return `${token.slice(0, 4)}...${token.slice(-4)}`;
 }
 
 function resolveRemote(state: SyncState, remoteName: string, tokenOverride?: string): SyncRemote {

--- a/src/core/sync.ts
+++ b/src/core/sync.ts
@@ -8,10 +8,18 @@ const SYNC_STATE_FILENAME = 'sync.json';
 const SYNC_PROTOCOL_VERSION = 1;
 
 export type SyncConflictPolicy = 'manual' | 'primary_wins';
+export type SyncAccessRole = 'read' | 'write';
 
 export interface SyncRemote {
   url: string;
   token?: string;
+}
+
+export interface SyncAccessToken {
+  name: string;
+  token: string;
+  role: SyncAccessRole;
+  created_at: string;
 }
 
 export interface SyncBaseline {
@@ -33,6 +41,7 @@ export interface SyncState {
   conflict_policy: SyncConflictPolicy;
   primary_device_id: string;
   remotes: Record<string, SyncRemote>;
+  access_tokens: Record<string, SyncAccessToken>;
   baselines: Record<string, SyncBaseline>;
   tombstones: Record<string, SyncTombstone>;
 }
@@ -116,14 +125,16 @@ export function loadSyncState(vaultRoot: string): SyncState {
     return state;
   }
   const deviceId = parsed.device_id || createDeviceId();
+  const localToken = parsed.local_token || createToken();
   const state: SyncState = {
     version: SYNC_PROTOCOL_VERSION,
     device_id: deviceId,
     device_name: parsed.device_name || os.hostname(),
-    local_token: parsed.local_token || createToken(),
+    local_token: localToken,
     conflict_policy: normalizeConflictPolicy(parsed.conflict_policy),
     primary_device_id: parsed.primary_device_id || deviceId,
     remotes: parsed.remotes ?? {},
+    access_tokens: normalizeAccessTokens(parsed.access_tokens, localToken),
     baselines: parsed.baselines ?? {},
     tombstones: parsed.tombstones ?? {},
   };
@@ -143,17 +154,62 @@ export function saveSyncState(vaultRoot: string, state: SyncState): void {
 
 export function createDefaultSyncState(): SyncState {
   const deviceId = createDeviceId();
+  const localToken = createToken();
   return {
     version: SYNC_PROTOCOL_VERSION,
     device_id: deviceId,
     device_name: os.hostname(),
-    local_token: createToken(),
+    local_token: localToken,
     conflict_policy: 'manual',
     primary_device_id: deviceId,
     remotes: {},
+    access_tokens: {
+      default: {
+        name: 'default',
+        token: localToken,
+        role: 'write',
+        created_at: new Date().toISOString(),
+      },
+    },
     baselines: {},
     tombstones: {},
   };
+}
+
+export function grantSyncAccess(
+  state: SyncState,
+  name: string,
+  role: SyncAccessRole,
+  now = new Date(),
+): SyncAccessToken {
+  const safeName = normalizeAccessName(name);
+  const grant: SyncAccessToken = {
+    name: safeName,
+    token: createToken(),
+    role,
+    created_at: now.toISOString(),
+  };
+  state.access_tokens[safeName] = grant;
+  return grant;
+}
+
+export function revokeSyncAccess(state: SyncState, name: string): boolean {
+  const safeName = normalizeAccessName(name);
+  if (!state.access_tokens[safeName]) {
+    return false;
+  }
+  delete state.access_tokens[safeName];
+  return true;
+}
+
+export function resolveSyncAccessRole(state: SyncState, token: string | null | undefined): SyncAccessRole | null {
+  if (!token) return null;
+
+  for (const grant of Object.values(state.access_tokens)) {
+    if (grant.token === token) return grant.role;
+  }
+
+  return null;
 }
 
 export function setSyncConflictPolicy(
@@ -514,6 +570,68 @@ function createToken(): string {
 
 function normalizeConflictPolicy(value: unknown): SyncConflictPolicy {
   return value === 'primary_wins' ? 'primary_wins' : 'manual';
+}
+
+function normalizeAccessTokens(
+  value: unknown,
+  localToken: string,
+): Record<string, SyncAccessToken> {
+  const grants: Record<string, SyncAccessToken> = {};
+  let shouldMigrateLocalToken = value === undefined;
+
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    const entries = Object.entries(value);
+    shouldMigrateLocalToken = true;
+    for (const [rawName, rawGrant] of entries) {
+      if (!rawGrant || typeof rawGrant !== 'object' || Array.isArray(rawGrant)) continue;
+      const grant = rawGrant as Partial<SyncAccessToken>;
+      const token = typeof grant.token === 'string' && grant.token ? grant.token : null;
+      if (!token) continue;
+      const name = normalizeOptionalAccessName(grant.name) ?? normalizeOptionalAccessName(rawName);
+      if (!name) continue;
+      grants[name] = {
+        name,
+        token,
+        role: normalizeAccessRole(grant.role),
+        created_at: typeof grant.created_at === 'string' && grant.created_at
+          ? grant.created_at
+          : new Date(0).toISOString(),
+      };
+      shouldMigrateLocalToken = false;
+    }
+  } else if (value !== undefined) {
+    shouldMigrateLocalToken = true;
+  }
+
+  if (shouldMigrateLocalToken && !Object.values(grants).some(grant => grant.token === localToken)) {
+    grants.default = {
+      name: 'default',
+      token: localToken,
+      role: 'write',
+      created_at: new Date(0).toISOString(),
+    };
+  }
+
+  return grants;
+}
+
+function normalizeAccessRole(value: unknown): SyncAccessRole {
+  return value === 'read' ? 'read' : 'write';
+}
+
+function normalizeAccessName(name: string): string {
+  const normalized = normalizeOptionalAccessName(name);
+  if (!normalized) {
+    throw new Error(`Invalid sync access name: ${name}`);
+  }
+  return normalized;
+}
+
+function normalizeOptionalAccessName(name: unknown): string | null {
+  if (typeof name !== 'string') return null;
+  const normalized = name.trim();
+  if (!/^[a-zA-Z0-9._-]+$/.test(normalized)) return null;
+  return normalized;
 }
 
 function preserveCorruptSyncState(statePath: string, raw: string): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,9 @@ import { attachCommand } from './commands/attach.js';
 import { extractDocumentCommand } from './commands/extract.js';
 import { importDocumentCommand } from './commands/import.js';
 import {
+  syncAccessGrantCommand,
+  syncAccessListCommand,
+  syncAccessRevokeCommand,
   syncConfigCommand,
   syncPullCommand,
   syncPushCommand,
@@ -255,6 +258,7 @@ const mcpCmd = program
   .option('--allow-origin <origin>', 'Allow an HTTP Origin for browser-based HTTP clients', collectValues, [])
   .option('--json-response', 'Prefer JSON HTTP responses instead of SSE streams')
   .option('--background', 'Run MCP server as a background daemon')
+  .option('--role <role>', 'MCP access role: read or write', 'write')
   .action(async (options: {
     vault?: string;
     transport?: 'stdio' | 'http';
@@ -263,6 +267,7 @@ const mcpCmd = program
     allowOrigin?: string[];
     jsonResponse?: boolean;
     background?: boolean;
+    role?: string;
   }) => {
     await mcpCommand(options);
   });
@@ -410,6 +415,41 @@ syncRemoteCmd
     syncRemoteRemoveCommand(name, options);
   });
 
+const syncAccessCmd = syncCmd
+  .command('access')
+  .description('Manage read/write sync access grants');
+
+syncAccessCmd
+  .command('list')
+  .alias('ls')
+  .description('List sync access grants without revealing full tokens')
+  .option('--vault <path>', 'Vault root')
+  .option('--json', 'Output as JSON')
+  .action((options: { vault?: string; json?: boolean }) => {
+    syncAccessListCommand(options);
+  });
+
+syncAccessCmd
+  .command('grant')
+  .description('Create or replace a named sync access grant')
+  .argument('<name>', 'Grant name, e.g. ipad or teammate-alice')
+  .option('--vault <path>', 'Vault root')
+  .option('--role <role>', 'Access role: read or write', 'read')
+  .option('--json', 'Output as JSON')
+  .action((name: string, options: { vault?: string; role?: string; json?: boolean }) => {
+    syncAccessGrantCommand(name, options);
+  });
+
+syncAccessCmd
+  .command('revoke')
+  .description('Revoke a named sync access grant')
+  .argument('<name>', 'Grant name')
+  .option('--vault <path>', 'Vault root')
+  .option('--json', 'Output as JSON')
+  .action((name: string, options: { vault?: string; json?: boolean }) => {
+    syncAccessRevokeCommand(name, options);
+  });
+
 syncCmd
   .command('serve')
   .description('Serve this vault for direct sync from another machine')
@@ -459,7 +499,8 @@ syncCmd
   .argument('<remote>', 'Remote name')
   .option('--vault <path>', 'Vault root')
   .option('--interval <seconds>', 'Seconds between sync runs', '30')
-  .action(async (remote: string, options: { vault?: string; interval?: string }) => {
+  .option('--direction <direction>', 'Watch direction: pull or run', 'run')
+  .action(async (remote: string, options: { vault?: string; interval?: string; direction?: string }) => {
     await syncWatchCommand(remote, options);
   });
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -48,17 +48,27 @@ export interface GraniteMcpHttpServerOptions {
   port: number;
   allowedOrigins?: string[];
   jsonResponse?: boolean;
+  role?: McpAccessRole;
 }
 
-function buildServerInstructions(runtime: GraniteMcpRuntime): string {
+export type McpAccessRole = 'read' | 'write';
+
+export interface GraniteMcpServerOptions {
+  role?: McpAccessRole;
+}
+
+function buildServerInstructions(runtime: GraniteMcpRuntime, role: McpAccessRole): string {
   const types = runtime.listNoteTypes();
   const signature = runtime.getTypeRegistrySignature();
   const defaultType = runtime.getDefaultNoteType();
+  const canWrite = role === 'write';
 
   const lines: string[] = [
     '# Granite — Knowledge Compilation System',
     '',
-    'You are operating a local-first markdown knowledge base. You are the primary writer and gardener of this vault — the human rarely edits notes directly.',
+    canWrite
+      ? 'You are operating a local-first markdown knowledge base. You are the primary writer and gardener of this vault — the human rarely edits notes directly.'
+      : 'You are operating a local-first markdown knowledge base in read-only mode. Inspect and compile context from the vault, but do not attempt to mutate it.',
     '',
     '## Public Interface',
     '',
@@ -70,16 +80,18 @@ function buildServerInstructions(runtime: GraniteMcpRuntime): string {
     '- **granite_query** — run structured queries over typed notes and indexed fields',
     '- **granite_compile_context** — compile a typed brief for a topic or slug using the graph',
     '- **granite_plan_garden** — compute the highest-leverage notes or clusters to revisit next',
-    '- **granite_adjudicate_garden_opportunity** — explicitly downrank or clear a garden opportunity the operator has adjudicated',
     '- **granite_list_garden_adjudications** — inspect the active operator adjudications influencing garden planning',
-    '- **granite_capture_knowledge** — capture new knowledge into the vault',
     '- **granite_extract_document** — read a local document into raw extracted text without importing it',
-    '- **granite_import_document** — attach a file and create a linked source note with caller-provided content',
     '- **granite_understand_note** — inspect a note in context, not in isolation',
-    '- **granite_revise_note** — make targeted edits when workflow prompts are insufficient',
-    '- **granite_dispose_note** — archive by default, delete only when intentional',
-    '',
-    'Use prompts for the higher-level workflows: refine notes, compile topics, and process the inbox.',
+    ...(canWrite ? [
+      '- **granite_adjudicate_garden_opportunity** — explicitly downrank or clear a garden opportunity the operator has adjudicated',
+      '- **granite_capture_knowledge** — capture new knowledge into the vault',
+      '- **granite_import_document** — attach a file and create a linked source note with caller-provided content',
+      '- **granite_revise_note** — make targeted edits when workflow prompts are insufficient',
+      '- **granite_dispose_note** — archive by default, delete only when intentional',
+      '',
+      'Use prompts for the higher-level workflows: refine notes, compile topics, and process the inbox.',
+    ] : []),
     '',
     `## Note Types (vault registry, sig=${signature})`,
     '',
@@ -107,17 +119,25 @@ function buildServerInstructions(runtime: GraniteMcpRuntime): string {
     '## Working Principles',
     '',
     '- **Read in context.** Prefer granite_understand_note over piecing together note, backlinks, and suggestions manually.',
-    '- **Capture first, refine second.** Capture quickly, then use workflow prompts to turn captures into durable knowledge.',
-    '- **Link aggressively.** Use [[wikilinks]] in note bodies and follow recommendations after each revision.',
-    '- **Archive before delete.** Knowledge systems should prefer reversible lifecycle transitions.',
-    '- **Respect the type registry.** Every note\'s type must exist in the vault config; write tools reject unknown types and report validation issues in their response.',
+    ...(canWrite ? [
+      '- **Capture first, refine second.** Capture quickly, then use workflow prompts to turn captures into durable knowledge.',
+      '- **Link aggressively.** Use [[wikilinks]] in note bodies and follow recommendations after each revision.',
+      '- **Archive before delete.** Knowledge systems should prefer reversible lifecycle transitions.',
+    ] : []),
+    canWrite
+      ? '- **Respect the type registry.** Every note\'s type must exist in the vault config; write tools reject unknown types and report validation issues in their response.'
+      : '- **Respect the type registry.** Every note\'s type is governed by the vault config exposed in granite://vault/types.',
     '- **Prefer explicit extraction for documents.** Use granite://notes/{slug} for markdown, granite://vault/types for type contracts, and granite_extract_document before summarizing imported documents.',
   );
 
   return lines.join('\n');
 }
 
-export function createGraniteMcpServer(runtime: GraniteMcpRuntime): McpServer {
+export function createGraniteMcpServer(
+  runtime: GraniteMcpRuntime,
+  options: GraniteMcpServerOptions = {},
+): McpServer {
+  const role = options.role ?? 'write';
   const server = new McpServer(
     {
       name: 'granite',
@@ -126,19 +146,24 @@ export function createGraniteMcpServer(runtime: GraniteMcpRuntime): McpServer {
     },
     {
       capabilities: { logging: {} },
-      instructions: buildServerInstructions(runtime),
+      instructions: buildServerInstructions(runtime, role),
     },
   );
 
-  registerTools(server, runtime);
+  registerTools(server, runtime, role);
   registerResources(server, runtime);
-  registerPrompts(server, runtime);
+  if (role === 'write') {
+    registerPrompts(server, runtime);
+  }
 
   return server;
 }
 
-export async function startGraniteMcpStdioServer(runtime: GraniteMcpRuntime): Promise<void> {
-  const server = createGraniteMcpServer(runtime);
+export async function startGraniteMcpStdioServer(
+  runtime: GraniteMcpRuntime,
+  options: GraniteMcpServerOptions = {},
+): Promise<void> {
+  const server = createGraniteMcpServer(runtime, options);
   const transport = new StdioServerTransport();
   await server.connect(transport);
   console.error(`Granite MCP server listening on stdio for ${runtime.vaultRoot}`);
@@ -220,7 +245,9 @@ function buildTypeSchema(runtime: GraniteMcpRuntime, describe: string) {
   );
 }
 
-function registerTools(server: McpServer, runtime: GraniteMcpRuntime): void {
+function registerTools(server: McpServer, runtime: GraniteMcpRuntime, role: McpAccessRole): void {
+  const canWrite = role === 'write';
+
   server.registerTool('granite_wakeup', {
     title: 'Granite Wakeup',
     description: 'Load a compressed AAAK snapshot of the entire vault into context. Call this at the start of every session to know what exists, how notes cluster, and what changed recently. Costs ~200-500 tokens instead of reading every note.',
@@ -256,7 +283,7 @@ function registerTools(server: McpServer, runtime: GraniteMcpRuntime): void {
     return toolResult(renderGardenPlanMarkdown(result));
   });
 
-  server.registerTool('granite_adjudicate_garden_opportunity', {
+  if (canWrite) server.registerTool('granite_adjudicate_garden_opportunity', {
     title: 'Adjudicate Granite Garden Opportunity',
     description: 'Record an explicit operator adjudication for a specific garden opportunity. Use this when a deterministic signal is real but should be downranked locally, or when an old adjudication should be cleared.',
     inputSchema: {
@@ -297,7 +324,7 @@ function registerTools(server: McpServer, runtime: GraniteMcpRuntime): void {
     return toolResult(renderGardenAdjudicationsMarkdown(adjudications));
   });
 
-  server.registerTool('granite_capture_knowledge', {
+  if (canWrite) server.registerTool('granite_capture_knowledge', {
     title: 'Capture Granite Knowledge',
     description: 'Capture new knowledge into the vault. Use this for raw captures, semi-structured notes, or deliberately titled note drafts. Returns recommendations for what to connect or write next.',
     inputSchema: {
@@ -352,7 +379,7 @@ function registerTools(server: McpServer, runtime: GraniteMcpRuntime): void {
     return toolResult(renderMutationResultMarkdown('Captured', result.note, result.recommendations, result.validation));
   });
 
-  server.registerTool('granite_import_document', {
+  if (canWrite) server.registerTool('granite_import_document', {
     title: 'Import Granite Document',
     description: 'Import a local document into the vault by attaching the file, creating a linked source note, and storing caller-provided document content in that note. This tool does not read, clean, or summarize the document for you.',
     inputSchema: {
@@ -402,7 +429,7 @@ function registerTools(server: McpServer, runtime: GraniteMcpRuntime): void {
     };
   });
 
-  server.registerTool('granite_revise_note', {
+  if (canWrite) server.registerTool('granite_revise_note', {
     title: 'Revise Granite Note',
     description: 'Make a targeted revision to an existing note. Use this when a workflow prompt tells you exactly what to change, or when you need a precise manual intervention.',
     inputSchema: {
@@ -488,7 +515,7 @@ function registerTools(server: McpServer, runtime: GraniteMcpRuntime): void {
     return toolResult(summary);
   });
 
-  server.registerTool('granite_dispose_note', {
+  if (canWrite) server.registerTool('granite_dispose_note', {
     title: 'Dispose Granite Note',
     description: 'Remove a note from the active knowledge loop. Archive by default; delete only when you are intentionally discarding the note.',
     inputSchema: {
@@ -768,6 +795,7 @@ function createGraniteMcpHttpApp(runtime: GraniteMcpRuntime, options: GraniteMcp
   const app = new Hono();
   const allowedHosts = buildAllowedHosts(options.host, options.port);
   const allowedOrigins = buildAllowedOrigins(options.host, options.port, options.allowedOrigins ?? []);
+  const role = options.role ?? 'write';
 
   app.use('/mcp', async (c, next) => {
     const requestHost = (c.req.header('host') ?? '').toLowerCase();
@@ -802,7 +830,7 @@ function createGraniteMcpHttpApp(runtime: GraniteMcpRuntime, options: GraniteMcp
 
   app.all('/mcp', async (c) => {
     const origin = c.req.header('origin');
-    const server = createGraniteMcpServer(runtime);
+    const server = createGraniteMcpServer(runtime, { role });
     const transport = new WebStandardStreamableHTTPServerTransport({
       sessionIdGenerator: undefined,
       enableJsonResponse: options.jsonResponse ?? false,

--- a/test/commands/mcp.test.ts
+++ b/test/commands/mcp.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { parsePort, parseTransport } from '../../src/commands/mcp.js';
+import { parseMcpRole, parsePort, parseTransport } from '../../src/commands/mcp.js';
 
 const originalMcpPort = process.env.MCP_PORT;
 
@@ -27,5 +27,12 @@ describe('mcp command helpers', () => {
 
   it('rejects invalid transport values', () => {
     expect(() => parseTransport('streamable-http' as 'stdio')).toThrow('Invalid MCP transport');
+  });
+
+  it('parses MCP access roles', () => {
+    expect(parseMcpRole()).toBe('write');
+    expect(parseMcpRole('read')).toBe('read');
+    expect(parseMcpRole('write')).toBe('write');
+    expect(() => parseMcpRole('admin')).toThrow('Invalid MCP role');
   });
 });

--- a/test/commands/sync.test.ts
+++ b/test/commands/sync.test.ts
@@ -1,16 +1,32 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import crypto from 'node:crypto';
 import fs from 'node:fs';
+import net from 'node:net';
 import os from 'node:os';
 import path from 'node:path';
-import { createSyncApp } from '../../src/commands/sync.js';
-import { loadSyncState, readSyncFilePayload, saveSyncState, type SyncFilePayload } from '../../src/core/sync.js';
+import {
+  createSyncApp,
+  parseAccessRole,
+  parseWatchDirection,
+  syncServeCommand,
+  syncStatusCommand,
+} from '../../src/commands/sync.js';
+import { grantSyncAccess, loadSyncState, readSyncFilePayload, saveSyncState, type SyncFilePayload } from '../../src/core/sync.js';
 
 describe('sync command transport', () => {
   let tmpDir: string;
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'granite-sync-command-'));
+  });
+
+  it('parses sync access roles and watch directions', () => {
+    expect(parseAccessRole()).toBe('read');
+    expect(parseAccessRole('write')).toBe('write');
+    expect(parseWatchDirection()).toBe('run');
+    expect(parseWatchDirection('pull')).toBe('pull');
+    expect(() => parseAccessRole('admin')).toThrow('Invalid sync access role');
+    expect(() => parseWatchDirection('push')).toThrow('Invalid sync watch direction');
   });
 
   afterEach(() => {
@@ -89,6 +105,107 @@ describe('sync command transport', () => {
     expect(fs.readFileSync(path.join(tmpDir, 'notes/notes/remote.md'), 'utf-8')).toBe(content);
   });
 
+  it('allows read access tokens to read but not write direct sync data', async () => {
+    const state = loadSyncState(tmpDir);
+    const readGrant = grantSyncAccess(state, 'reader', 'read');
+    saveSyncState(tmpDir, state);
+    const app = createSyncApp(tmpDir);
+    const content = 'remote note\n';
+    const payload: SyncFilePayload = {
+      path: 'notes/notes/remote.md',
+      hash: sha(content),
+      size: Buffer.byteLength(content),
+      modified: '2026-05-28T12:00:00.000Z',
+      device_id: 'remote',
+      content_base64: Buffer.from(content).toString('base64'),
+      base_hash: null,
+    };
+
+    const manifest = await app.request('/sync/manifest', {
+      headers: { Authorization: `Bearer ${readGrant.token}` },
+    });
+    const write = await app.request('/sync/file', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${readGrant.token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    });
+
+    expect(manifest.status).toBe(200);
+    expect(write.status).toBe(403);
+    expect(fs.existsSync(path.join(tmpDir, 'notes/notes/remote.md'))).toBe(false);
+  });
+
+  it('allows write access tokens to push direct sync data', async () => {
+    const state = loadSyncState(tmpDir);
+    const writeGrant = grantSyncAccess(state, 'writer', 'write');
+    saveSyncState(tmpDir, state);
+    const app = createSyncApp(tmpDir);
+    const content = 'remote writer note\n';
+    const payload: SyncFilePayload = {
+      path: 'notes/notes/writer.md',
+      hash: sha(content),
+      size: Buffer.byteLength(content),
+      modified: '2026-05-28T12:00:00.000Z',
+      device_id: 'remote',
+      content_base64: Buffer.from(content).toString('base64'),
+      base_hash: null,
+    };
+
+    const response = await app.request('/sync/file', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${writeGrant.token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ path: 'notes/notes/writer.md', action: 'created' });
+    expect(fs.readFileSync(path.join(tmpDir, 'notes/notes/writer.md'), 'utf-8')).toBe(content);
+  });
+
+  it('does not print full sync tokens in status output', () => {
+    const state = loadSyncState(tmpDir);
+    const readGrant = grantSyncAccess(state, 'reader', 'read');
+    const writeGrant = grantSyncAccess(state, 'writer', 'write');
+    saveSyncState(tmpDir, state);
+
+    const human = captureStdout(() => syncStatusCommand({ vault: tmpDir }));
+    const json = captureStdout(() => syncStatusCommand({ vault: tmpDir, json: true }));
+
+    expect(human).not.toContain(state.local_token);
+    expect(human).not.toContain(readGrant.token);
+    expect(human).not.toContain(writeGrant.token);
+    expect(json).not.toContain(state.local_token);
+    expect(json).not.toContain(readGrant.token);
+    expect(json).not.toContain(writeGrant.token);
+    expect(json).toContain('token_hint');
+  });
+
+  it('does not print full sync tokens when serving', async () => {
+    const state = loadSyncState(tmpDir);
+    const readGrant = grantSyncAccess(state, 'reader', 'read');
+    const writeGrant = grantSyncAccess(state, 'writer', 'write');
+    saveSyncState(tmpDir, state);
+    const port = await getFreePort();
+
+    let server: ReturnType<typeof syncServeCommand> | undefined;
+    const output = captureStdout(() => {
+      server = syncServeCommand({ vault: tmpDir, host: '127.0.0.1', port: String(port) });
+    });
+    server?.close();
+
+    expect(output).not.toContain(state.local_token);
+    expect(output).not.toContain(readGrant.token);
+    expect(output).not.toContain(writeGrant.token);
+    expect(output).toContain('granite sync access grant <name> --role read');
+    expect(output).toContain('--token <token>');
+  });
+
   it('preserves existing files when delete payload hashes are unknown', async () => {
     const state = loadSyncState(tmpDir);
     const notePath = path.join(tmpDir, 'notes/notes/local.md');
@@ -146,4 +263,34 @@ describe('sync command transport', () => {
 
 function sha(content: string): string {
   return crypto.createHash('sha256').update(content).digest('hex');
+}
+
+function captureStdout(fn: () => void): string {
+  const original = console.log;
+  const lines: string[] = [];
+  console.log = (...args: unknown[]) => {
+    lines.push(args.map(String).join(' '));
+  };
+  try {
+    fn();
+  } finally {
+    console.log = original;
+  }
+  return lines.join('\n');
+}
+
+async function getFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        server.close(() => reject(new Error('Could not allocate test port.')));
+        return;
+      }
+      const port = address.port;
+      server.close(() => resolve(port));
+    });
+  });
 }

--- a/test/core/sync.test.ts
+++ b/test/core/sync.test.ts
@@ -9,10 +9,13 @@ import {
   buildSyncManifest,
   createDefaultSyncState,
   detectLocalDeletions,
+  grantSyncAccess,
   getSyncStatePath,
   loadSyncState,
   normalizeRemoteUrl,
   readSyncFilePayload,
+  resolveSyncAccessRole,
+  revokeSyncAccess,
   saveSyncState,
   type SyncFilePayload,
   type SyncState,
@@ -47,6 +50,89 @@ describe('sync core', () => {
   it('normalizes remote addresses for direct machine sync', () => {
     expect(normalizeRemoteUrl('100.64.0.10', '8765')).toBe('http://100.64.0.10:8765');
     expect(normalizeRemoteUrl('http://macbook.tailnet.ts.net:8765/sync')).toBe('http://macbook.tailnet.ts.net:8765');
+  });
+
+  it('migrates the legacy local sync token as write access', () => {
+    writeFile('.granite/sync.json', JSON.stringify({
+      version: 1,
+      device_id: 'legacy-device',
+      device_name: 'legacy',
+      local_token: 'legacy-token',
+      conflict_policy: 'manual',
+      primary_device_id: 'legacy-device',
+      remotes: {},
+      baselines: {},
+      tombstones: {},
+    }));
+
+    const state = loadSyncState(tmpDir);
+
+    expect(resolveSyncAccessRole(state, 'legacy-token')).toBe('write');
+    expect(Object.values(state.access_tokens)).toContainEqual(expect.objectContaining({
+      token: 'legacy-token',
+      role: 'write',
+    }));
+  });
+
+  it('recovers legacy local token when access token state is malformed', () => {
+    writeFile('.granite/sync.json', JSON.stringify({
+      version: 1,
+      device_id: 'legacy-device',
+      device_name: 'legacy',
+      local_token: 'legacy-token',
+      conflict_policy: 'manual',
+      primary_device_id: 'legacy-device',
+      remotes: {},
+      access_tokens: { default: { token: '', role: 'read' } },
+      baselines: {},
+      tombstones: {},
+    }));
+
+    const state = loadSyncState(tmpDir);
+
+    expect(resolveSyncAccessRole(state, 'legacy-token')).toBe('write');
+  });
+
+  it('grants and revokes named read/write sync access tokens', () => {
+    const state = createState('local');
+    const readGrant = grantSyncAccess(state, 'ipad', 'read', new Date('2026-05-28T12:00:00.000Z'));
+    const writeGrant = grantSyncAccess(state, 'desktop', 'write', new Date('2026-05-28T12:01:00.000Z'));
+
+    expect(resolveSyncAccessRole(state, readGrant.token)).toBe('read');
+    expect(resolveSyncAccessRole(state, writeGrant.token)).toBe('write');
+    expect(revokeSyncAccess(state, 'ipad')).toBe(true);
+    expect(resolveSyncAccessRole(state, readGrant.token)).toBeNull();
+    expect(revokeSyncAccess(state, 'missing')).toBe(false);
+  });
+
+  it('recovers legacy local token when access token state is empty', () => {
+    writeFile('.granite/sync.json', JSON.stringify({
+      version: 1,
+      device_id: 'legacy-device',
+      device_name: 'legacy',
+      local_token: 'legacy-token',
+      conflict_policy: 'manual',
+      primary_device_id: 'legacy-device',
+      remotes: {},
+      access_tokens: {},
+      baselines: {},
+      tombstones: {},
+    }));
+
+    const state = loadSyncState(tmpDir);
+
+    expect(resolveSyncAccessRole(state, 'legacy-token')).toBe('write');
+  });
+
+  it('persists revocation of named sync access tokens', () => {
+    const state = createState('local');
+    const readGrant = grantSyncAccess(state, 'reader', 'read');
+    expect(revokeSyncAccess(state, 'reader')).toBe(true);
+    saveSyncState(tmpDir, state);
+
+    const reloaded = loadSyncState(tmpDir);
+
+    expect(resolveSyncAccessRole(reloaded, readGrant.token)).toBeNull();
   });
 
   it('creates a conflict copy when both devices changed the same file manually', () => {

--- a/test/mcp/server.test.ts
+++ b/test/mcp/server.test.ts
@@ -68,6 +68,33 @@ describe('granite MCP server', () => {
     expect(client.getInstructions()).toContain('Knowledge Compilation System');
   });
 
+  it('hides mutating tools and prompts in read-only MCP mode', async () => {
+    const readServer = createGraniteMcpServer(runtime, { role: 'read' });
+    const readClient = new Client({ name: 'granite-read-client', version: '1.0.0' });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await readServer.connect(serverTransport);
+    await readClient.connect(clientTransport);
+
+    try {
+      const tools = await readClient.listTools();
+      const toolNames = tools.tools.map(tool => tool.name);
+
+      expect(toolNames).toContain('granite_wakeup');
+      expect(toolNames).toContain('granite_extract_document');
+      expect(toolNames).toContain('granite_understand_note');
+      expect(toolNames).not.toContain('granite_capture_knowledge');
+      expect(toolNames).not.toContain('granite_import_document');
+      expect(toolNames).not.toContain('granite_revise_note');
+      expect(toolNames).not.toContain('granite_dispose_note');
+      expect(toolNames).not.toContain('granite_adjudicate_garden_opportunity');
+      expect(readClient.getInstructions()).toContain('read-only mode');
+      expect(readClient.getInstructions()).not.toContain('granite_capture_knowledge');
+    } finally {
+      await readClient.close();
+      await readServer.close();
+    }
+  });
+
   it('serves note resources and prompt templates', async () => {
     const resource = await client.readResource({ uri: 'granite://notes/mcp-note' });
     const typeResource = await client.readResource({ uri: 'granite://vault/types' });
@@ -293,4 +320,3 @@ function extractTextContent(result: Awaited<ReturnType<Client['callTool']>>) {
   }
   return textContent.text;
 }
-


### PR DESCRIPTION
## Summary
- Add named sync access grants with read/write roles and enforce read-only tokens on direct sync write endpoints.
- Add read-only MCP mode that hides mutating tools/prompts while keeping per-vault MCP servers.
- Document read-only sync replicas, write-capable peers, and MCP role usage.

## Test plan
- `npm run lint`
- `npm run test`
- `cubic review -j` (0 issues)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add read-only vault access control across sync and MCP. You can now issue named tokens with read/write roles, enforce read-only on sync endpoints, and run MCP in read-only mode that hides mutating tools.

- **New Features**
  - Sync access grants: `granite sync access grant|list|revoke` to create named read/write tokens; reads allowed for GET/HEAD, writes require a write token; `sync status` and `sync serve` hide full tokens.
  - Watch direction: `granite sync watch <remote> --direction pull|run` to pull-only or bidirectional.
  - MCP roles: `granite mcp --role read|write`; read-only mode removes mutating tools/prompts and adjusts server instructions.
  - State: `sync.json` now includes `access_tokens`; helpers to grant/revoke/resolve roles; safe token hints in JSON/status output.
  - Docs: README shows read-only replicas, write-capable peers, and MCP role usage.

- **Migration**
  - No manual steps. Legacy `local_token` is auto-migrated to a write-capable `default` grant.
  - To share access, run: `granite sync access grant <name> --role read|write` and give the token to the peer.

<sup>Written for commit 6601e411314d24b87db4d9caaffe636a540ac862. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Vibe-Company/Granite/pull/38?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

