### PR TITLE
fix(web): preserve markdown renderer in production bundle

### DIFF
--- a/scripts/build-web.mjs
+++ b/scripts/build-web.mjs
@@ -5,6 +5,7 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import url from 'node:url';
+import vm from 'node:vm';
 import { build } from 'esbuild';
 
 const root = path.resolve(path.dirname(url.fileURLToPath(import.meta.url)), '..');
@@ -57,6 +58,31 @@ for (const f of jsFiles) {
     target: 'es2020',
     logLevel: 'error',
   });
+}
+
+// Smoke-test the compiled renderer. It is consumed by app.js through a browser
+// global, so a successful minification must preserve both that global and its
+// rendering behavior.
+const rendererBundle = await fs.readFile(path.join(out, 'markdown-renderer.js'), 'utf8');
+const rendererContext = vm.createContext({ window: {} });
+vm.runInContext(rendererBundle, rendererContext, { filename: 'markdown-renderer.js' });
+
+const renderer = rendererContext.window.MarkdownRenderer;
+if (typeof renderer?.render !== 'function') {
+  throw new Error('Compiled markdown renderer does not expose window.MarkdownRenderer.render');
+}
+
+const renderedMarkdown = renderer.render(
+  '# Build check\nA paragraph with [[Granite]].',
+  [{ target: 'Granite', resolved: true, resolved_slug: 'granite' }],
+);
+if (
+  !renderedMarkdown.includes('<h1 class="md-h1">Build check</h1>')
+  || !renderedMarkdown.includes('<p class="md-body">')
+  || !renderedMarkdown.includes('class="wikilink"')
+  || !renderedMarkdown.includes('data-slug="granite"')
+) {
+  throw new Error('Compiled markdown renderer failed its semantic smoke test');
 }
 
 // Minify each CSS file.

--- a/src/web/public/app.js
+++ b/src/web/public/app.js
@@ -912,7 +912,7 @@
     readerMeta.innerHTML = metaParts.join('');
 
     // Article body
-    readerArticle.innerHTML = MarkdownRenderer.render(note.body || '', note.outgoing_links || []);
+    readerArticle.innerHTML = window.MarkdownRenderer.render(note.body || '', note.outgoing_links || []);
 
     // Links out + backlinks
     renderReaderLinks(note);

--- a/src/web/public/markdown-renderer.js
+++ b/src/web/public/markdown-renderer.js
@@ -4,7 +4,7 @@
  * Converts markdown + wikilinks to semantic HTML.
  * Supports: headings, lists, blockquotes, code, tables, inline formatting, wikilinks.
  */
-const MarkdownRenderer = (() => {
+window.MarkdownRenderer = (() => {
 
   function parseInline(text, outgoingLinks) {
     const re = /(\[\[([^\]]+)\]\])|(`([^`]+)`)|(\*\*(.+?)\*\*)|(\*(.+?)\*)|(\[([^\]]+)\]\(([^)]+)\))|(!\[([^\]]*)\]\(([^)]+)\))/g;


### PR DESCRIPTION
## Summary
- preserve the Markdown renderer as an explicit browser global so esbuild cannot remove it from the production bundle
- add a semantic build-time smoke test for the compiled renderer's heading, paragraph, and wikilink output

## Verification
- [x] `npm run lint` - TypeScript check passed
- [x] `npm test` - 288 tests passed across 41 files
- [x] `npm run build` - web build and compiled-renderer smoke test passed
- [x] `npm pack --dry-run --json` - packaged renderer is present at 3,259 bytes

## CI
- Latest commit: `b01b14b8002965cb6996e982de5213152062f4f1`
- Status: all required checks passed
- Checks: `CI/ci` passed; `cubic · AI code reviewer` completed neutral/skipped

## Review Gate
- `review-code-dev`: passed with no P0-P3 findings
- Review board: passed across build-regression and release-coverage angles
- Frontend gate: passed for the constellation note-reader path

## Risk
- Low: the browser-global contract now matches the existing graph-engine pattern, while script order and minification settings remain unchanged.
- No CLI, MCP, API, server, or package-version behavior changes.

## Human Review Notes
- Focus on the compiled renderer global and the build-time semantic assertions.
