### PR TITLE
fix(cli): derive version from package metadata

### DIFF
--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,18 @@
-export const GRANITE_VERSION = '0.1.2';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const GRANITE_VERSION = readPackageVersion();
+
+function readPackageVersion(): string {
+  const packageJsonPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../package.json');
+  try {
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8')) as { version?: unknown };
+    if (typeof packageJson.version === 'string' && packageJson.version.length > 0) {
+      return packageJson.version;
+    }
+  } catch {
+    // Keep the CLI usable even if package metadata is unavailable in a dev build.
+  }
+  return '0.0.0';
+}

--- a/test/version.test.ts
+++ b/test/version.test.ts
@@ -1,0 +1,10 @@
+import fs from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { GRANITE_VERSION } from '../src/version.js';
+
+describe('GRANITE_VERSION', () => {
+  it('matches package.json', () => {
+    const packageJson = JSON.parse(fs.readFileSync('package.json', 'utf-8')) as { version: string };
+    expect(GRANITE_VERSION).toBe(packageJson.version);
+  });
+});


### PR DESCRIPTION
## Summary
- make Granite read its runtime version from package.json instead of the stale hardcoded 0.1.2 constant
- add a regression test that keeps GRANITE_VERSION aligned with package.json

## Verification
- PATH=/Users/stan/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm run build
- PATH=/Users/stan/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm run lint
- PATH=/Users/stan/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm run test:coverage
- PATH=/Users/stan/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm pack --dry-run