### PR TITLE
fix(release): publish npm without legacy token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,6 @@ jobs:
         with:
           node-version: 24
           package-manager-cache: false
-          registry-url: https://registry.npmjs.org
 
       - name: Install dependencies
         run: npm ci
@@ -71,7 +70,10 @@ jobs:
 
       - name: Publish to npm
         if: steps.package.outputs.publish == 'true'
-        run: npm publish
+        run: |
+          rm -f "${NPM_CONFIG_USERCONFIG:-}"
+          unset NODE_AUTH_TOKEN NPM_CONFIG_USERCONFIG
+          npm publish --provenance
 
   publish-current:
     if: github.event_name == 'workflow_dispatch'
@@ -86,7 +88,6 @@ jobs:
         with:
           node-version: 24
           package-manager-cache: false
-          registry-url: https://registry.npmjs.org
 
       - name: Install dependencies
         run: npm ci
@@ -118,4 +119,7 @@ jobs:
 
       - name: Publish to npm
         if: steps.package.outputs.publish == 'true'
-        run: npm publish
+        run: |
+          rm -f "${NPM_CONFIG_USERCONFIG:-}"
+          unset NODE_AUTH_TOKEN NPM_CONFIG_USERCONFIG
+          npm publish --provenance


### PR DESCRIPTION
## Summary
- remove setup-node registry-url so npm does not create a token-based .npmrc
- explicitly clear NODE_AUTH_TOKEN/NPM_CONFIG_USERCONFIG before npm publish
- publish with provenance through npm trusted publishing/OIDC

## Verification
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml'); puts 'workflow yaml ok'"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the release workflow to tokenless Trusted Publishing for `npm` using OIDC and provenance. Prevents token-based `.npmrc` creation and hardens the publish step.

- **Bug Fixes**
  - Removed `registry-url` from `actions/setup-node` to avoid token `.npmrc`.
  - Cleared `NODE_AUTH_TOKEN` and `NPM_CONFIG_USERCONFIG` before `npm publish`.
  - Publish with `npm publish --provenance` via npm Trusted Publishing/OIDC.

<sup>Written for commit ed4fc656cba61dd3942bb951c7a6d71f7afc843b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Vibe-Company/Granite/pull/43?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

