### PR TITLE
feat(web): show only vault note types

### DIFF
--- a/scripts/build-web.mjs
+++ b/scripts/build-web.mjs
@@ -85,6 +85,29 @@ if (
   throw new Error('Compiled markdown renderer failed its semantic smoke test');
 }
 
+// The app consumes the type-filter resolver through a browser global too.
+// Verify the production asset keeps custom types while dropping empty ones.
+const typeFiltersBundle = await fs.readFile(path.join(out, 'type-filters.js'), 'utf8');
+const typeFiltersContext = vm.createContext({ window: {} });
+vm.runInContext(typeFiltersBundle, typeFiltersContext, { filename: 'type-filters.js' });
+
+const typeFilters = typeFiltersContext.window.GraniteTypeFilters;
+const visibleTypes = typeFilters?.visibleTypeNames(
+  { note: {}, source: {}, meeting: {} },
+  [{ type: 'note' }, { type: 'meeting' }, { type: 'retro' }],
+);
+if (JSON.stringify(visibleTypes) !== JSON.stringify(['note', 'meeting', 'retro'])) {
+  throw new Error('Compiled type-filter registry failed its semantic smoke test');
+}
+if (
+  typeFilters.noteType(
+    { slug: 'weekly-sync' },
+    { 'weekly-sync': { type: 'meeting' } },
+  ) !== 'meeting'
+) {
+  throw new Error('Compiled type-filter registry failed its legacy search compatibility check');
+}
+
 // Minify each CSS file.
 for (const f of cssFiles) {
   const rel = path.relative(src, f);

--- a/src/core/search.ts
+++ b/src/core/search.ts
@@ -31,6 +31,7 @@ export function searchNotes(db: Database.Database, query: string, limit = 20): S
     SELECT
       n.slug,
       n.title,
+      n.type,
       snippet(notes_fts, 1, '>>>', '<<<', '...', 30) as snippet,
       rank
     FROM notes_fts
@@ -44,6 +45,7 @@ export function searchNotes(db: Database.Database, query: string, limit = 20): S
     const rows = stmt.all(ftsQuery, cappedLimit) as Array<{
       slug: string;
       title: string;
+      type: string;
       snippet: string;
       rank: number;
     }>;
@@ -51,6 +53,7 @@ export function searchNotes(db: Database.Database, query: string, limit = 20): S
     return rows.map(r => ({
       slug: r.slug,
       title: r.title,
+      type: r.type,
       snippet: r.snippet,
       score: r.rank,
     }));
@@ -60,6 +63,7 @@ export function searchNotes(db: Database.Database, query: string, limit = 20): S
       SELECT
         n.slug,
         n.title,
+        n.type,
         substr(n.body, 1, 200) as snippet,
         0 as rank
       FROM notes n
@@ -70,6 +74,7 @@ export function searchNotes(db: Database.Database, query: string, limit = 20): S
     const rows = fallback.all(pattern, pattern, cappedLimit) as Array<{
       slug: string;
       title: string;
+      type: string;
       snippet: string;
       rank: number;
     }>;
@@ -77,6 +82,7 @@ export function searchNotes(db: Database.Database, query: string, limit = 20): S
     return rows.map(r => ({
       slug: r.slug,
       title: r.title,
+      type: r.type,
       snippet: r.snippet,
       score: r.rank,
     }));

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -113,6 +113,7 @@ export interface WikiLink {
 export interface SearchResult {
   slug: string;
   title: string;
+  type: string;
   snippet: string;
   score: number;
 }
@@ -128,4 +129,3 @@ export interface DoctorIssue {
   file: string;
   message: string;
 }
-

--- a/src/web/public/app.js
+++ b/src/web/public/app.js
@@ -194,17 +194,11 @@
       nodes = graphRes.nodes || [];
       const rawEdges = graphRes.edges || [];
       const typesRaw = typesRes.types || [];
-      types = Array.isArray(typesRaw)
-        ? typesRaw.map(t => typeof t === 'string' ? t : (t.name || t.type))
-        : Object.keys(typesRaw);
+      types = window.GraniteTypeFilters.visibleTypeNames(typesRaw, nodes);
 
       // Map types → palette colors
       typeColor = {};
       types.forEach((t, i) => { typeColor[t] = BRAND_CYCLE[i % BRAND_CYCLE.length]; });
-      // Any types that appear in nodes but weren't in config — assign next colors
-      for (const n of nodes) {
-        if (!typeColor[n.type]) typeColor[n.type] = BRAND_CYCLE[Object.keys(typeColor).length % BRAND_CYCLE.length];
-      }
 
       // De-dup & canonicalise edges (undirected, no self-loops, both ends in nodes)
       const slugSet = new Set(nodes.map(n => n.slug));
@@ -1135,14 +1129,15 @@
       return;
     }
     cmdResults.innerHTML = results.map((r, i) => {
-      const tc = colorForType(r.type);
+      const type = window.GraniteTypeFilters.noteType(r, byslug);
+      const tc = colorForType(type);
       return `<div class="command-result${i === 0 ? ' active' : ''}" data-idx="${i}" data-slug="${escapeHtml(r.slug)}">
         <span class="command-result-dot" style="background:${tc.hex}"></span>
         <div class="command-result-body">
           <div class="command-result-title">${escapeHtml(r.title || r.slug)}</div>
           <div class="command-result-slug">${escapeHtml(r.slug)}</div>
         </div>
-        <span class="command-result-type" style="background:${tc.soft};color:${tc.hex}">${escapeHtml(r.type || 'note')}</span>
+        <span class="command-result-type" title="${escapeHtml(type)}" style="background:${tc.soft};color:${tc.hex}">${escapeHtml(type)}</span>
       </div>`;
     }).join('');
   }

--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -144,6 +144,7 @@
 
   <script src="/graph-engine.js"></script>
   <script src="/markdown-renderer.js"></script>
+  <script src="/type-filters.js"></script>
   <script src="/app.js"></script>
 </body>
 </html>

--- a/src/web/public/style.css
+++ b/src/web/public/style.css
@@ -670,7 +670,11 @@ button { font: inherit; color: inherit; }
 .command-result-body { flex: 1; min-width: 0; }
 .command-result-title { font-weight: 600; font-size: 0.92rem; color: #fff8ef; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .command-result-slug { font-family: var(--font-mono); font-size: 0.66rem; color: rgba(255,236,220,0.5); margin-top: 2px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.command-result-type { font-size: 0.58rem; font-weight: 800; letter-spacing: 0.14em; text-transform: uppercase; padding: 2px 8px; border-radius: 999px; flex: 0 0 auto; }
+.command-result-type {
+  max-width: 30%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  font-size: 0.58rem; font-weight: 800; letter-spacing: 0.14em; text-transform: uppercase;
+  padding: 2px 8px; border-radius: 999px; flex: 0 1 auto;
+}
 .command-empty {
   padding: 20px 16px; text-align: center; color: rgba(255,236,220,0.5); font-size: 0.86rem;
 }

--- a/src/web/public/type-filters.js
+++ b/src/web/public/type-filters.js
@@ -1,0 +1,58 @@
+/**
+ * Granite — Type Filter Registry
+ *
+ * Resolves the filter list from the configured type registry and the types
+ * that are actually present in the selected vault's graph.
+ */
+window.GraniteTypeFilters = (() => {
+  'use strict';
+
+  function configuredTypeNames(typesPayload) {
+    const candidates = Array.isArray(typesPayload)
+      ? typesPayload.map(type => {
+          if (typeof type === 'string') return type;
+          if (!type || typeof type !== 'object') return null;
+          if (typeof type.name === 'string' && type.name.length > 0) return type.name;
+          return typeof type.type === 'string' ? type.type : null;
+        })
+      : typesPayload && typeof typesPayload === 'object'
+        ? Object.keys(typesPayload)
+        : [];
+
+    const seen = new Set();
+    return candidates.filter(type => {
+      if (typeof type !== 'string' || type.length === 0 || seen.has(type)) return false;
+      seen.add(type);
+      return true;
+    });
+  }
+
+  function visibleTypeNames(typesPayload, nodes) {
+    const present = new Set();
+    for (const node of Array.isArray(nodes) ? nodes : []) {
+      if (node && typeof node.type === 'string' && node.type.length > 0) {
+        present.add(node.type);
+      }
+    }
+
+    const configured = configuredTypeNames(typesPayload);
+    const configuredSet = new Set(configured);
+    const visible = configured.filter(type => present.has(type));
+    const unregistered = [...present]
+      .filter(type => !configuredSet.has(type))
+      .sort((a, b) => a.localeCompare(b));
+
+    return visible.concat(unregistered);
+  }
+
+  function noteType(result, nodesBySlug) {
+    if (result && typeof result.type === 'string' && result.type.length > 0) {
+      return result.type;
+    }
+
+    const graphType = result && nodesBySlug?.[result.slug]?.type;
+    return typeof graphType === 'string' && graphType.length > 0 ? graphType : 'note';
+  }
+
+  return { visibleTypeNames, noteType };
+})();

--- a/test/core/querying.test.ts
+++ b/test/core/querying.test.ts
@@ -39,6 +39,7 @@ describe('querying helpers', () => {
     expect(results[0]).toMatchObject({
       slug: 'graph-memory',
       title: 'Graph Memory',
+      type: 'note',
     });
     expect(results[0].snippet).toContain('>>>');
     expect(typeof results[0].score).toBe('number');

--- a/test/core/search.test.ts
+++ b/test/core/search.test.ts
@@ -19,12 +19,14 @@ describe('searchNotes', () => {
       vault_name: 't', version: 1,
       note_types: {
         note: { folder: 'notes', description: '', template: '', line_limit: 200, warn_only: false },
+        meeting: { folder: 'meetings', description: '', template: '', line_limit: 200, warn_only: false },
       },
       defaults: { note_type: 'note', editor: '$EDITOR' },
       index: { auto_rebuild: true },
     };
     fs.writeFileSync(path.join(tmpDir, 'granite.yml'), yaml.dump(cfg));
     fs.mkdirSync(path.join(tmpDir, 'notes'), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, 'meetings'), { recursive: true });
     config = loadConfig(tmpDir);
   });
 
@@ -33,14 +35,17 @@ describe('searchNotes', () => {
   });
 
   it('OR-joins multiple words and returns matches', () => {
-    createNote(tmpDir, config, 'note', 'Distillation primer', 'about distillation and fermentation.\n');
+    createNote(tmpDir, config, 'meeting', 'Distillation primer', 'about distillation and fermentation.\n');
     createNote(tmpDir, config, 'note', 'Other', 'unrelated content.\n');
 
     const db = createDatabase(path.join(tmpDir, '.granite', 'index.db'));
     rebuildIndex(tmpDir, config, db);
 
     const results = searchNotes(db, 'distillation fermentation');
-    expect(results.map(r => r.slug)).toContain('distillation-primer');
+    expect(results).toContainEqual(expect.objectContaining({
+      slug: 'distillation-primer',
+      type: 'meeting',
+    }));
     db.close();
   });
 
@@ -65,12 +70,13 @@ describe('searchNotes', () => {
   });
 
   it('falls back to LIKE when FTS parsing throws', () => {
-    createNote(tmpDir, config, 'note', 'Paren', 'text with symbols.\n');
+    createNote(tmpDir, config, 'note', 'Paren', 'text with " symbols.\n');
     const db = createDatabase(path.join(tmpDir, '.granite', 'index.db'));
     rebuildIndex(tmpDir, config, db);
     // Quote-only query is invalid FTS5 → triggers fallback
     const results = searchNotes(db, '"');
     expect(Array.isArray(results)).toBe(true);
+    expect(results[0]?.type).toBe('note');
     db.close();
   });
 });

--- a/test/web/type-filters.test.ts
+++ b/test/web/type-filters.test.ts
@@ -1,0 +1,66 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+import { describe, expect, it } from 'vitest';
+
+interface TypeFilterRegistry {
+  visibleTypeNames: (typesPayload: unknown, nodes: unknown) => string[];
+  noteType: (result: unknown, nodesBySlug: unknown) => string;
+}
+
+function loadTypeFilterRegistry(): TypeFilterRegistry {
+  const source = fs.readFileSync(
+    path.resolve(process.cwd(), 'src/web/public/type-filters.js'),
+    'utf8',
+  );
+  const context = vm.createContext({ window: {} });
+  vm.runInContext(source, context, { filename: 'type-filters.js' });
+  return (context.window as { GraniteTypeFilters: TypeFilterRegistry }).GraniteTypeFilters;
+}
+
+describe('web type filters', () => {
+  const registry = loadTypeFilterRegistry();
+
+  it('keeps configured order while showing standard and custom types that have notes', () => {
+    const types = registry.visibleTypeNames({
+      note: {},
+      source: {},
+      meeting: {},
+      output: {},
+    }, [
+      { slug: 'idea', type: 'note' },
+      { slug: 'weekly-sync', type: 'meeting' },
+    ]);
+
+    expect(Array.from(types)).toEqual(['note', 'meeting']);
+  });
+
+  it('hides every configured type when the vault is empty', () => {
+    const types = registry.visibleTypeNames({ note: {}, meeting: {} }, []);
+
+    expect(Array.from(types)).toEqual([]);
+  });
+
+  it('deduplicates legacy array payloads and appends unregistered note types', () => {
+    const types = registry.visibleTypeNames([
+      'source',
+      { name: 'note' },
+      { type: 'source' },
+      null,
+    ], [
+      { slug: 'raw', type: 'source' },
+      { slug: 'retro', type: 'retro' },
+      { slug: 'decision', type: 'decision' },
+    ]);
+
+    expect(Array.from(types)).toEqual(['source', 'decision', 'retro']);
+  });
+
+  it('falls back to graph metadata for legacy search results without a type', () => {
+    expect(registry.noteType(
+      { slug: 'weekly-sync', title: 'Weekly Sync' },
+      { 'weekly-sync': { slug: 'weekly-sync', type: 'meeting' } },
+    )).toBe('meeting');
+    expect(registry.noteType({ slug: 'missing' }, {})).toBe('note');
+  });
+});


### PR DESCRIPTION
## Summary
- show only note types that are actually present in the selected vault while preserving configured order and supporting custom/unregistered types
- keep custom type colors consistent across filters, search results, and the reader, including supported older cloud instances
- add regression coverage and production asset smoke checks for empty vaults, legacy payloads, and custom types

## Verification
- [x] `npm run lint` - TypeScript check passed
- [x] `npm run test:coverage` - 42 files and 292 tests passed; coverage thresholds passed
- [x] `npm run build` - CLI and all production web assets built successfully
- [x] targeted web/core tests - 24 tests passed
- [x] browser smoke - local/custom types, legacy-compatible search colors, reader colors, and a 390px long-type layout passed without browser errors

## CI
- Latest commit: `ad26ebdde4c23b510d4ce357e33ea512ca1e9729`
- Status: all required checks passed
- Checks: `CI/ci` passed; `cubic · AI code reviewer` completed neutral with no comments

## Review Gate
- `review-code-dev`: passed after two confirmed findings were fixed
- Review board: passed after mixed-version cloud compatibility fix
- Frontend gate: passed after responsive long-badge fix and follow-up review

## Risk
- Low: `/api/search` adds the note `type` field; older cloud responses without it fall back to graph metadata.
- `/api/types` and `/api/graph` contracts are unchanged.

## Human Review Notes
- Focus on mixed-version cloud search behavior and the configured-order/custom-type filter resolution.
