### PR TITLE
fix(release): publish granite-mem through trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -13,6 +14,7 @@ permissions:
 
 jobs:
   release-please:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
@@ -25,18 +27,18 @@ jobs:
 
   publish:
     needs: release-please
-    if: needs.release-please.outputs.release_created == 'true'
+    if: github.event_name == 'push' && needs.release-please.outputs.release_created == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
-          cache: npm
+          node-version: 24
+          package-manager-cache: false
           registry-url: https://registry.npmjs.org
 
       - name: Install dependencies
@@ -54,7 +56,66 @@ jobs:
       - name: Verify package contents
         run: npm pack --dry-run
 
+      - name: Check npm version availability
+        id: package
+        run: |
+          name="$(node -p "require('./package.json').name")"
+          version="$(node -p "require('./package.json').version")"
+          if npm view "${name}@${version}" version >/dev/null 2>&1; then
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            echo "${name}@${version} is already published"
+          else
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+            echo "Publishing ${name}@${version}"
+          fi
+
       - name: Publish to npm
-        run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        if: steps.package.outputs.publish == 'true'
+        run: npm publish
+
+  publish-current:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          package-manager-cache: false
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Typecheck
+        run: npm run lint
+
+      - name: Test with coverage
+        run: npm run test:coverage
+
+      - name: Verify package contents
+        run: npm pack --dry-run
+
+      - name: Check npm version availability
+        id: package
+        run: |
+          name="$(node -p "require('./package.json').name")"
+          version="$(node -p "require('./package.json').version")"
+          if npm view "${name}@${version}" version >/dev/null 2>&1; then
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            echo "${name}@${version} is already published"
+          else
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+            echo "Publishing ${name}@${version}"
+          fi
+
+      - name: Publish to npm
+        if: steps.package.outputs.publish == 'true'
+        run: npm publish

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Local-first markdown memory system for humans and AI agents: MCP server, typed knowledge graph, deterministic garden planning.",
   "type": "module",
   "bin": {
-    "granite": "./dist/index.js"
+    "granite": "dist/index.js"
   },
   "files": [
     "dist",
@@ -31,7 +31,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/The-Vibe-Company/Granite"
+    "url": "git+https://github.com/The-Vibe-Company/Granite.git"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "scripts": {
     "build": "tsup && node scripts/build-web.mjs && rm -rf dist/templates && cp -r templates dist/templates",


### PR DESCRIPTION
## Summary
- switch npm publishing to GitHub OIDC trusted publishing instead of the failing long-lived NPM_TOKEN path
- use Node 24/setup-node v6 for the npm trusted publishing requirements
- add a manual Release workflow dispatch so the already-cut 0.1.11 package can be published after the npm trusted publisher is configured
- normalize npm package metadata to avoid publish-time auto-fix warnings
- derive the CLI/MCP version from package.json and add a regression test so Granite no longer reports the stale 0.1.2 version

## Verification
- PATH=/Users/stan/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm ci
- PATH=/Users/stan/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm run build
- PATH=/Users/stan/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm run lint
- PATH=/Users/stan/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm run test:coverage
- PATH=/Users/stan/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm pack --dry-run

## After merge
Configure npm trusted publishing for package granite-mem: GitHub Actions, repo The-Vibe-Company/Granite, workflow release.yml, allowed action npm publish. Then manually run the Release workflow to publish the current 0.1.11 version.