### PR TITLE
feat(mcp): secure remote HTTP transport

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+node_modules
+dist
+coverage
+.git
+.context
+plans
+.granite
+granite.yml
+notes
+.env
+.env.*
+.DS_Store
+npm-debug.log*

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,48 @@
+name: Docker
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE_NAME: ghcr.io/the-vibe-company/granite
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read package version
+        id: package
+        run: |
+          version="$(node -p "require('./package.json').version")"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ steps.package.outputs.version }}
+            type=raw,value=latest
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+FROM node:22-bookworm-slim AS build
+
+WORKDIR /app
+
+ENV HUSKY=0
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+FROM node:22-bookworm-slim AS runtime
+
+WORKDIR /app
+
+ENV NODE_ENV=production \
+    GRANITE_VAULT=/vault
+
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev --ignore-scripts \
+  && npm rebuild better-sqlite3 \
+  && npm cache clean --force
+
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/templates ./templates
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+
+RUN chmod +x /app/dist/index.js /usr/local/bin/docker-entrypoint.sh \
+  && ln -s /app/dist/index.js /usr/local/bin/granite \
+  && mkdir -p /vault
+
+EXPOSE 3321
+VOLUME ["/vault"]
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["granite", "mcp", "--transport", "http", "--host", "0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -177,6 +177,36 @@ Your agent reads these before writing and sets them as it works. You inherit a f
 - `granite serve` gives you a local web UI — browse, search, explore the graph
 - `granite daemon start` runs MCP + web UI in one background process
 
+## Remote MCP / self-hosting
+
+Granite can also expose the MCP server over HTTP for a private remote vault. When binding outside localhost, require a bearer token:
+
+```bash
+export GRANITE_MCP_TOKEN="$(openssl rand -hex 32)"
+granite mcp --vault ~/.granite \
+  --transport http \
+  --host 0.0.0.0 \
+  --port 3321
+```
+
+Clients must send the token on every MCP request:
+
+```bash
+claude mcp add --transport http granite https://granite.example.com/mcp \
+  --header "Authorization: Bearer $GRANITE_MCP_TOKEN"
+```
+
+The Docker image auto-initializes `/vault` on first boot and serves only MCP on port 3321:
+
+```bash
+docker run --rm -p 3321:3321 \
+  -e GRANITE_MCP_TOKEN="$GRANITE_MCP_TOKEN" \
+  -v granite-vault:/vault \
+  ghcr.io/the-vibe-company/granite:latest
+```
+
+Use `GRANITE_INIT_TEMPLATE=founder-os` to initialize a new mounted vault from a template. The `/health` endpoint is unauthenticated for platform checks. Do not expose `granite serve` or the web UI port `4321` on the public internet; the web UI is local-only and has no authentication.
+
 ## Direct sync
 
 Granite sync is direct machine-to-machine. Run it over LAN, Tailscale, or a private DNS name; there is no relay, hosted worker, billing tier, or cloud authority.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env sh
+set -eu
+
+: "${GRANITE_VAULT:=/vault}"
+export GRANITE_VAULT
+
+if [ ! -f "$GRANITE_VAULT/granite.yml" ]; then
+  mkdir -p "$GRANITE_VAULT"
+  if [ -n "${GRANITE_INIT_TEMPLATE:-}" ]; then
+    granite init --template "$GRANITE_INIT_TEMPLATE"
+  else
+    granite init
+  fi
+fi
+
+if [ "$#" -eq 0 ]; then
+  set -- granite mcp --transport http --host 0.0.0.0
+elif [ "${1#-}" != "$1" ]; then
+  set -- granite mcp --transport http --host 0.0.0.0 "$@"
+fi
+
+exec "$@"

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -7,8 +7,8 @@ export interface InitVaultOptions {
   template?: string;
 }
 
-export function initVault(dir = getDefaultVaultRoot(), options: InitVaultOptions = {}): void {
-  const targetDir = path.resolve(dir);
+export function initVault(dir?: string, options: InitVaultOptions = {}): void {
+  const targetDir = path.resolve(dir ?? process.env.GRANITE_VAULT ?? getDefaultVaultRoot());
   fs.mkdirSync(targetDir, { recursive: true });
 
   if (fs.existsSync(path.join(targetDir, CONFIG_FILENAME))) {

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -12,6 +12,7 @@ interface McpCommandOptions {
   host?: string;
   port?: string;
   allowOrigin?: string[];
+  authToken?: string;
   jsonResponse?: boolean;
   background?: boolean;
   role?: string;
@@ -116,12 +117,14 @@ export async function mcpCommand(options: McpCommandOptions): Promise<void> {
   if (transport === 'http') {
     const port = parsePort(options.port);
     const host = options.host ?? '127.0.0.1';
+    const authToken = resolveAuthToken(options.authToken);
     const localUrl = `http://${host}:${port}/mcp`;
 
     startGraniteMcpHttpServer(runtime, {
       host,
       port,
       allowedOrigins: options.allowOrigin ?? [],
+      authToken,
       jsonResponse: options.jsonResponse ?? false,
       role,
     });
@@ -195,4 +198,15 @@ export function parseMcpRole(value?: string): McpAccessRole {
   const role = value ?? 'write';
   if (role === 'read' || role === 'write') return role;
   throw new Error(`Invalid MCP role: ${role}. Expected "read" or "write".`);
+}
+
+export function resolveAuthToken(value?: string): string | undefined {
+  const raw = value ?? process.env.GRANITE_MCP_TOKEN;
+  if (raw === undefined) return undefined;
+
+  const token = raw.trim();
+  if (!token) {
+    throw new Error('Invalid MCP auth token: token cannot be empty.');
+  }
+  return token;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -256,6 +256,7 @@ const mcpCmd = program
   .option('--host <host>', 'Host for HTTP transport', '127.0.0.1')
   .option('--port <port>', 'Port for HTTP transport', '3321')
   .option('--allow-origin <origin>', 'Allow an HTTP Origin for browser-based HTTP clients', collectValues, [])
+  .option('--auth-token <token>', 'Bearer token required for HTTP MCP requests. Defaults to $GRANITE_MCP_TOKEN')
   .option('--json-response', 'Prefer JSON HTTP responses instead of SSE streams')
   .option('--background', 'Run MCP server as a background daemon')
   .option('--role <role>', 'MCP access role: read or write', 'write')
@@ -265,6 +266,7 @@ const mcpCmd = program
     host?: string;
     port?: string;
     allowOrigin?: string[];
+    authToken?: string;
     jsonResponse?: boolean;
     background?: boolean;
     role?: string;

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,5 +1,6 @@
 import { serve } from '@hono/node-server';
 import { Hono } from 'hono';
+import net from 'node:net';
 import { McpServer, ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js';
@@ -47,6 +48,7 @@ export interface GraniteMcpHttpServerOptions {
   host: string;
   port: number;
   allowedOrigins?: string[];
+  authToken?: string;
   jsonResponse?: boolean;
   role?: McpAccessRole;
 }
@@ -170,6 +172,10 @@ export async function startGraniteMcpStdioServer(
 }
 
 export function startGraniteMcpHttpServer(runtime: GraniteMcpRuntime, options: GraniteMcpHttpServerOptions): void {
+  if (requiresMcpHttpAuth(options.host) && !options.authToken?.trim()) {
+    throw new Error('Refusing to bind Granite MCP HTTP server outside localhost without --auth-token or GRANITE_MCP_TOKEN.');
+  }
+
   const app = createGraniteMcpHttpApp(runtime, options);
 
   console.error(`Granite MCP server listening on http://${options.host}:${options.port}/mcp`);
@@ -791,10 +797,11 @@ function formatCompileTopicNote(note: { title: string; slug: string; type: strin
   ].join('\n');
 }
 
-function createGraniteMcpHttpApp(runtime: GraniteMcpRuntime, options: GraniteMcpHttpServerOptions): Hono {
+export function createGraniteMcpHttpApp(runtime: GraniteMcpRuntime, options: GraniteMcpHttpServerOptions): Hono {
   const app = new Hono();
   const allowedHosts = buildAllowedHosts(options.host, options.port);
   const allowedOrigins = buildAllowedOrigins(options.host, options.port, options.allowedOrigins ?? []);
+  const authToken = options.authToken?.trim();
   const role = options.role ?? 'write';
 
   app.use('/mcp', async (c, next) => {
@@ -821,6 +828,17 @@ function createGraniteMcpHttpApp(runtime: GraniteMcpRuntime, options: GraniteMcp
         status: 204,
         headers: corsHeaders(origin, allowedOrigins),
       });
+    }
+
+    if (authToken) {
+      const token = readBearerToken(c.req.header('authorization'));
+      if (token !== authToken) {
+        return c.json({
+          jsonrpc: '2.0',
+          error: { code: -32000, message: 'Unauthorized.' },
+          id: null,
+        }, 401);
+      }
     }
 
     await next();
@@ -854,7 +872,7 @@ function createGraniteMcpHttpApp(runtime: GraniteMcpRuntime, options: GraniteMcp
 
 function buildAllowedHosts(host: string, port: number): Set<string> {
   const normalizedHost = host.toLowerCase();
-  if (normalizedHost === '0.0.0.0' || normalizedHost === '::' || normalizedHost === '[::]') {
+  if (isWildcardBindHost(normalizedHost)) {
     return new Set<string>();
   }
 
@@ -870,6 +888,25 @@ function buildAllowedHosts(host: string, port: number): Set<string> {
   }
 
   return allowed;
+}
+
+function isWildcardBindHost(host: string): boolean {
+  const normalizedHost = host.toLowerCase();
+  return normalizedHost === '0.0.0.0' || normalizedHost === '::' || normalizedHost === '[::]';
+}
+
+export function requiresMcpHttpAuth(host: string): boolean {
+  return !isLoopbackBindHost(host);
+}
+
+function isLoopbackBindHost(host: string): boolean {
+  const normalizedHost = host.toLowerCase();
+  if (normalizedHost === 'localhost' || normalizedHost === '::1' || normalizedHost === '[::1]') {
+    return true;
+  }
+
+  const ipv4 = net.isIP(normalizedHost) === 4 ? normalizedHost : '';
+  return ipv4.startsWith('127.');
 }
 
 function buildAllowedOrigins(host: string, port: number, extraOrigins: string[]): Set<string> {
@@ -909,9 +946,15 @@ function corsHeaders(origin: string | undefined, allowedOrigins: Set<string>): H
   if (origin && allowedOrigins.has(origin)) {
     headers.set('Access-Control-Allow-Origin', origin);
     headers.set('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
-    headers.set('Access-Control-Allow-Headers', 'Content-Type, MCP-Protocol-Version, Last-Event-ID');
+    headers.set('Access-Control-Allow-Headers', 'Authorization, Content-Type, MCP-Protocol-Version, Last-Event-ID');
     headers.set('Access-Control-Expose-Headers', 'MCP-Session-Id, MCP-Protocol-Version');
     headers.set('Vary', 'Origin');
   }
   return headers;
+}
+
+function readBearerToken(header: string | undefined): string | null {
+  if (!header) return null;
+  const match = header.match(/^Bearer\s+(.+)$/i);
+  return match ? match[1] : null;
 }

--- a/test/commands/init.test.ts
+++ b/test/commands/init.test.ts
@@ -10,14 +10,17 @@ describe('initVault', () => {
   let tmpHome: string;
   let tmpCwd: string;
   let previousHome: string | undefined;
+  let previousGraniteVault: string | undefined;
   let previousCwd: string;
 
   beforeEach(() => {
     tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'granite-init-home-'));
     tmpCwd = fs.mkdtempSync(path.join(os.tmpdir(), 'granite-init-cwd-'));
     previousHome = process.env.HOME;
+    previousGraniteVault = process.env.GRANITE_VAULT;
     previousCwd = process.cwd();
     process.env.HOME = tmpHome;
+    delete process.env.GRANITE_VAULT;
     process.chdir(tmpCwd);
     vi.spyOn(console, 'log').mockImplementation(() => {});
   });
@@ -29,6 +32,11 @@ describe('initVault', () => {
       delete process.env.HOME;
     } else {
       process.env.HOME = previousHome;
+    }
+    if (previousGraniteVault === undefined) {
+      delete process.env.GRANITE_VAULT;
+    } else {
+      process.env.GRANITE_VAULT = previousGraniteVault;
     }
     fs.rmSync(tmpHome, { recursive: true, force: true });
     fs.rmSync(tmpCwd, { recursive: true, force: true });
@@ -48,5 +56,15 @@ describe('initVault', () => {
     for (const typeConfig of Object.values(config.note_types)) {
       expect(fs.existsSync(path.join(vaultRoot, typeConfig.folder))).toBe(true);
     }
+  });
+
+  it('uses GRANITE_VAULT as the default init target when set', () => {
+    const envVault = path.join(tmpCwd, 'env-vault');
+    process.env.GRANITE_VAULT = envVault;
+
+    initVault();
+
+    expect(fs.existsSync(path.join(envVault, 'granite.yml'))).toBe(true);
+    expect(fs.existsSync(path.join(getDefaultVaultRoot(), 'granite.yml'))).toBe(false);
   });
 });

--- a/test/commands/mcp.test.ts
+++ b/test/commands/mcp.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { parseMcpRole, parsePort, parseTransport } from '../../src/commands/mcp.js';
+import { parseMcpRole, parsePort, parseTransport, resolveAuthToken } from '../../src/commands/mcp.js';
 
 const originalMcpPort = process.env.MCP_PORT;
+const originalGraniteMcpToken = process.env.GRANITE_MCP_TOKEN;
 
 describe('mcp command helpers', () => {
   afterEach(() => {
@@ -9,6 +10,11 @@ describe('mcp command helpers', () => {
       delete process.env.MCP_PORT;
     } else {
       process.env.MCP_PORT = originalMcpPort;
+    }
+    if (originalGraniteMcpToken === undefined) {
+      delete process.env.GRANITE_MCP_TOKEN;
+    } else {
+      process.env.GRANITE_MCP_TOKEN = originalGraniteMcpToken;
     }
   });
 
@@ -34,5 +40,16 @@ describe('mcp command helpers', () => {
     expect(parseMcpRole('read')).toBe('read');
     expect(parseMcpRole('write')).toBe('write');
     expect(() => parseMcpRole('admin')).toThrow('Invalid MCP role');
+  });
+
+  it('resolves the MCP auth token from explicit options and GRANITE_MCP_TOKEN', () => {
+    process.env.GRANITE_MCP_TOKEN = 'env-token';
+
+    expect(resolveAuthToken('explicit-token')).toBe('explicit-token');
+    expect(resolveAuthToken()).toBe('env-token');
+
+    delete process.env.GRANITE_MCP_TOKEN;
+    expect(resolveAuthToken()).toBeUndefined();
+    expect(() => resolveAuthToken('   ')).toThrow('Invalid MCP auth token');
   });
 });

--- a/test/mcp/server-auth.test.ts
+++ b/test/mcp/server-auth.test.ts
@@ -1,0 +1,150 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { writeDefaultConfig } from '../../src/core/config.js';
+import { GraniteMcpRuntime } from '../../src/mcp/runtime.js';
+import {
+  createGraniteMcpHttpApp,
+  requiresMcpHttpAuth,
+  startGraniteMcpHttpServer,
+} from '../../src/mcp/server.js';
+
+describe('granite MCP HTTP auth', () => {
+  let tmpDir: string;
+  let runtime: GraniteMcpRuntime;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'granite-mcp-auth-'));
+    writeDefaultConfig(tmpDir);
+    runtime = new GraniteMcpRuntime(tmpDir, { indexCheckIntervalMs: 0 });
+  });
+
+  afterEach(() => {
+    runtime.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('rejects MCP requests without the configured bearer token', async () => {
+    const app = createGraniteMcpHttpApp(runtime, {
+      host: '0.0.0.0',
+      port: 3321,
+      authToken: 'secret-token',
+      jsonResponse: true,
+    });
+
+    const response = await app.request('/mcp', initializeRequest());
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toMatchObject({
+      jsonrpc: '2.0',
+      error: { code: -32000, message: 'Unauthorized.' },
+      id: null,
+    });
+  });
+
+  it('rejects MCP requests with an invalid bearer token', async () => {
+    const app = createGraniteMcpHttpApp(runtime, {
+      host: '0.0.0.0',
+      port: 3321,
+      authToken: 'secret-token',
+      jsonResponse: true,
+    });
+
+    const response = await app.request('/mcp', initializeRequest('wrong-token'));
+
+    expect(response.status).toBe(401);
+  });
+
+  it('accepts MCP requests with the configured bearer token', async () => {
+    const app = createGraniteMcpHttpApp(runtime, {
+      host: '0.0.0.0',
+      port: 3321,
+      authToken: 'secret-token',
+      jsonResponse: true,
+    });
+
+    const response = await app.request('/mcp', initializeRequest('secret-token'));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      jsonrpc: '2.0',
+      id: 1,
+      result: {
+        serverInfo: {
+          name: 'granite',
+        },
+      },
+    });
+  });
+
+  it('allows OPTIONS preflight without a bearer token', async () => {
+    const app = createGraniteMcpHttpApp(runtime, {
+      host: '0.0.0.0',
+      port: 3321,
+      allowedOrigins: ['https://client.example'],
+      authToken: 'secret-token',
+    });
+
+    const response = await app.request('/mcp', {
+      method: 'OPTIONS',
+      headers: {
+        Origin: 'https://client.example',
+      },
+    });
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get('Access-Control-Allow-Headers')).toContain('Authorization');
+  });
+
+  it('refuses to bind a public HTTP server without a bearer token', () => {
+    expect(() => startGraniteMcpHttpServer(runtime, {
+      host: '0.0.0.0',
+      port: 3321,
+    })).toThrow('outside localhost without --auth-token or GRANITE_MCP_TOKEN');
+  });
+
+  it('requires auth for every non-loopback HTTP bind host', () => {
+    expect(requiresMcpHttpAuth('0.0.0.0')).toBe(true);
+    expect(requiresMcpHttpAuth('::')).toBe(true);
+    expect(requiresMcpHttpAuth('[::]')).toBe(true);
+    expect(requiresMcpHttpAuth('192.168.1.20')).toBe(true);
+    expect(requiresMcpHttpAuth('10.0.0.5')).toBe(true);
+    expect(requiresMcpHttpAuth('100.64.0.10')).toBe(true);
+    expect(requiresMcpHttpAuth('granite.example.com')).toBe(true);
+
+    expect(requiresMcpHttpAuth('localhost')).toBe(false);
+    expect(requiresMcpHttpAuth('127.0.0.1')).toBe(false);
+    expect(requiresMcpHttpAuth('127.10.20.30')).toBe(false);
+    expect(requiresMcpHttpAuth('::1')).toBe(false);
+    expect(requiresMcpHttpAuth('[::1]')).toBe(false);
+  });
+});
+
+function initializeRequest(token?: string): RequestInit {
+  const headers: Record<string, string> = {
+    Accept: 'application/json, text/event-stream',
+    'Content-Type': 'application/json',
+  };
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+
+  return {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2025-06-18',
+        capabilities: {},
+        clientInfo: {
+          name: 'granite-test-client',
+          version: '1.0.0',
+        },
+      },
+    }),
+  };
+}


### PR DESCRIPTION
## Summary
- Add bearer-token protection for HTTP MCP requests, with startup refusal for every non-loopback bind host unless `--auth-token` or `GRANITE_MCP_TOKEN` is configured.
- Add Docker packaging for remote MCP self-hosting with `/vault` auto-init, plus GHCR release publishing.
- Document remote MCP setup and add tests for auth, bind classification, CLI token resolution, and container init behavior.

## Verification
- [x] `npx vitest run test/mcp/server-auth.test.ts test/commands/mcp.test.ts test/commands/init.test.ts` - passed, 13 tests
- [x] `npm run build` - passed
- [x] `npm run lint` - passed
- [x] `npm run test:coverage` - passed, 34 files / 217 tests
- [x] `docker build -t granite-mem:test .` - passed
- [x] Docker smoke - `/health=200`, unauthenticated `/mcp=401`, authenticated `/mcp=200`
- [x] Docker no-token smoke - refused public bind without token
- [x] `git diff --check` - passed

## CI
- Latest commit: `c0d0a21e7d626fbfca5a608e80d062af389cfad7`
- Status: all visible non-skipped checks green on the latest commit
- Checks: `ci` success, `cubic · AI code reviewer` success

## Review Gate
- `mega-code-review`: findings fixed
- Review board: findings fixed
- Frontend gate: N/A
- Artifacts: local ship artifacts retained outside the PR

## Risk
- Security-sensitive transport change; covered by auth middleware tests, non-loopback bind classification tests, and Docker smoke checks.
- No database migrations or frontend changes.

## Human Review Notes
- The Docker workflow publishes `latest` on release publication, matching the requested release image flow.
