### PR TITLE
fix(release): rely on npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
         run: |
           rm -f "${NPM_CONFIG_USERCONFIG:-}"
           unset NODE_AUTH_TOKEN NPM_CONFIG_USERCONFIG
-          npm publish --provenance
+          npm publish
 
   publish-current:
     if: github.event_name == 'workflow_dispatch'
@@ -122,4 +122,4 @@ jobs:
         run: |
           rm -f "${NPM_CONFIG_USERCONFIG:-}"
           unset NODE_AUTH_TOKEN NPM_CONFIG_USERCONFIG
-          npm publish --provenance
+          npm publish


### PR DESCRIPTION
## Summary
- publish with plain npm publish so npm's trusted publishing path can handle OIDC auth and provenance automatically
- keep token cleanup before publish to avoid falling back to legacy npm tokens

## Verification
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml'); puts 'workflow yaml ok'"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch release workflow to `npm` Trusted Publishing so OIDC handles auth and provenance automatically. Replace `npm publish --provenance` with `npm publish` and keep token cleanup to prevent using legacy tokens.

<sup>Written for commit ec412c9bf1d8eab8af6a424351458b325074d9dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/The-Vibe-Company/Granite/pull/44?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

